### PR TITLE
Fix World Load/Unload API

### DIFF
--- a/canvas-api/paper-patches/files/src/main/java/org/bukkit/event/player/PlayerKickEvent.java.patch
+++ b/canvas-api/paper-patches/files/src/main/java/org/bukkit/event/player/PlayerKickEvent.java.patch
@@ -1,0 +1,9 @@
+--- a/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
++++ b/src/main/java/org/bukkit/event/player/PlayerKickEvent.java
+@@ -194,5 +_,6 @@
+          * Fallback cause
+          */
+         UNKNOWN,
++        WORLD_UNLOAD, // Canvas - fix world loading/unloading
+     }
+ }

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
@@ -97,3 +97,40 @@
      }
  
      private void tickPlayerSample() {
+@@ -399,6 +_,36 @@
+     // A global tick only updates things like weather / worldborder, basically anything in the world that is
+     // NOT tied to a specific region, but rather shared amongst all of them.
+     private void globalTick(final ServerLevel world, final int tickCount) {
++        // Canvas start - fix world loading/unloading
++        if (world.isUnloading) {
++            // we are unloading, return.
++            AtomicBoolean isSingularRegionAlive = new AtomicBoolean(false);
++            world.regioniser.computeForAllRegions((region) -> {
++                if (!region.getData().isClosed) {
++                    // region still active, possibly still saving or hasn't gotten to that yet
++                    isSingularRegionAlive.set(true);
++                }
++            });
++            if (!isSingularRegionAlive.get()) {
++                LOGGER.info("Finalizing unload of world '" + world.getWorld().getName() + "'");
++                // all regions saved and players are removed, we can now close this world
++                world.moonrise$getChunkTaskScheduler().halt(false, 0L);
++                world.chunkSource.getDataStorage().close();
++                world.moonrise$getChunkTaskScheduler().chunkHolderManager.close(false, true, true, false, false);
++                io.papermc.paper.FeatureHooks.closeEntityManager(world, false); // SPIGOT-6722: close entityManager // Paper - chunk system
++                try {
++                    world.levelStorageAccess.close();
++                } catch (java.io.IOException e) {
++                    throw new RuntimeException("Unable to close level storage access for world unload", e);
++                }
++                this.worlds.remove(world);
++                MinecraftServer.getServer().removeLevel(world);
++                MinecraftServer.getServer().server.worlds.remove(world.getWorld().getName().toLowerCase(java.util.Locale.ROOT));
++                LOGGER.info("Completed unload of world '{}'", world.getWorld().getName());
++            }
++            return;
++        }
++        // Canvas end
+         // needs
+         // worldborder tick
+         // advancing the weather cycle

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
@@ -71,11 +71,7 @@
          }
      }
  
-@@ -298,10 +_,11 @@
-         }
-         this.randomWalk();
-          */
--        ++this.tickCount;
+@@ -302,6 +_,8 @@
          // expire invalid click command callbacks
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.CALLBACK_MANAGER.handleQueue((int)this.tickCount);
  

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
@@ -108,7 +108,7 @@
 +                // double check that *all* players are removed from this world, since they may
 +                // be added in some weird spot during shutdown of the world that we didn't catch previously
 +                for (final net.minecraft.server.level.ServerPlayer player : world.players()) {
-+                    player.getBukkitEntity().kick(net.kyori.adventure.text.Component.text("World unloading"), org.bukkit.event.player.PlayerKickEvent.Cause.UNKNOWN);
++                    player.getBukkitEntity().kick(net.kyori.adventure.text.Component.text("World unloading"), org.bukkit.event.player.PlayerKickEvent.Cause.WORLD_UNLOAD);
 +                }
 +                // all regions saved and players are removed, we can now close this world
 +                world.moonrise$getChunkTaskScheduler().halt(false, 0L);

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
@@ -1,13 +1,5 @@
 --- a/io/papermc/paper/threadedregions/RegionizedServer.java
 +++ b/io/papermc/paper/threadedregions/RegionizedServer.java
-@@ -24,6 +_,7 @@
- import java.util.ArrayList;
- import java.util.Collections;
- import java.util.List;
-+import java.util.Set;
- import java.util.concurrent.CopyOnWriteArrayList;
- import java.util.concurrent.atomic.AtomicBoolean;
- import java.util.function.BooleanSupplier;
 @@ -65,7 +_,7 @@
          // now we can schedule
          this.tickHandle.setInitialStart(System.nanoTime() + TickRegionScheduler.TIME_BETWEEN_TICKS);
@@ -79,7 +71,11 @@
          }
      }
  
-@@ -302,6 +_,8 @@
+@@ -298,10 +_,11 @@
+         }
+         this.randomWalk();
+          */
+-        ++this.tickCount;
          // expire invalid click command callbacks
          io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.CALLBACK_MANAGER.handleQueue((int)this.tickCount);
  
@@ -97,7 +93,7 @@
      }
  
      private void tickPlayerSample() {
-@@ -399,6 +_,36 @@
+@@ -399,6 +_,41 @@
      // A global tick only updates things like weather / worldborder, basically anything in the world that is
      // NOT tied to a specific region, but rather shared amongst all of them.
      private void globalTick(final ServerLevel world, final int tickCount) {
@@ -113,6 +109,11 @@
 +            });
 +            if (!isSingularRegionAlive.get()) {
 +                LOGGER.info("Finalizing unload of world '" + world.getWorld().getName() + "'");
++                // double check that *all* players are removed from this world, since they may
++                // be added in some weird spot during shutdown of the world that we didn't catch previously
++                for (final net.minecraft.server.level.ServerPlayer player : world.players()) {
++                    player.getBukkitEntity().kick(net.kyori.adventure.text.Component.text("World unloading"), org.bukkit.event.player.PlayerKickEvent.Cause.UNKNOWN);
++                }
 +                // all regions saved and players are removed, we can now close this world
 +                world.moonrise$getChunkTaskScheduler().halt(false, 0L);
 +                world.chunkSource.getDataStorage().close();

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/TickRegionScheduler.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/TickRegionScheduler.java.patch
@@ -5,7 +5,7 @@
      // Folia end - watchdog
  
 -    private final SchedulerThreadPool scheduler;
-+    private final io.canvasmc.canvas.tick.ScheduledTaskThreadPool scheduler; // Canvas - rewrite scheduler
++    public final io.canvasmc.canvas.tick.ScheduledTaskThreadPool scheduler; // Canvas - rewrite scheduler
  
 -    public TickRegionScheduler(final int threads) {
 -        this.scheduler = new SchedulerThreadPool(threads, new ThreadFactory() {

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/TickRegions.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/TickRegions.java.patch
@@ -212,6 +212,20 @@
  
              // generic regionised data
              final long fromTickOffset = currentTickTo - currentTickFrom; // see merge jd
+@@ -328,6 +_,13 @@
+             // task queue
+             this.taskQueueData.mergeInto(data.taskQueueData);
+         }
++        // Canvas start - fix world loading/unloading
++        public volatile boolean isClosed = false;
++
++        public void markClosed() {
++            this.isClosed = true;
++        }
++        // Canvas end
+     }
+ 
+     public static final class ConcreteRegionTickHandle extends TickRegionScheduler.RegionScheduleHandle { // Folia - watchdog
 @@ -350,11 +_,11 @@
          }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -253,7 +253,7 @@
 +                if (!serverLevel.players().isEmpty()) {
 +                    // a player was teleported into the world when finishing teleports, kick.
 +                    for (final ServerPlayer localPlayer : serverLevel.getLocalPlayers()) {
-+                        localPlayer.getBukkitEntity().kickPlayer("World unloading");
++                        localPlayer.getBukkitEntity().kick(net.kyori.adventure.text.Component.text("World unloading"), org.bukkit.event.player.PlayerKickEvent.Cause.WORLD_UNLOAD);
 +                    }
 +                }
 +

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -327,6 +327,30 @@
      }
  
      public boolean isLevelEnabled(Level level) {
+@@ -1922,18 +_,23 @@
+     }
+ 
+     // CraftBukkit start
++    private final Object levelLock = new Object(); // Canvas - fix world loading/unloading
+     public void addLevel(ServerLevel level) {
++        synchronized (levelLock) { // Canvas - fix world loading/unloading
+         Map<ResourceKey<Level>, ServerLevel> oldLevels = this.levels;
+         Map<ResourceKey<Level>, ServerLevel> newLevels = Maps.newLinkedHashMap(oldLevels);
+         newLevels.put(level.dimension(), level);
+         this.levels = Collections.unmodifiableMap(newLevels);
++        } // Canvas - fix world loading/unloading
+     }
+ 
+     public void removeLevel(ServerLevel level) {
++        synchronized (levelLock) { // Canvas - fix world loading/unloading
+         Map<ResourceKey<Level>, ServerLevel> oldLevels = this.levels;
+         Map<ResourceKey<Level>, ServerLevel> newLevels = Maps.newLinkedHashMap(oldLevels);
+         newLevels.remove(level.dimension());
+         this.levels = Collections.unmodifiableMap(newLevels);
++        } // Canvas - fix world loading/unloading
+     }
+     // CraftBukkit end
+ 
 @@ -2720,55 +_,6 @@
      }
      // CraftBukkit end

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -1,6 +1,23 @@
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -114,19 +_,8 @@
+@@ -13,6 +_,8 @@
+ import com.mojang.jtracy.DiscontinuousFrame;
+ import com.mojang.jtracy.TracyClient;
+ import com.mojang.logging.LogUtils;
++import io.papermc.paper.threadedregions.RegionizedWorldData;
++import io.papermc.paper.threadedregions.TickRegions;
+ import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+ import it.unimi.dsi.fastutil.objects.ObjectArraySet;
+ import java.awt.image.BufferedImage;
+@@ -70,6 +_,7 @@
+ import net.minecraft.data.worldgen.features.MiscOverworldFeatures;
+ import net.minecraft.gametest.framework.GameTestTicker;
+ import net.minecraft.nbt.Tag;
++import net.minecraft.network.DisconnectionDetails;
+ import net.minecraft.network.chat.ChatDecorator;
+ import net.minecraft.network.chat.ChatType;
+ import net.minecraft.network.chat.Component;
+@@ -114,28 +_,19 @@
  import net.minecraft.util.debugchart.RemoteDebugSampleType;
  import net.minecraft.util.debugchart.SampleLogger;
  import net.minecraft.util.debugchart.TpsDebugDimensions;
@@ -20,6 +37,25 @@
  import net.minecraft.util.thread.ReentrantBlockableEventLoop;
  import net.minecraft.world.Difficulty;
  import net.minecraft.world.RandomSequences;
++import net.minecraft.world.entity.Entity;
+ import net.minecraft.world.entity.ai.village.VillageSiege;
+ import net.minecraft.world.entity.npc.CatSpawner;
+ import net.minecraft.world.entity.npc.WanderingTraderSpawner;
+ import net.minecraft.world.entity.player.Player;
+ import net.minecraft.world.flag.FeatureFlagSet;
+ import net.minecraft.world.flag.FeatureFlags;
++import net.minecraft.world.item.ItemStack;
+ import net.minecraft.world.item.alchemy.PotionBrewing;
+ import net.minecraft.world.item.crafting.RecipeManager;
+ import net.minecraft.world.level.ChunkPos;
+@@ -171,6 +_,7 @@
+ import net.minecraft.world.level.storage.WorldData;
+ import net.minecraft.world.phys.Vec2;
+ import net.minecraft.world.phys.Vec3;
++import org.bukkit.event.inventory.InventoryCloseEvent;
+ import org.slf4j.Logger;
+ 
+ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTask> implements ServerInfo, ChunkIOErrorReporter, CommandSource, ca.spottedleaf.moonrise.patches.chunk_system.server.ChunkSystemMinecraftServer { // Paper - rewrite chunk system
 @@ -199,13 +_,6 @@
      public LevelStorageSource.LevelStorageAccess storageSource;
      public final PlayerDataStorage playerDataStorage;
@@ -203,9 +239,60 @@
  
          // CraftBukkit start
          // Run tasks that are waiting on processing
-@@ -1816,57 +_,38 @@
+@@ -1795,6 +_,7 @@
+         // Send time updates to everyone, it will get the right time from the world the player is in.
+         // Paper start - Perf: Optimize time updates
+         for (final ServerLevel level : Arrays.asList(region.world)) { // Folia - region threading
++            if (region.world.isUnloading) continue; // Canvas - fix world loading/unloading
+             final boolean doDaylight = level.getGameRules().getBoolean(GameRules.RULE_DAYLIGHT);
+             final long dayTime = level.getDayTime();
+             long worldTime = level.getGameTime();
+@@ -1815,58 +_,81 @@
+ 
          //this.isIteratingOverLevels = true; // Paper - Throw exception on world create while being ticked // Folia - region threading
          for (ServerLevel serverLevel : Arrays.asList(region.world)) { // Folia - region threading
++            // Canvas start - fix world loading/unloading
++            if (serverLevel.isUnloading) {
++                // finish teleports
++                final ChunkPos center = region.region.getCenterChunk();
++                final List<ServerLevel.PendingTeleport> pendingTeleports = serverLevel.removeAllRegionTeleports();
++                if (!pendingTeleports.isEmpty()) {
++                    LOGGER.info("Completing " + pendingTeleports.size() + " pending teleports in region around chunk " + center + " in world '" + region.region.regioniser.world.getWorld().getName() + "'");
++                    for (final ServerLevel.PendingTeleport pendingTeleport : pendingTeleports) {
++                        LOGGER.info("Completing teleportation to target position " + pendingTeleport.to());
++
++                        // first, add entities to entity chunk so that they will be saved
++                        for (final Entity.EntityTreeNode node : pendingTeleport.rootVehicle().getFullTree()) {
++                            // assume that world and position are set to destination here
++                            node.root.setLevel(serverLevel); // in case the pending teleport is from a portal before it finds the exact destination
++                            serverLevel.moonrise$getEntityLookup().addEntityForShutdownTeleportComplete(node.root);
++                        }
++
++                        // then, rebuild the passenger tree so that when saving only the root vehicle will be written - and if
++                        // there are any player passengers, that the later player saving will save the tree
++                        pendingTeleport.rootVehicle().restore();
++
++                        // now we are finished
++                        LOGGER.info("Completed teleportation to target position " + pendingTeleport.to());
++                    }
++                }
++
++                if (!serverLevel.players().isEmpty()) {
++                    // a player was teleported into the world when finishing teleports, kick.
++                    for (final ServerPlayer localPlayer : serverLevel.getLocalPlayers()) {
++                        localPlayer.getBukkitEntity().kickPlayer("World unloading");
++                    }
++                }
++
++                LOGGER.info("Saving chunks around region around chunk " + center + " in world '" + region.region.regioniser.world.getWorld().getName() + "'");
++                region.region.regioniser.world.moonrise$getChunkTaskScheduler().chunkHolderManager.close(true, true, false, false, false);
++
++                LOGGER.info("Descheduling region around chunk " + center + " in world '" + region.region.regioniser.world.getWorld().getName() + "'");
++                TickRegions.getScheduler().descheduleRegion(region.getRegionSchedulingHandle());
++                region.markClosed();
++                continue;
++            }
++            // Canvas end
              // Folia - region threading
 -            profilerFiller.push(() -> serverLevel + " " + serverLevel.dimension().location());
              /* Drop global time updates

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -1,23 +1,6 @@
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
-@@ -13,6 +_,8 @@
- import com.mojang.jtracy.DiscontinuousFrame;
- import com.mojang.jtracy.TracyClient;
- import com.mojang.logging.LogUtils;
-+import io.papermc.paper.threadedregions.RegionizedWorldData;
-+import io.papermc.paper.threadedregions.TickRegions;
- import it.unimi.dsi.fastutil.objects.ObjectArrayList;
- import it.unimi.dsi.fastutil.objects.ObjectArraySet;
- import java.awt.image.BufferedImage;
-@@ -70,6 +_,7 @@
- import net.minecraft.data.worldgen.features.MiscOverworldFeatures;
- import net.minecraft.gametest.framework.GameTestTicker;
- import net.minecraft.nbt.Tag;
-+import net.minecraft.network.DisconnectionDetails;
- import net.minecraft.network.chat.ChatDecorator;
- import net.minecraft.network.chat.ChatType;
- import net.minecraft.network.chat.Component;
-@@ -114,28 +_,19 @@
+@@ -114,19 +_,8 @@
  import net.minecraft.util.debugchart.RemoteDebugSampleType;
  import net.minecraft.util.debugchart.SampleLogger;
  import net.minecraft.util.debugchart.TpsDebugDimensions;
@@ -37,25 +20,6 @@
  import net.minecraft.util.thread.ReentrantBlockableEventLoop;
  import net.minecraft.world.Difficulty;
  import net.minecraft.world.RandomSequences;
-+import net.minecraft.world.entity.Entity;
- import net.minecraft.world.entity.ai.village.VillageSiege;
- import net.minecraft.world.entity.npc.CatSpawner;
- import net.minecraft.world.entity.npc.WanderingTraderSpawner;
- import net.minecraft.world.entity.player.Player;
- import net.minecraft.world.flag.FeatureFlagSet;
- import net.minecraft.world.flag.FeatureFlags;
-+import net.minecraft.world.item.ItemStack;
- import net.minecraft.world.item.alchemy.PotionBrewing;
- import net.minecraft.world.item.crafting.RecipeManager;
- import net.minecraft.world.level.ChunkPos;
-@@ -171,6 +_,7 @@
- import net.minecraft.world.level.storage.WorldData;
- import net.minecraft.world.phys.Vec2;
- import net.minecraft.world.phys.Vec3;
-+import org.bukkit.event.inventory.InventoryCloseEvent;
- import org.slf4j.Logger;
- 
- public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTask> implements ServerInfo, ChunkIOErrorReporter, CommandSource, ca.spottedleaf.moonrise.patches.chunk_system.server.ChunkSystemMinecraftServer { // Paper - rewrite chunk system
 @@ -199,13 +_,6 @@
      public LevelStorageSource.LevelStorageAccess storageSource;
      public final PlayerDataStorage playerDataStorage;
@@ -262,7 +226,7 @@
 +                        LOGGER.info("Completing teleportation to target position " + pendingTeleport.to());
 +
 +                        // first, add entities to entity chunk so that they will be saved
-+                        for (final Entity.EntityTreeNode node : pendingTeleport.rootVehicle().getFullTree()) {
++                        for (final net.minecraft.world.entity.Entity.EntityTreeNode node : pendingTeleport.rootVehicle().getFullTree()) {
 +                            // assume that world and position are set to destination here
 +                            node.root.setLevel(serverLevel); // in case the pending teleport is from a portal before it finds the exact destination
 +                            serverLevel.moonrise$getEntityLookup().addEntityForShutdownTeleportComplete(node.root);
@@ -288,7 +252,7 @@
 +                region.region.regioniser.world.moonrise$getChunkTaskScheduler().chunkHolderManager.close(true, true, false, false, false);
 +
 +                LOGGER.info("Descheduling region around chunk " + center + " in world '" + region.region.regioniser.world.getWorld().getName() + "'");
-+                TickRegions.getScheduler().descheduleRegion(region.getRegionSchedulingHandle());
++                io.papermc.paper.threadedregions.TickRegions.getScheduler().descheduleRegion(region.getRegionSchedulingHandle());
 +                region.markClosed();
 +                continue;
 +            }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -34,6 +34,15 @@
      private ServerConnectionListener connection;
      public final ChunkProgressListenerFactory progressListenerFactory;
      @Nullable
+@@ -1020,7 +_,7 @@
+     // CraftBukkit end
+ 
+     // Folia start - region threading
+-    private final java.util.concurrent.atomic.AtomicBoolean hasStartedShutdownThread = new java.util.concurrent.atomic.AtomicBoolean();
++    public final java.util.concurrent.atomic.AtomicBoolean hasStartedShutdownThread = new java.util.concurrent.atomic.AtomicBoolean(); // Canvas - private -> public
+ 
+     private void haltServerRegionThreading() {
+         if (this.hasStartedShutdownThread.getAndSet(true)) {
 @@ -1059,9 +_,6 @@
          shutdownThread = Thread.currentThread(); // Paper - Improved watchdog support
          org.spigotmc.WatchdogThread.doStop(); // Paper - Improved watchdog support
@@ -327,7 +336,16 @@
      }
  
      public boolean isLevelEnabled(Level level) {
-@@ -1922,18 +_,23 @@
+@@ -1918,22 +_,31 @@
+ 
+     @Nullable
+     public ServerLevel getLevel(ResourceKey<Level> dimension) {
+-        return this.levels.get(dimension);
++        // Canvas start - fix world loading/unloading
++        ServerLevel serverLevel = this.levels.get(dimension);
++        if (serverLevel != null && serverLevel.isUnloading) return null;
++        return serverLevel;
++        // Canvas end
      }
  
      // CraftBukkit start

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -9,6 +9,14 @@
  import net.minecraft.util.valueproviders.IntProvider;
  import net.minecraft.util.valueproviders.UniformInt;
  import net.minecraft.world.DifficultyInstance;
+@@ -656,6 +_,7 @@
+     public static final int WORLD_INIT_CHECKED = 2;
+     public final java.util.concurrent.atomic.AtomicInteger checkInitialised = new java.util.concurrent.atomic.AtomicInteger(WORLD_INIT_NOT_CHECKED);
+     public ChunkPos randomSpawnSelection;
++    public volatile boolean isUnloading = false; // Canvas - fix world loading/unloading
+ 
+     public static final record PendingTeleport(Entity.EntityTreeNode rootVehicle, Vec3 to) {}
+     private final it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<PendingTeleport> pendingTeleports = new it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<>();
 @@ -727,17 +_,12 @@
  
      public void tick(BooleanSupplier hasTimeLeft, io.papermc.paper.threadedregions.TickRegions.TickRegionData region) { // Folia - regionised ticking

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -93,6 +93,22 @@
                      }
                      // Folia end - region threading
                  } else if (this.portalProcess.hasExpired()) {
+@@ -4358,6 +_,7 @@
+         EntityTreeNode passengerTree = this.detachPassengers();
+         List<EntityTreeNode> fullPassengerTree = passengerTree.getFullTree();
+         ServerLevel originWorld = (ServerLevel)this.level;
++        if (destination.isUnloading) return false; // Canvas - fix world loading/unloading
+ 
+         for (EntityTreeNode node : fullPassengerTree) {
+             node.root.preChangeDimension();
+@@ -4622,6 +_,7 @@
+                 }
+             }
+         }
++        if (to.isUnloading) return false; // Canvas - fix world loading/unloading
+ 
+         return true;
+     }
 @@ -4797,15 +_,12 @@
              entity.teleport(this.calculatePassengerTransition(teleportTransition, entity));
          }

--- a/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
+++ b/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
@@ -1,13 +1,5 @@
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
-@@ -96,6 +_,7 @@
- import net.minecraft.world.item.crafting.RecipeHolder;
- import net.minecraft.world.item.crafting.RecipeType;
- import net.minecraft.world.item.crafting.RepairItemRecipe;
-+import net.minecraft.world.level.ChunkPos;
- import net.minecraft.world.level.CustomSpawner;
- import net.minecraft.world.level.GameRules;
- import net.minecraft.world.level.GameType;
 @@ -286,7 +_,7 @@
      private final StructureManager structureManager;
      final DedicatedServer console;
@@ -33,10 +25,10 @@
 +        // Canvas start - fix world loading/unloading
 +        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addWorld(serverLevel);
 +        int loadRegionRadius = 1024 >> 4;
-+        serverLevel.randomSpawnSelection = new ChunkPos(serverLevel.getChunkSource().randomState().sampler().findSpawnPosition());
++        serverLevel.randomSpawnSelection = new net.minecraft.world.level.ChunkPos(serverLevel.getChunkSource().randomState().sampler().findSpawnPosition());
 +        for (int currX = -loadRegionRadius; currX <= loadRegionRadius; ++currX) {
 +            for (int currZ = -loadRegionRadius; currZ <= loadRegionRadius; ++currZ) {
-+                ChunkPos pos = new ChunkPos(currX, currZ);
++                net.minecraft.world.level.ChunkPos pos = new net.minecraft.world.level.ChunkPos(currX, currZ);
 +                serverLevel.moonrise$getChunkTaskScheduler().chunkHolderManager.addTicketAtLevel(
 +                    net.minecraft.server.level.TicketType.UNKNOWN, pos, ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.MAX_TICKET_LEVEL, null
 +                );

--- a/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
+++ b/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
@@ -5,7 +5,7 @@
      final DedicatedServer console;
      private final DedicatedPlayerList playerList;
 -    private final Map<String, World> worlds = new LinkedHashMap<>();
-+    public final Map<String, World> worlds = new java.util.concurrent.ConcurrentHashMap<>(); // Canvas - private -> public - concurrent
++    public final Map<String, World> worlds = it.unimi.dsi.fastutil.objects.Object2ObjectMaps.synchronize(new it.unimi.dsi.fastutil.objects.Object2ObjectLinkedOpenHashMap<>()); // Canvas - private -> public - fastutil - synchronized
      private YamlConfiguration configuration;
      private YamlConfiguration commandsConfiguration;
      private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
@@ -77,7 +77,7 @@
  
 -        this.worlds.remove(world.getName().toLowerCase(Locale.ROOT));
 -        this.console.removeLevel(handle);
-+        // Canvas - fix world loading/unloading
++        // Canvas - fix world loading/unloading - moved to global tick
          return true;
      }
  

--- a/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
+++ b/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
@@ -1,5 +1,94 @@
 --- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -96,6 +_,7 @@
+ import net.minecraft.world.item.crafting.RecipeHolder;
+ import net.minecraft.world.item.crafting.RecipeType;
+ import net.minecraft.world.item.crafting.RepairItemRecipe;
++import net.minecraft.world.level.ChunkPos;
+ import net.minecraft.world.level.CustomSpawner;
+ import net.minecraft.world.level.GameRules;
+ import net.minecraft.world.level.GameType;
+@@ -286,7 +_,7 @@
+     private final StructureManager structureManager;
+     final DedicatedServer console;
+     private final DedicatedPlayerList playerList;
+-    private final Map<String, World> worlds = new LinkedHashMap<>();
++    public final Map<String, World> worlds = new java.util.concurrent.ConcurrentHashMap<>(); // Canvas - private -> public - concurrent
+     private YamlConfiguration configuration;
+     private YamlConfiguration commandsConfiguration;
+     private final Yaml yaml = new Yaml(new SafeConstructor(new LoaderOptions()));
+@@ -1259,7 +_,6 @@
+ 
+     @Override
+     public World createWorld(WorldCreator creator) {
+-        if (true) throw new UnsupportedOperationException(); // Folia - not implemented properly yet
+         Preconditions.checkState(this.console.getAllLevels().iterator().hasNext(), "Cannot create additional worlds on STARTUP");
+         //Preconditions.checkState(!this.console.isIteratingOverLevels, "Cannot create a world while worlds are being ticked"); // Paper - Cat - Temp disable. We'll see how this goes.
+         Preconditions.checkArgument(creator != null, "WorldCreator cannot be null");
+@@ -1438,7 +_,20 @@
+         }
+ 
+         this.console.addLevel(serverLevel); // Paper - Put world into worldlist before initing the world; move up
+-        this.console.initWorld(serverLevel, primaryLevelData, primaryLevelData, primaryLevelData.worldGenOptions());
++        // Canvas start - fix world loading/unloading
++        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addWorld(serverLevel);
++        int loadRegionRadius = 1024 >> 4;
++        serverLevel.randomSpawnSelection = new ChunkPos(serverLevel.getChunkSource().randomState().sampler().findSpawnPosition());
++        for (int currX = -loadRegionRadius; currX <= loadRegionRadius; ++currX) {
++            for (int currZ = -loadRegionRadius; currZ <= loadRegionRadius; ++currZ) {
++                ChunkPos pos = new ChunkPos(currX, currZ);
++                serverLevel.moonrise$getChunkTaskScheduler().chunkHolderManager.addTicketAtLevel(
++                    net.minecraft.server.level.TicketType.UNKNOWN, pos, ca.spottedleaf.moonrise.patches.chunk_system.scheduling.ChunkHolderManager.MAX_TICKET_LEVEL, null
++                );
++            }
++        }
++        // this.console.initWorld(serverLevel, primaryLevelData, primaryLevelData, primaryLevelData.worldGenOptions());
++        // Canvas end
+ 
+         serverLevel.setSpawnSettings(true);
+         // Paper - Put world into worldlist before initing the world; move up
+@@ -1457,13 +_,13 @@
+ 
+     @Override
+     public boolean unloadWorld(World world, boolean save) {
+-        if (true) throw new UnsupportedOperationException(); // Folia - not implemented properly yet
+         //Preconditions.checkState(!this.console.isIteratingOverLevels, "Cannot unload a world while worlds are being ticked"); // Paper - Cat - Temp disable. We'll see how this goes.
+         if (world == null) {
+             return false;
+         }
+ 
+         ServerLevel handle = ((CraftWorld) world).getHandle();
++        if (handle.isUnloading) return true; // Canvas - fix world loading/unloading - we are already unloading
+ 
+         if (this.console.getLevel(handle.dimension()) == null) {
+             return false;
+@@ -1483,19 +_,18 @@
+         }
+ 
+         try {
+-            if (save) {
+-                handle.save(null, true, false); // Paper - Fix saving in unloadWorld
+-            }
++            // Canvas start - fix world loading/unloading
++            MinecraftServer.LOGGER.info("Beginning unload for World '" + world.getName() + "'");
++            handle.isUnloading = true;
++            // moved to regions
+ 
+-            handle.getChunkSource().close(save);
+-            io.papermc.paper.FeatureHooks.closeEntityManager(handle, save); // SPIGOT-6722: close entityManager // Paper - chunk system
+-            handle.levelStorageAccess.close();
++            // moved to global tick
++            // Canvas end
+         } catch (Exception ex) {
+             this.getLogger().log(Level.SEVERE, null, ex);
+         }
+ 
+-        this.worlds.remove(world.getName().toLowerCase(Locale.ROOT));
+-        this.console.removeLevel(handle);
++        // Canvas - fix world loading/unloading
+         return true;
+     }
+ 
 @@ -2954,7 +_,7 @@
      @Override
      public double getAverageTickTime() {

--- a/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
+++ b/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/CraftServer.java.patch
@@ -50,11 +50,11 @@
          }
  
          ServerLevel handle = ((CraftWorld) world).getHandle();
-+        if (handle.isUnloading) return true; // Canvas - fix world loading/unloading - we are already unloading
++        if (handle.isUnloading) return false; // Canvas - fix world loading/unloading - we are already unloading
  
          if (this.console.getLevel(handle.dimension()) == null) {
              return false;
-@@ -1483,19 +_,18 @@
+@@ -1483,19 +_,19 @@
          }
  
          try {
@@ -62,6 +62,7 @@
 -                handle.save(null, true, false); // Paper - Fix saving in unloadWorld
 -            }
 +            // Canvas start - fix world loading/unloading
++            if (this.console.hasStartedShutdownThread.get()) return false; // don't unload during shutdown
 +            MinecraftServer.LOGGER.info("Beginning unload for World '" + world.getName() + "'");
 +            handle.isUnloading = true;
 +            // moved to regions


### PR DESCRIPTION
Fixes world load/unload API

This API is broken and disabled in Folia. This PR fixes this and re-enables the API.

For world *loading*:
- The thing that was broken about this was thread ownership and the fact that the RegionizedServer did *not* have the world added to it. The thread ownership was already solved by Folia by postponing the `initWorld` call to the first tick of the first region to init spawn, and placing tickets within a 1024 block radius of 0,0 to prevent thread ownership issues during startup. The changes made to `CraftServer#createWorld` reflect these changes, and replace `initWorld` with the same system. To accommodate for the RegionizedServer not having the world added to it, at the same time of the world being added to the `MinecraftServer#levels`, we add it to the RegionizedServer.

For world *unloading*:
- World unloading is ***much*** trickier. To unload a Bukkit world in Paper, the world needs to not have players, so we can guarantee no players are *currently* in the world. Unloading follows a specific structure of steps:
  - Mark the world for unloading. This is achieved via a new `volatile boolean isUnloading` in `ServerLevel`
  - With the world marked for unloading, on the regions **next** tick, when about to tick the world in `MinecraftServer#tickChildren`, we check if the world is marked for unload
  - If the world *is* marked for unload, we begin the shutdown of the region.
  - First, we complete any pending teleports. This does introduce the possibility for a player to enter the world at the time of unloading, if this *does* happen, we kick the player(WIP, subject to change)
  - After completing teleports, we save chunks in the region
  - Once *all* of that is done, we deschedule the region and marked it as "closed" via `TickRegionData#markClosed`
  - Meanwhile, the RegionizedServer `globalTick` is checking each world tick if the world is marked for unload. If the world is marked for unload, it doesn't tick the world. It checks for if all regions(using `computeForAllRegions`) are marked as "closed"
  - Once *all* regions are marked as closed, the global tick takes over the finalization of shutdown, such as halting the chunk system and releasing the level storage lock. It removes it from all 3 world holders(`RegionizedServer#worlds`, `CraftServer#worlds`, `MinecraftServer#removeLevel`).

We don't need to worry about the server shutdown process interfering with the unload if a plugin calls unload during shutdown, as it will just be picked up by the shutdown thread since unload follows closely to what shutdown does, so it would be realistically the same thing. If this is called and *then* shutdown is called, then the shutdown thread halts all regions, so the unload just completes what it can before shutdown. Worse-case-scenario we save a region a second time on the shutdown thread, as the unload logic follows closely to the shutdown logic.

If a player is teleported into the world(or a player is *in* the world at the time of unload, which is impossible because Bukkit won't let you unload the world) during unload, we kick the player with the disconnect message of "World unloading". If a player attempts to begin teleporting during unload, we have checks added to prevent the player from teleporting into the world during unload, so only teleports that were called prior to unload can actually be processed to avoid race conditions with players never being placed in the destination world.

We kick the player because when the player rejoins, they are placed at the overworld spawn location if the world hasn't been loaded back in. If the world was loaded back in when the player relogs, then they are placed at the teleport location from when they were kicked. If a player is placed via login during unload, we return the `ServerLevel` as null so it defaults to the overworld spawn location. During the `globalTick` finalization of shutdown, we kick any remaining players that might have been added during unload via conditions that weren't caught before.