### PR TITLE
Fix GLOBAL_BROADCAST to only send messages to operators

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -53,7 +53,9 @@ public class Config {
         LOGGER.info(text);
         if (isServerAccessible()) {
             for (final ServerPlayer player : MinecraftServer.getServer().getPlayerList().players) {
-                player.sendSystemMessage(PaperAdventure.asVanilla(merged));
+                if (player.getBukkitEntity().isOp()) {
+                    player.sendSystemMessage(PaperAdventure.asVanilla(merged));
+                }
             }
         }
     };


### PR DESCRIPTION
- Added operator check in GLOBAL_BROADCAST consumer
- Messages now only appear to ops instead of all players
- Console logging remains unchanged