### PR TITLE
restore vanilla ender pearl behavior

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -197,3 +197,29 @@
              return true;
          } else {
              return super.endPortalLogicAsync(portalPos);
+@@ -3280,13 +_,23 @@
+         return getInputVector(new Vec3(f, 0.0, f1), 1.0F, this.getYRot());
+     }
+ 
++    // Canvas start - restore vanilla ender pearl behavior
+     public void registerEnderPearl(ThrownEnderpearl enderPearl) {
+-        //this.enderPearls.add(enderPearl); // Folia - region threading - do not track ender pearls
++        if (io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) {
++            this.enderPearls.add(enderPearl);
++        } else {
++            //this.enderPearls.add(enderPearl); // Folia - region threading - do not track ender pearls
++        }
+     }
+ 
+     public void deregisterEnderPearl(ThrownEnderpearl enderPearl) {
+-        //this.enderPearls.remove(enderPearl); // Folia - region threading - do not track ender pearls
++        if (io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) {
++            this.enderPearls.remove(enderPearl);
++        } else {
++            //this.enderPearls.remove(enderPearl); // Folia - region threading - do not track ender pearls
++        }
+     }
++    // Canvas end - restore vanilla ender pearl behavior
+ 
+     public Set<ThrownEnderpearl> getEnderPearls() {
+         return this.enderPearls;

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1,5 +1,22 @@
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -19,6 +_,7 @@
+ import java.util.OptionalInt;
+ import java.util.Set;
+ import java.util.UUID;
++import java.util.concurrent.ConcurrentHashMap;
+ import java.util.stream.Collectors;
+ import javax.annotation.Nonnull;
+ import javax.annotation.Nullable;
+@@ -265,7 +_,7 @@
+     private BlockPos raidOmenPosition;
+     private Vec3 lastKnownClientMovement = Vec3.ZERO;
+     private Input lastClientInput = Input.EMPTY;
+-    private final Set<ThrownEnderpearl> enderPearls = new HashSet<>();
++    private final Set<ThrownEnderpearl> enderPearls = ConcurrentHashMap.newKeySet();
+     public final ContainerSynchronizer containerSynchronizer = new ContainerSynchronizer() {
+         private final LoadingCache<TypedDataComponent<?>, Integer> cache = CacheBuilder.newBuilder()
+             .maximumSize(256L)
 @@ -1524,14 +_,25 @@
       * internally for {@link #respawn(java.util.function.Consumer, org.bukkit.event.player.PlayerRespawnEvent.RespawnReason)}
       */
@@ -197,7 +214,7 @@
              return true;
          } else {
              return super.endPortalLogicAsync(portalPos);
-@@ -3280,13 +_,23 @@
+@@ -3280,13 +_,19 @@
          return getInputVector(new Vec3(f, 0.0, f1), 1.0F, this.getYRot());
      }
  
@@ -206,8 +223,6 @@
 -        //this.enderPearls.add(enderPearl); // Folia - region threading - do not track ender pearls
 +        if (io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) {
 +            this.enderPearls.add(enderPearl);
-+        } else {
-+            //this.enderPearls.add(enderPearl); // Folia - region threading - do not track ender pearls
 +        }
      }
  
@@ -215,8 +230,6 @@
 -        //this.enderPearls.remove(enderPearl); // Folia - region threading - do not track ender pearls
 +        if (io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) {
 +            this.enderPearls.remove(enderPearl);
-+        } else {
-+            //this.enderPearls.remove(enderPearl); // Folia - region threading - do not track ender pearls
 +        }
      }
 +    // Canvas end - restore vanilla ender pearl behavior

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1,19 +1,11 @@
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
-@@ -19,6 +_,7 @@
- import java.util.OptionalInt;
- import java.util.Set;
- import java.util.UUID;
-+import java.util.concurrent.ConcurrentHashMap;
- import java.util.stream.Collectors;
- import javax.annotation.Nonnull;
- import javax.annotation.Nullable;
 @@ -265,7 +_,7 @@
      private BlockPos raidOmenPosition;
      private Vec3 lastKnownClientMovement = Vec3.ZERO;
      private Input lastClientInput = Input.EMPTY;
 -    private final Set<ThrownEnderpearl> enderPearls = new HashSet<>();
-+    private final Set<ThrownEnderpearl> enderPearls = ConcurrentHashMap.newKeySet();
++    private final Set<ThrownEnderpearl> enderPearls = java.util.concurrent.ConcurrentHashMap.newKeySet();
      public final ContainerSynchronizer containerSynchronizer = new ContainerSynchronizer() {
          private final LoadingCache<TypedDataComponent<?>, Integer> cache = CacheBuilder.newBuilder()
              .maximumSize(256L)

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -5,7 +5,7 @@
      private Vec3 lastKnownClientMovement = Vec3.ZERO;
      private Input lastClientInput = Input.EMPTY;
 -    private final Set<ThrownEnderpearl> enderPearls = new HashSet<>();
-+    private final Set<ThrownEnderpearl> enderPearls = java.util.concurrent.ConcurrentHashMap.newKeySet();
++    private final Set<ThrownEnderpearl> enderPearls = java.util.concurrent.ConcurrentHashMap.newKeySet(); // Canvas - restore vanilla ender pearl behavior
      public final ContainerSynchronizer containerSynchronizer = new ContainerSynchronizer() {
          private final LoadingCache<TypedDataComponent<?>, Integer> cache = CacheBuilder.newBuilder()
              .maximumSize(256L)

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -24,7 +24,7 @@
 +                } else {
 +                    thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
 +                }
-+                // Canvas start - restore vanilla ender pearl behavior
++                // Canvas end - restore vanilla ender pearl behavior
              } else {
                  thrownEnderpearl.setOwner(null);
              }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -9,6 +9,25 @@
              // Folia end - rewrite login process
              connection.setupInboundProtocol(
                  GameProtocols.SERVERBOUND_TEMPLATE.bind(RegistryFriendlyByteBuf.decorator(this.server.registryAccess()), serverGamePacketListenerImpl),
+@@ -650,7 +_,17 @@
+         for (ThrownEnderpearl thrownEnderpearl : player.getEnderPearls()) {
+             // Paper start - Allow using old ender pearl behavior
+             if (!thrownEnderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) {
+-                thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
++                // Canvas start - restore vanilla ender pearl behavior
++                if (io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) {
++                    io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
++                        thrownEnderpearl.level().getMinecraftWorld(), thrownEnderpearl.chunkPosition().x, thrownEnderpearl.chunkPosition().z, () -> {
++                            thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
++                        }
++                    );
++                } else {
++                    thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
++                }
++                // Canvas start - restore vanilla ender pearl behavior
+             } else {
+                 thrownEnderpearl.setOwner(null);
+             }
 @@ -1385,6 +_,7 @@
      }
  

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -159,6 +159,9 @@ public class Config {
     @Comment("Disables Minecraft Chat Signing to prevent player reporting")
     public boolean enableNoChatReports = false;
 
+    @Comment("Restores vanilla loading and unloading behavior broken by Folia")
+    public boolean restoreVanillaEnderPearlBehavior = false;
+
     private static <T extends Config> @NotNull ConfigSerializer<T> buildSerializer(Configuration config, Class<T> configClass) {
         ConfigurationUtils.extractKeys(configClass);
         Set<String> changes = new LinkedHashSet<>();


### PR DESCRIPTION
This PR restores the vanilla Ender Pearl loading and unloading behavior when a player joins or leaves, which Folia removed.