### PR TITLE
Fix ender pearls despawning when switching dimensions

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
@@ -18,3 +18,12 @@
      }
  
      @Override
+@@ -263,7 +_,7 @@
+             int sectionPosZ = SectionPos.blockToSectionCoord(this.position().z());
+             Entity entity = this.owner != null ? findOwnerIncludingDeadPlayer(serverLevel, this.owner.getUUID()) : null;
+             if (entity instanceof ServerPlayer serverPlayer
+-                && !entity.isAlive()
++                && entity.getBukkitEntity().taskScheduler.isRetired() // Canvas - Fix ender pearls despawning when switching dimensions
+                 && !serverPlayer.wonGame
+                 && serverPlayer.level().getGameRules().get(GameRules.ENDER_PEARLS_VANISH_ON_DEATH)) {
+                 this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
@@ -23,7 +23,7 @@
              Entity entity = this.owner != null ? findOwnerIncludingDeadPlayer(serverLevel, this.owner.getUUID()) : null;
              if (entity instanceof ServerPlayer serverPlayer
 -                && !entity.isAlive()
-+                && entity.getBukkitEntity().taskScheduler.isRetired() // Canvas - Fix ender pearls despawning when switching dimensions
++                && serverPlayer.deathTime > 0 // Canvas - Fix ender pearls despawning when switching dimensions
                  && !serverPlayer.wonGame
                  && serverPlayer.level().getGameRules().get(GameRules.ENDER_PEARLS_VANISH_ON_DEATH)) {
                  this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause


### PR DESCRIPTION
- Swapped to a better fix that does not remove pearl ticking.
- !entity.isAlive() caused it to despawn when swapping dimensions.
- entity.getBukkitEntity().taskScheduler.isRetired() breaks the gamerule and causes a pearl not disappearing on disconnecting from the server.
- serverPlayer.deathTime > 0 patches it by checking the time of death instead to patch the issue while maintaining parity.