### PR TITLE
Entity Culling

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ChunkMap.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ChunkMap.java.patch
@@ -25,6 +25,15 @@
                  this.ticketStorage.getTicketDebugString(longKey, true),
                  this.distanceManager.getChunkLevel(longKey, true),
                  optional1.<Integer>map(chunk -> chunk.getBlockTicks().count()).orElse(0),
+@@ -1277,7 +_,7 @@
+                 double d1 = vec3_dx * vec3_dx + vec3_dz * vec3_dz; // Paper
+                 double d2 = d * d;
+                 // Paper start - Configurable entity tracking range by Y
+-                boolean flag = d1 <= d2;
++                boolean flag = d1 <= d2 && !entity.isCulled(player); // Canvas - entity culling
+                 if (flag && level.paperConfig().entities.trackingRangeY.enabled) {
+                     double rangeY = level.paperConfig().entities.trackingRangeY.get(this.entity, -1);
+                     if (rangeY != -1) {
 @@ -1293,7 +_,7 @@
                  }
                  // Folia end - region threading

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
@@ -21,6 +21,15 @@
              this.broadcastWithIgnore.accept(new ClientboundSetPassengersPacket(this.entity), list);
              // Paper start - Allow riding players
              if (this.entity instanceof ServerPlayer player) {
+@@ -176,7 +_,7 @@
+                 boolean flag1 = (vec3_dx * vec3_dx + vec3_dy * vec3_dy + vec3_dz * vec3_dz) >= 7.62939453125E-6D;
+                 // Paper end - reduce allocation of Vec3D here
+                 Packet<?> packet = null;
+-                boolean flag2 = flag1 || this.tickCount % 60 == 0;
++                // Canvas - reduce useless move packets
+                 boolean flag3 = false;
+                 boolean flag4 = false;
+                 long l = this.positionCodec.encodeX(vec3);
 @@ -193,21 +_,36 @@
                      packet = ClientboundEntityPositionSyncPacket.of(this.entity);
                      flag3 = true;
@@ -38,14 +47,14 @@
 -                    packet = new ClientboundMoveEntityPacket.PosRot(this.entity.getId(), (short)l, (short)l1, (short)l2, b, b1, this.entity.onGround());
 -                    flag3 = true;
 -                    flag4 = true;
-+                    if (flag2 || flag || this.entity instanceof AbstractArrow) {
-+                        if (this.entity instanceof AbstractArrow || (flag2 && flag)) {
++                    if (flag1 || flag || this.entity instanceof AbstractArrow) {
++                        if (this.entity instanceof AbstractArrow || (flag1 && flag)) {
 +                            packet = new ClientboundMoveEntityPacket.PosRot(
 +                                this.entity.getId(), (short) l, (short) l1, (short) l2, b, b1, this.entity.onGround()
 +                            );
 +                            flag3 = true;
 +                            flag4 = true;
-+                        } else if (flag2) {
++                        } else if (flag1) {
 +                            packet = new ClientboundMoveEntityPacket.Pos(
 +                                this.entity.getId(), (short) l, (short) l1, (short) l2, this.entity.onGround()
 +                            );
@@ -70,7 +79,7 @@
                      Vec3 deltaMovement = this.entity.getDeltaMovement();
                      double d = deltaMovement.distanceToSqr(this.lastSentMovement);
                      if (d > 1.0E-7 || d > 0.0 && deltaMovement.lengthSqr() == 0.0) {
-@@ -222,9 +_,38 @@
+@@ -222,9 +_,41 @@
                                          )
                                      )
                                  );
@@ -95,13 +104,16 @@
 +                               2. Item Entities, disabling this causes glitches and often slightly desyncs their position within 0.5 blocks on the client side
 +                               3. Ender Eyes, they depend on their velocity being set bc the packet sets the velocity on the client, but the client doesn't handle the
 +                                    ender eye velocity on its own bc the ender eye velocity is in relation to the stronghold structure which the client doesn't have access to
++                               4. Shulker Bullets move randomly, and as a result, the client cannot predict these. This is required due to how the logic of the entity
++                                    is constructed to maintain smoothness.
 +
 +                               This filter helps keep unneeded packets reduced, but also ensures that we keep smooth visual gameplay
 +                            */
 +                            if (
 +                                this.entity instanceof net.minecraft.world.entity.item.ItemEntity ||
-+                                    this.entity instanceof net.minecraft.world.entity.projectile.EyeOfEnder ||
-+                                    this.entity instanceof net.minecraft.world.entity.animal.Squid
++                                this.entity instanceof net.minecraft.world.entity.projectile.EyeOfEnder ||
++                                this.entity instanceof net.minecraft.world.entity.animal.Squid ||
++                                this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet
 +                            ) {
 +                                this.broadcast.accept(new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement));
 +                            }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -657,3 +657,17 @@
      }
  
      public double getFluidJumpThreshold() {
+@@ -6067,6 +_,13 @@
+         }
+         // Paper end - Folia schedulers
+     }
++    // Canvas start - entity culling
++
++    public boolean isCulled(Player player) {
++        if (!io.canvasmc.canvas.Config.INSTANCE.networking.enableOptimizedEntityTracker) return false;
++        return player.isEntityCulled(this);
++    }
++    // Canvas end - entity culling
+ 
+     public void unsetRemoved() {
+         this.removalReason = null;

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -1,13 +1,210 @@
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
-@@ -223,6 +_,7 @@
+@@ -223,6 +_,195 @@
      public boolean affectsSpawning = true; // Paper - Affects Spawning API
      public net.kyori.adventure.util.TriState flyingFallDamage = net.kyori.adventure.util.TriState.NOT_SET; // Paper - flying fall damage
  	 public int sixRowEnderchestSlotCount = -1; // Purpur - Barrels and enderchests 6 rows
 +    public boolean canvas$isTemporarilyBlocking = false; // Canvas - implement sword blocking
++    // Canvas start - entity culling
++    private static final byte UNSET = (byte) -1;
++    private static final byte FALSE = (byte) 0;
++    private static final byte TRUE = (byte) 1;
++    private final it.unimi.dsi.fastutil.longs.Long2ByteOpenHashMap cachedIsOpaqueFullCube;
++    private int lastTick = -1;
++
++    public boolean isEntityCulled(Entity entity) {
++        if (entity == this) return false; // if we are the entity(which shouldn't happen, but we check anyway) please render us!
++        if (!((ServerPlayer) this).isRealPlayer) return true; // if we aren't real, don't track!
++
++        if (this.gameMode().getId() == 3) return false; // if we are in spectator, the entity should always render
++
++        if (entity instanceof Player player) {
++            // if the entity is a player, special handling
++            // generally speaking, all players should render, however we need
++            // to account for spectator mode being a thing
++            int otherGm = player.gameMode().getId();
++            // if the other players gamemode is spectator, we can cull them. otherwise, they need to be rendered
++            return otherGm == 3;
++        }
++
++        // Note: Bukkit canSee check is *not* covered. this will never show up here, ever.
++        //       that method is expensive AF, and shouldn't be used in a place where this
++        //       needs to be as lightweight as possible. Bukkit will handle this themselves
++        if (
++            // if entity is glowing we must render, because that can be seen through blocks
++            entity.isCurrentlyGlowing()
++            // skip armor stands being used as markers, they can be tracked
++            || (entity instanceof ArmorStand && entity.isInvisible())
++            // if custom name is always rendering(plugin?), we should render
++            || entity.isCustomNameVisible()
++            // skip display entities, they can be tracked
++            || entity instanceof net.minecraft.world.entity.Display
++        ) {
++            return false;
++        }
++
++        final double distSqr = entity.position.distanceToSqr(this.position);
++
++        if (distSqr < 6) return false; // if they are within 3 blocks, just force-render them
++        if (distSqr >= (64 * 64)) return true; // 64 blocks is good, no need to render beyond that
++
++        // if the bounding box is greater than 20, just render it, no point in trying to cull this thing...
++        final AABB box = entity.getBoundingBox().inflate(0.3);
++        if (box.getXsize() > 20 || box.getYsize() > 20 || box.getZsize() > 20)
++            return false;
++
++        // passed all exceptions, culling time
++        final Vec3 eye = this.getEyePosition(0);
++        return !canSeeAABB(eye.x, eye.y, eye.z, box.minX, box.minY, box.minZ, box.maxX, box.maxY, box.maxZ);
++    }
++
++    public boolean canSeeAABB(
++        final double eyeX, final double eyeY, final double eyeZ,
++        final double minX, final double minY, final double minZ,
++        final double maxX, final double maxY, final double maxZ
++    ) {
++        // if the AABBs are touching, they are obviously visible
++        if (eyeX >= minX && eyeX <= maxX &&
++            eyeY >= minY && eyeY <= maxY &&
++            eyeZ >= minZ && eyeZ <= maxZ)
++            return true;
++
++        // 8 targets to get all corners in the 3D box
++        final double[][] targets = {
++            {minX, minY, minZ}, {minX, minY, maxZ}, {minX, maxY, minZ}, {minX, maxY, maxZ},
++            {maxX, minY, minZ}, {maxX, minY, maxZ}, {maxX, maxY, minZ}, {maxX, maxY, maxZ}
++        };
++
++        // clear cache every tick
++        if (this.tickCount > this.lastTick) {
++            this.cachedIsOpaqueFullCube.clear();
++            this.lastTick = this.tickCount;
++        }
++
++        for (double[] t : targets) {
++            if (!raycastBlocks(eyeX, eyeY, eyeZ, t[0], t[1], t[2])) {
++                return true;
++            }
++        }
++
++        return false;
++    }
++
++    private boolean raycastBlocks(double sx, double sy, double sz, double ex, double ey, double ez) {
++        double dx = ex - sx;
++        double dy = ey - sy;
++        double dz = ez - sz;
++
++        double lenSq = dx * dx + dy * dy + dz * dz;
++        if (lenSq < 1e-9) return false;
++        double invLen = 1.0 / Math.sqrt(lenSq);
++        dx *= invLen; dy *= invLen; dz *= invLen;
++        double maxDist = Math.sqrt(lenSq);
++
++        int bx = (int) Math.floor(sx);
++        int by = (int) Math.floor(sy);
++        int bz = (int) Math.floor(sz);
++
++        final double stepX = dx > 0 ? 1.0 : -1.0;
++        final double stepY = dy > 0 ? 1.0 : -1.0;
++        final double stepZ = dz > 0 ? 1.0 : -1.0;
++
++        double tMaxX = intBound(sx, dx);
++        double tMaxY = intBound(sy, dy);
++        double tMaxZ = intBound(sz, dz);
++
++        final double tDeltaX = Math.abs(1.0 / dx);
++        final double tDeltaY = Math.abs(1.0 / dy);
++        final double tDeltaZ = Math.abs(1.0 / dz);
++
++        double dist = 0.0;
++        final double EPS = 1e-6;
++
++        int lastChunkX = bx >> 4;
++        int lastChunkZ = bz >> 4;
++        net.minecraft.world.level.chunk.LevelChunk access = level().getChunkIfLoaded(lastChunkX, lastChunkZ);
++        while (dist <= maxDist) {
++            long key = ((bx & 67108863L) << 38) | ((by &  4095L)) | ((bz & 67108863L) << 12);
++            byte a;
++            if ((a = cachedIsOpaqueFullCube.get(key)) == UNSET) {
++                int currChunkX = bx >> 4;
++                int currChunkZ = bz >> 4;
++                if (lastChunkX != currChunkX || lastChunkZ != currChunkZ) {
++                    access = level().getChunkIfLoaded(currChunkX, currChunkZ);
++                    lastChunkX = currChunkX;
++                    lastChunkZ = currChunkZ;
++                }
++                if (access != null) {
++                    boolean opaque = isOpaqueFullCube(access, bx, by, bz);
++                    cachedIsOpaqueFullCube.put(key, opaque ? TRUE : FALSE);
++                    if (opaque) return true;
++                } // else | non-opaque
++            } else if (a == TRUE) {
++                return true;
++            } // else | non-opaque
++
++            if (tMaxX < tMaxY) {
++                if (tMaxX < tMaxZ) {
++                    bx += stepX;
++                    dist = tMaxX;
++                    tMaxX += tDeltaX;
++                } else {
++                    bz += stepZ;
++                    dist = tMaxZ;
++                    tMaxZ += tDeltaZ;
++                }
++            } else {
++                if (tMaxY < tMaxZ) {
++                    by += stepY;
++                    dist = tMaxY;
++                    tMaxY += tDeltaY;
++                } else {
++                    bz += stepZ;
++                    dist = tMaxZ;
++                    tMaxZ += tDeltaZ;
++                }
++            }
++
++            if (dist > maxDist + EPS)
++                break;
++        }
++
++        return false;
++    }
++
++    private static double intBound(double s, double ds) {
++        if (ds > 0) {
++            s = s - Math.floor(s);
++            return (1.0 - s) / ds;
++        } else if (ds < 0) {
++            s = s - Math.floor(s);
++            return s / -ds;
++        } else {
++            return Double.POSITIVE_INFINITY;
++        }
++    }
++
++    public boolean isOpaqueFullCube(net.minecraft.world.level.chunk.LevelChunk access, int x, int y, int z) {
++        if (y < this.level().getMinY() || y > this.level().getMaxY()) {
++            return false; // just say we can see the entity ATP
++        } else {
++            BlockState bs = access.getBlockStateFinal(x, y, z);
++            return bs.canOcclude() && bs.isSolidRender();
++        }
++    }
++    // Canvas end - entity culling
  
      // CraftBukkit start
      public boolean fauxSleeping;
+@@ -241,6 +_,8 @@
+         this.inventory = new Inventory(this, this.equipment);
+         this.inventoryMenu = new InventoryMenu(this.inventory, !level.isClientSide, this);
+         this.containerMenu = this.inventoryMenu;
++        this.cachedIsOpaqueFullCube = new it.unimi.dsi.fastutil.longs.Long2ByteOpenHashMap(); // Canvas - entity culling
++        this.cachedIsOpaqueFullCube.defaultReturnValue(UNSET); // Canvas - entity culling
+     }
+ 
+     @Override
 @@ -355,7 +_,7 @@
              this.setPos(d, this.getY(), d1);
          }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -239,6 +239,26 @@ public class Config {
         @Comment("Filters entity movement packets to reduce the amount of useless move packets sent")
         public boolean reduceUselessMovePackets = false;
 
+        @Comment({
+            "Canvas has an implementation of entity culling builtin that was made",
+            "to help cut networking bandwidth. However, this has a few pros and cons",
+            "",
+            "Generally, this should only be used if necessary. This implementation creates",
+            "a system where entity tracking contains a culling filter, so if entities cannot",
+            "be seen by a player(via a non-translucent block between the entity and player for",
+            "example), it gets removed from tracking. This also does break Vanilla compat",
+            "to a small degree, where entities may not render as far away, and the issue bellow",
+            "",
+            "This is very good for optimizing networking usage, however this causes issues with",
+            "players with higher ping. The higher the ping, the less smooth this will be.",
+            "Like if you had high ping, and looked around a corner(where an entity is), it may",
+            "take a second for it to show up again. This is just unavoidable with this impl.",
+            "",
+            "Note: players are ignored and will always be tracked no matter what, along with",
+            "some other exceptions, like entities that are glowing and such."
+        })
+        public boolean enableOptimizedEntityTracker = false;
+
         @Comment("When enabled, hides flames on entities with fire resistance")
         public boolean hideFlamesOnEntitiesWithFireResistance = false;
 


### PR DESCRIPTION
This implementation tracks and untracks entities out of sight of the Player entity via raytrace culling. This can greatly improve network bandwidth, and even client FPS.

This implementation creates a system where if entities cannot be seen by a player, specifically via a non-translucent block between teh entity and player for example, it gets removed from tracking of that player.

Note: the entity visibility is conducted via an 8-point raytrace calculation using the entity AABB, slightly inflated so that it covers edges of walls better, to make the effect more smooth.

The system *does* come with pre-filters so that Vanilla compat is kept. Those filters are: (for this example we will have "Target" be the entity that is being tested for culling, and "Origin" as the player we are testing to)
- If the origin is *not* a real player(decided by ServerPlayer#isRealPlayer), we cull them.
- If the origin is a spectator, we don't cull any entities, as trying to cull for spectator mode sounds like a personal nightmare and a half
- If the target is a Player, if their gamemode is spectator we will cull them. Do note, we have already ensured by this check we are not in spectator mode either, so they wouldn't be shown regardless.
- If the target is a player though and has passed the previous checks, they will not be culled.
- If the target is glowing, we do not cull them. The glowing effect can be seen through walls.
- If the target is an armor stand, and is invisible, it may be used as a "marker entity", so we don't cull them.
- If the target has a custom name(nametag) always visible(possibly via a plugin), we shouldn't cull them, as nametags can be displayed through walls.
- If the target is a display entity, we do not cull it.
- If the target is within 3 blocks, we don't cull them
- If the target is >=64 blocks out, we cull them
- If the target bounding box(inflated by 0.3) is greater than 20 on all 3 axis's, we will not cull them
- If the origin can see the full target AABB using the eye position as its look origin, we do not cull them. Otherwise, they are culled.

> [!NOTE]
> This should probably be tested further for performance regressions, visual appeal, actual effect networking-wise, etc. Generally just needs more testing before I feel comfortable with merging this to the master branch.