### PR TITLE
weaver 2.1.4

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ You can download the latest release from the [Downloads Page](https://canvasmc.i
 
 ```bash
 ./gradlew applyAllPatches         # Apply all patches
-./gradlew buildPublisherJar       # Build the server jar
+./gradlew buildMojmapPublisherJar # Build the server jar
 ./gradlew runDevServer            # Run dev server
 ./rebuildPatches                  # Custom script to generate patches for modified directories
 ````

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import io.papermc.paperweight.tasks.RebuildBaseGitPatches
 
 plugins {
     java
-    id("io.canvasmc.weaver.patcher") version "2.1.3-SNAPSHOT"
+    id("io.canvasmc.weaver.patcher") version "2.1.4-SNAPSHOT"
 }
 
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"
@@ -122,34 +122,6 @@ project(":canvas-api") {
                     }
                 }
             }
-        }
-    }
-}
-
-// build publication
-tasks.register<Jar>("createMojmapClipboardJar") {
-    dependsOn(":canvas-server:createMojmapPaperclipJar")
-}
-
-tasks.register("buildPublisherJar") {
-    dependsOn(":createMojmapClipboardJar")
-
-    doLast {
-        val buildNumber = System.getenv("BUILD_NUMBER") ?: "local"
-
-        val paperclipJarTask = project(":canvas-server").tasks.getByName("createMojmapPaperclipJar")
-        val outputJar = paperclipJarTask.outputs.files.singleFile
-        val outputDir = outputJar.parentFile
-
-        if (outputJar.exists()) {
-            val newJarName = "canvas-build.$buildNumber.jar"
-            val newJarFile = File(outputDir, newJarName)
-
-            outputDir.listFiles()
-                ?.filter { it.name.startsWith("canvas-build.") && it.name.endsWith(".jar") }
-                ?.forEach { it.delete() }
-            outputJar.renameTo(newJarFile)
-            println("Renamed ${outputJar.name} to $newJarName in ${outputDir.absolutePath}")
         }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -4,6 +4,7 @@ version = 1.21.7-R0.1-SNAPSHOT
 mcVersion = 1.21.7
 foliaCommit = 40402e402c8061f8896587ae280ffdef0fa2b6ec
 
+org.gradle.configuration-cache = true
 org.gradle.caching = true
 org.gradle.parallel = true
 org.gradle.vfs.watch = false


### PR DESCRIPTION
Pull request for when weaver 2.1.4-SNAPSHOT gets deployed.

**notes:**
-> forks can now make use of the `build...PublisherJar` task too; to configure a build number set the `BUILD_NUMBER` env variable