### PR TITLE
[ci-skip] chore: bump weaver to 2.3.10

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@
 
 ```bash
 ./gradlew applyAllPatches
-./gradlew buildMojmapPublisherJar
+./gradlew createMojmapPublisherJar
 ./gradlew runDevServer
 ```
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -5,7 +5,7 @@ import io.papermc.paperweight.tasks.RebuildBaseGitPatches
 
 plugins {
     java
-    id("io.canvasmc.weaver.patcher") version "2.3.9"
+    id("io.canvasmc.weaver.patcher") version "2.3.10"
 }
 
 val paperMavenPublicUrl = "https://repo.papermc.io/repository/maven-public/"

--- a/buildEnv
+++ b/buildEnv
@@ -14,5 +14,5 @@ echo "Building development environment"
 
 if $build; then
     echo "Building publisher jar"
-    ./gradlew buildPublisherJar
+    ./gradlew createMojmapPublisherJar
 fi


### PR DESCRIPTION
Requires an update to CI build due to publisher task rename