### PR TITLE
Secure 1024-bit seed feature generation

### DIFF
--- a/canvas-server/minecraft-patches/base/0008-Leaf-Secure-seed-and-matter-seed-command.patch
+++ b/canvas-server/minecraft-patches/base/0008-Leaf-Secure-seed-and-matter-seed-command.patch
@@ -1,0 +1,419 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrHua269 <wangxyper@163.com>
+Date: Tue, 28 Jan 2025 18:56:53 +0800
+Subject: [PATCH] Leaf: Secure seed and matter seed command
+
+Ported to Canvas by: Chesvin1 <Chesvin1@hotmail.com>
+
+diff --git a/net/minecraft/server/commands/SeedCommand.java b/net/minecraft/server/commands/SeedCommand.java
+index 7c1e18d8362be5ae885c32b05e98b9ef45942d93..ae2a52193eb87467c31ed79b95e15d9b50f56076 100644
+--- a/net/minecraft/server/commands/SeedCommand.java
++++ b/net/minecraft/server/commands/SeedCommand.java
+@@ -12,6 +12,16 @@ public class SeedCommand {
+             long seed = commandContext.getSource().getLevel().getSeed();
+             Component component = ComponentUtils.copyOnClickText(String.valueOf(seed));
+             commandContext.getSource().sendSuccess(() -> Component.translatable("commands.seed.success", component), false);
++            // Leaf start - Matter - SecureSeed Command
++            if (io.canvasmc.canvas.Config.INSTANCE.secureSeed) {
++                su.plo.matter.Globals.setupGlobals(commandContext.getSource().getLevel());
++                String seedStr = su.plo.matter.Globals.seedToString(su.plo.matter.Globals.worldSeed);
++                Component featureSeedComponent = ComponentUtils.copyOnClickText(seedStr);
++
++                commandContext.getSource().sendSuccess(() -> Component.translatable(("Feature seed: %s"), featureSeedComponent), false);
++            }
++            // Leaf end - Matter - SecureSeed Command
++
+             return (int)seed;
+         }));
+     }
+diff --git a/net/minecraft/server/dedicated/DedicatedServerProperties.java b/net/minecraft/server/dedicated/DedicatedServerProperties.java
+index 4a01088da91fc6d620cb804a9ab6d6eb1630b473..2affc83e3e449776e7983919d7d6878ae6e9b3a9 100644
+--- a/net/minecraft/server/dedicated/DedicatedServerProperties.java
++++ b/net/minecraft/server/dedicated/DedicatedServerProperties.java
+@@ -115,7 +115,17 @@ public class DedicatedServerProperties extends Settings<DedicatedServerPropertie
+         String string = this.get("level-seed", "");
+         boolean flag = this.get("generate-structures", true);
+         long l = WorldOptions.parseSeed(string).orElse(WorldOptions.randomSeed());
+-        this.worldOptions = new WorldOptions(l, flag, false);
++        // Leaf start - Matter - Secure Seed
++        if (io.canvasmc.canvas.Config.INSTANCE.secureSeed) {
++            String featureSeedStr = this.get("feature-level-seed", "");
++            long[] featureSeed = su.plo.matter.Globals.parseSeed(featureSeedStr)
++                .orElse(su.plo.matter.Globals.createRandomWorldSeed());
++
++            this.worldOptions = new WorldOptions(l, featureSeed, flag, false);
++        } else {
++            this.worldOptions = new WorldOptions(l, flag, false);
++        }
++        // Leaf end - Matter - Secure Seed
+         this.worldDimensionData = new DedicatedServerProperties.WorldDimensionData(
+             this.get("generator-settings", property -> GsonHelper.parse(!property.isEmpty() ? property : "{}"), new JsonObject()),
+             this.get("level-type", property -> property.toLowerCase(Locale.ROOT), WorldPresets.NORMAL.location().toString())
+diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
+index 250d09fe3c49d1d0cbfde0fc06abd16fe329f9ed..05bad0366bd36b8134290a0cceb4d4dfcbbd0544 100644
+--- a/net/minecraft/server/level/ServerChunkCache.java
++++ b/net/minecraft/server/level/ServerChunkCache.java
+@@ -674,6 +674,7 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+     }
+ 
+     public ChunkGenerator getGenerator() {
++        su.plo.matter.Globals.setupGlobals(level); // Leaf - Matter - Secure Seed
+         return this.chunkMap.generator();
+     }
+ 
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index 00482efc8e736e73ad136105ad7b9dd2cafd581f..55f3497503e3317d765abb0bd4a9a620f63cd240 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -567,6 +567,7 @@ public class ServerLevel extends Level implements ServerEntityGetter, WorldGenLe
+             chunkGenerator = new org.bukkit.craftbukkit.generator.CustomChunkGenerator(this, chunkGenerator, gen);
+         }
+         // CraftBukkit end
++        su.plo.matter.Globals.setupGlobals(this); // Leaf - Matter - Secure Seed
+         boolean flag = server.forceSynchronousWrites();
+         DataFixer fixerUpper = server.getFixerUpper();
+         // Paper - rewrite chunk system
+diff --git a/net/minecraft/world/entity/monster/Slime.java b/net/minecraft/world/entity/monster/Slime.java
+index 7b9105cc38380d60892647e52608787dbde28f0d..4686846d3841e3b294c488f8ab8329e4e901c866 100644
+--- a/net/minecraft/world/entity/monster/Slime.java
++++ b/net/minecraft/world/entity/monster/Slime.java
+@@ -329,7 +329,12 @@ public class Slime extends Mob implements Enemy {
+             }
+ 
+             ChunkPos chunkPos = new ChunkPos(pos);
+-            boolean flag = level.getMinecraftWorld().paperConfig().entities.spawning.allChunksAreSlimeChunks || WorldgenRandom.seedSlimeChunk(chunkPos.x, chunkPos.z, ((WorldGenLevel) level).getSeed(), level.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0; // Paper
++            // Leaf start - Matter - Secure Seed
++            boolean isSlimeChunk = io.canvasmc.canvas.Config.INSTANCE.secureSeed
++                ? level.getChunk(chunkPos.x, chunkPos.z).isSlimeChunk()
++                : WorldgenRandom.seedSlimeChunk(chunkPos.x, chunkPos.z, ((WorldGenLevel) level).getSeed(), level.getMinecraftWorld().spigotConfig.slimeSeed).nextInt(10) == 0; // Spigot // Paper
++            boolean flag = level.getMinecraftWorld().paperConfig().entities.spawning.allChunksAreSlimeChunks || isSlimeChunk;
++            // Leaf end - Matter - Secure Seed
+                 // Paper start - Replace rules for Height in Slime Chunks
+                 final double maxHeightSlimeChunk = level.getMinecraftWorld().paperConfig().entities.spawning.slimeSpawnHeight.slimeChunk.maximum;
+                 if (random.nextInt(10) == 0 && flag && pos.getY() < maxHeightSlimeChunk) {
+diff --git a/net/minecraft/world/level/chunk/ChunkAccess.java b/net/minecraft/world/level/chunk/ChunkAccess.java
+index 182c14b660f8860bed627eed4e01fd4002153e9a..686c031ec73acc80683aaa39a78fe9221f0215a6 100644
+--- a/net/minecraft/world/level/chunk/ChunkAccess.java
++++ b/net/minecraft/world/level/chunk/ChunkAccess.java
+@@ -88,6 +88,10 @@ public abstract class ChunkAccess implements BiomeManager.NoiseBiomeSource, Ligh
+     public org.bukkit.craftbukkit.persistence.DirtyCraftPersistentDataContainer persistentDataContainer = new org.bukkit.craftbukkit.persistence.DirtyCraftPersistentDataContainer(ChunkAccess.DATA_TYPE_REGISTRY);
+     // CraftBukkit end
+     public final Registry<Biome> biomeRegistry; // CraftBukkit
++    // Leaf start - Matter - Secure Seed
++    private boolean slimeChunk;
++    private boolean hasComputedSlimeChunk;
++    // Leaf end - Matter - Secure Seed
+ 
+     // Paper start - rewrite chunk system
+     private volatile ca.spottedleaf.moonrise.patches.starlight.light.SWMRNibbleArray[] blockNibbles;
+@@ -192,6 +196,17 @@ public abstract class ChunkAccess implements BiomeManager.NoiseBiomeSource, Ligh
+         return GameEventListenerRegistry.NOOP;
+     }
+ 
++    // Leaf start - Matter - Secure Seed
++    public boolean isSlimeChunk() {
++        if (!hasComputedSlimeChunk) {
++            hasComputedSlimeChunk = true;
++            slimeChunk = su.plo.matter.WorldgenCryptoRandom.seedSlimeChunk(chunkPos.x, chunkPos.z).nextInt(10) == 0;
++        }
++
++        return slimeChunk;
++    }
++    // Leaf end - Matter - Secure Seed
++
+     public abstract BlockState getBlockState(final int x, final int y, final int z); // Paper
+ 
+     @Nullable
+diff --git a/net/minecraft/world/level/chunk/ChunkGenerator.java b/net/minecraft/world/level/chunk/ChunkGenerator.java
+index 92d13f9b886114553b471271391255ba08c8108f..5e517d36bb5f16bcd1cbab97d749b2c18cef9df8 100644
+--- a/net/minecraft/world/level/chunk/ChunkGenerator.java
++++ b/net/minecraft/world/level/chunk/ChunkGenerator.java
+@@ -342,7 +342,11 @@ public abstract class ChunkGenerator {
+             Registry<Structure> registry = level.registryAccess().lookupOrThrow(Registries.STRUCTURE);
+             Map<Integer, List<Structure>> map = registry.stream().collect(Collectors.groupingBy(structure1 -> structure1.step().ordinal()));
+             List<FeatureSorter.StepFeatureData> list = this.featuresPerStep.get();
+-            WorldgenRandom worldgenRandom = new WorldgenRandom(new XoroshiroRandomSource(RandomSupport.generateUniqueSeed()));
++            // Leaf start - Matter - Secure Seed
++            WorldgenRandom worldgenRandom = io.canvasmc.canvas.Config.INSTANCE.secureSeed
++                ? new su.plo.matter.WorldgenCryptoRandom(blockPos.getX(), blockPos.getZ(), su.plo.matter.Globals.Salt.UNDEFINED, 0)
++                : new WorldgenRandom(new XoroshiroRandomSource(RandomSupport.generateUniqueSeed()));
++            // Leaf end - Matter - Secure Seed
+             long l = worldgenRandom.setDecorationSeed(level.getSeed(), blockPos.getX(), blockPos.getZ());
+             Set<Holder<Biome>> set = new ObjectArraySet<>();
+             ChunkPos.rangeClosed(sectionPos.chunk(), 1).forEach(chunkPos -> {
+@@ -551,8 +555,15 @@ public abstract class ChunkGenerator {
+                         } else {
+                             ArrayList<StructureSet.StructureSelectionEntry> list1 = new ArrayList<>(list.size());
+                             list1.addAll(list);
+-                            WorldgenRandom worldgenRandom = new WorldgenRandom(new LegacyRandomSource(0L));
+-                            worldgenRandom.setLargeFeatureSeed(structureState.getLevelSeed(), pos.x, pos.z);
++                            // Leaf start - Matter - Secure Seed
++                            WorldgenRandom worldgenRandom;
++                            if (io.canvasmc.canvas.Config.INSTANCE.secureSeed) {
++                                worldgenRandom = new su.plo.matter.WorldgenCryptoRandom(pos.x, pos.z, su.plo.matter.Globals.Salt.GENERATE_FEATURE, 0);
++                            } else {
++                                worldgenRandom = new WorldgenRandom(new LegacyRandomSource(0L));
++                                worldgenRandom.setLargeFeatureSeed(structureState.getLevelSeed(), pos.x, pos.z);
++                            }
++                            // Leaf end - Matter - Secure Seed
+                             int i = 0;
+ 
+                             for (StructureSet.StructureSelectionEntry structureSelectionEntry1 : list1) {
+diff --git a/net/minecraft/world/level/chunk/ChunkGeneratorStructureState.java b/net/minecraft/world/level/chunk/ChunkGeneratorStructureState.java
+index 619b98e42e254c0c260c171a26a2472ddf59b885..22bcf554daa3686f955ac2a5809d8ebd1e1f38eb 100644
+--- a/net/minecraft/world/level/chunk/ChunkGeneratorStructureState.java
++++ b/net/minecraft/world/level/chunk/ChunkGeneratorStructureState.java
+@@ -205,7 +205,12 @@ public class ChunkGeneratorStructureState {
+             List<CompletableFuture<ChunkPos>> list = new ArrayList<>(count);
+             int spread = placement.spread();
+             HolderSet<Biome> holderSet = placement.preferredBiomes();
+-            RandomSource randomSource = RandomSource.create();
++            // Leaf start - Matter - Secure Seed
++            RandomSource randomSource = io.canvasmc.canvas.Config.INSTANCE.secureSeed
++                ? new su.plo.matter.WorldgenCryptoRandom(0, 0, su.plo.matter.Globals.Salt.STRONGHOLDS, 0)
++                : RandomSource.create();
++            // Leaf end - Matter - Secure Seed
++            if (!io.canvasmc.canvas.Config.INSTANCE.secureSeed) {
+             // Paper start - Add missing structure set seed configs
+             if (this.conf.strongholdSeed != null && structureSet.is(net.minecraft.world.level.levelgen.structure.BuiltinStructureSets.STRONGHOLDS)) {
+                 randomSource.setSeed(this.conf.strongholdSeed);
+@@ -213,6 +218,7 @@ public class ChunkGeneratorStructureState {
+             // Paper end - Add missing structure set seed configs
+             randomSource.setSeed(this.concentricRingsSeed);
+             } // Paper - Add missing structure set seed configs
++            } // Leaf - Matter - Secure Seed
+             double d = randomSource.nextDouble() * Math.PI * 2.0;
+             int i = 0;
+             int i1 = 0;
+diff --git a/net/minecraft/world/level/chunk/status/ChunkStep.java b/net/minecraft/world/level/chunk/status/ChunkStep.java
+index b8348976e80578d9eff64eea68c04c603fed49ad..bc5c6ea1f1e4f1608a70116f03fb2a58ca3252c3 100644
+--- a/net/minecraft/world/level/chunk/status/ChunkStep.java
++++ b/net/minecraft/world/level/chunk/status/ChunkStep.java
+@@ -60,6 +60,7 @@ public final class ChunkStep implements ca.spottedleaf.moonrise.patches.chunk_sy
+     }
+ 
+     public CompletableFuture<ChunkAccess> apply(WorldGenContext worldGenContext, StaticCache2D<GenerationChunkHolder> cache, ChunkAccess chunk) {
++        su.plo.matter.Globals.setupGlobals(worldGenContext.level()); // Leaf - Matter - Secure Seed
+         if (chunk.getPersistedStatus().isBefore(this.targetStatus)) {
+             ProfiledDuration profiledDuration = JvmProfiler.INSTANCE
+                 .onChunkGenerate(chunk.getPos(), worldGenContext.level().dimension(), this.targetStatus.getName());
+diff --git a/net/minecraft/world/level/levelgen/WorldOptions.java b/net/minecraft/world/level/levelgen/WorldOptions.java
+index c92508741439a8d0d833ea02d0104416adb83c92..cb5269b8e7b2df67d5e78f8313f6fbc14cd1e39e 100644
+--- a/net/minecraft/world/level/levelgen/WorldOptions.java
++++ b/net/minecraft/world/level/levelgen/WorldOptions.java
+@@ -9,8 +9,20 @@ import net.minecraft.util.RandomSource;
+ import org.apache.commons.lang3.StringUtils;
+ 
+ public class WorldOptions {
++    // Leaf start - Matter - Secure Seed
++    private static final com.google.gson.Gson gson = new com.google.gson.Gson();
++    private static final boolean isSecureSeedEnabled = io.canvasmc.canvas.Config.INSTANCE.secureSeed;
+     public static final MapCodec<WorldOptions> CODEC = RecordCodecBuilder.mapCodec(
+-        instance -> instance.group(
++        instance -> isSecureSeedEnabled
++            ? instance.group(
++                Codec.LONG.fieldOf("seed").stable().forGetter(WorldOptions::seed),
++                Codec.STRING.fieldOf("feature_seed").orElse(gson.toJson(su.plo.matter.Globals.createRandomWorldSeed())).stable().forGetter(WorldOptions::featureSeedSerialize),
++                Codec.BOOL.fieldOf("generate_features").orElse(true).stable().forGetter(WorldOptions::generateStructures),
++                Codec.BOOL.fieldOf("bonus_chest").orElse(false).stable().forGetter(WorldOptions::generateBonusChest),
++                Codec.STRING.lenientOptionalFieldOf("legacy_custom_options").stable().forGetter(worldOptions -> worldOptions.legacyCustomOptions)
++            )
++            .apply(instance, instance.stable(WorldOptions::new))
++            : instance.group(
+                 Codec.LONG.fieldOf("seed").stable().forGetter(WorldOptions::seed),
+                 Codec.BOOL.fieldOf("generate_features").orElse(true).stable().forGetter(WorldOptions::generateStructures),
+                 Codec.BOOL.fieldOf("bonus_chest").orElse(false).stable().forGetter(WorldOptions::generateBonusChest),
+@@ -18,8 +30,14 @@ public class WorldOptions {
+             )
+             .apply(instance, instance.stable(WorldOptions::new))
+     );
+-    public static final WorldOptions DEMO_OPTIONS = new WorldOptions("North Carolina".hashCode(), true, true);
++    // Leaf end - Matter - Secure Seed
++    // Leaf start - Matter - Secure Seed
++    public static final WorldOptions DEMO_OPTIONS = isSecureSeedEnabled
++            ? new WorldOptions((long) "North Carolina".hashCode(), su.plo.matter.Globals.createRandomWorldSeed(), true, true)
++            : new WorldOptions("North Carolina".hashCode(), true, true);
++    // Leaf end - Matter - Secure Seed
+     private final long seed;
++    private long[] featureSeed = su.plo.matter.Globals.createRandomWorldSeed(); // Leaf - Matter - Secure Seed
+     private final boolean generateStructures;
+     private final boolean generateBonusChest;
+     private final Optional<String> legacyCustomOptions;
+@@ -28,14 +46,35 @@ public class WorldOptions {
+         this(seed, generateStructures, generateBonusChest, Optional.empty());
+     }
+ 
++    // Leaf start - Matter - Secure Seed
++    public WorldOptions(long seed, long[] featureSeed, boolean generateStructures, boolean bonusChest) {
++        this(seed, featureSeed, generateStructures, bonusChest, Optional.empty());
++    }
++
++    private WorldOptions(long seed, String featureSeedJson, boolean generateStructures, boolean bonusChest, Optional<String> legacyCustomOptions) {
++        this(seed, gson.fromJson(featureSeedJson, long[].class), generateStructures, bonusChest, legacyCustomOptions);
++    }
++    // Leaf end - Matter - Secure Seed
++
+     public static WorldOptions defaultWithRandomSeed() {
+-        return new WorldOptions(randomSeed(), true, false);
++        // Leaf start - Matter - Secure Seed
++        return isSecureSeedEnabled
++                ? new WorldOptions(randomSeed(), su.plo.matter.Globals.createRandomWorldSeed(), true, false)
++                : new WorldOptions(randomSeed(), true, false);
++        // Leaf end - Matter - Secure Seed
+     }
+ 
+     public static WorldOptions testWorldWithRandomSeed() {
+         return new WorldOptions(randomSeed(), false, false);
+     }
+ 
++    // Leaf start - Matter - Secure Seed
++    private WorldOptions(long seed, long[] featureSeed, boolean generateStructures, boolean bonusChest, Optional<String> legacyCustomOptions) {
++        this(seed, generateStructures, bonusChest, legacyCustomOptions);
++        this.featureSeed = featureSeed;
++    }
++    // Leaf end - Matter - Secure Seed
++
+     private WorldOptions(long seed, boolean generateStructures, boolean generateBonusChest, Optional<String> legacyCustomOptions) {
+         this.seed = seed;
+         this.generateStructures = generateStructures;
+@@ -47,6 +86,16 @@ public class WorldOptions {
+         return this.seed;
+     }
+ 
++    // Leaf start - Matter - Secure Seed
++    public long[] featureSeed() {
++        return this.featureSeed;
++    }
++
++    private String featureSeedSerialize() {
++        return gson.toJson(this.featureSeed);
++    }
++    // Leaf end - Matter - Secure Seed
++
+     public boolean generateStructures() {
+         return this.generateStructures;
+     }
+@@ -59,17 +108,25 @@ public class WorldOptions {
+         return this.legacyCustomOptions.isPresent();
+     }
+ 
++    // Leaf start - Matter -  Secure Seed
+     public WorldOptions withBonusChest(boolean generateBonusChest) {
+-        return new WorldOptions(this.seed, this.generateStructures, generateBonusChest, this.legacyCustomOptions);
++        return isSecureSeedEnabled
++                ? new WorldOptions(this.seed, this.featureSeed, this.generateStructures, generateBonusChest, this.legacyCustomOptions)
++                : new WorldOptions(this.seed, this.generateStructures, generateBonusChest, this.legacyCustomOptions);
+     }
+ 
+     public WorldOptions withStructures(boolean generateStructures) {
+-        return new WorldOptions(this.seed, generateStructures, this.generateBonusChest, this.legacyCustomOptions);
++        return isSecureSeedEnabled
++                ? new WorldOptions(this.seed, this.featureSeed, generateStructures, this.generateBonusChest, this.legacyCustomOptions)
++                : new WorldOptions(this.seed, generateStructures, this.generateBonusChest, this.legacyCustomOptions);
+     }
+ 
+     public WorldOptions withSeed(OptionalLong seed) {
+-        return new WorldOptions(seed.orElse(randomSeed()), this.generateStructures, this.generateBonusChest, this.legacyCustomOptions);
++        return isSecureSeedEnabled
++                ? new WorldOptions(seed.orElse(randomSeed()), su.plo.matter.Globals.createRandomWorldSeed(), this.generateStructures, this.generateBonusChest, this.legacyCustomOptions)
++                : new WorldOptions(seed.orElse(randomSeed()), this.generateStructures, this.generateBonusChest, this.legacyCustomOptions);
+     }
++    // Leaf end - Matter - Secure Seed
+ 
+     public static OptionalLong parseSeed(String seed) {
+         seed = seed.trim();
+diff --git a/net/minecraft/world/level/levelgen/feature/GeodeFeature.java b/net/minecraft/world/level/levelgen/feature/GeodeFeature.java
+index 4e72eb49dbf4c70ae7556ba6eb210fcd5ef36aaa..c0919291c6f4923c42f662814bfa938b4206eeeb 100644
+--- a/net/minecraft/world/level/levelgen/feature/GeodeFeature.java
++++ b/net/minecraft/world/level/levelgen/feature/GeodeFeature.java
+@@ -41,7 +41,11 @@ public class GeodeFeature extends Feature<GeodeConfiguration> {
+         int i1 = geodeConfiguration.maxGenOffset;
+         List<Pair<BlockPos, Integer>> list = Lists.newLinkedList();
+         int i2 = geodeConfiguration.distributionPoints.sample(randomSource);
+-        WorldgenRandom worldgenRandom = new WorldgenRandom(new LegacyRandomSource(worldGenLevel.getSeed()));
++        // Leaf start - Matter - Secure Seed
++        WorldgenRandom worldgenRandom = io.canvasmc.canvas.Config.INSTANCE.secureSeed
++                ? new su.plo.matter.WorldgenCryptoRandom(0, 0, su.plo.matter.Globals.Salt.GEODE_FEATURE, 0)
++                : new WorldgenRandom(new LegacyRandomSource(worldGenLevel.getSeed()));
++        // Leaf end - Matter - Secure Seed
+         NormalNoise normalNoise = NormalNoise.create(worldgenRandom, -4, 1.0);
+         List<BlockPos> list1 = Lists.newLinkedList();
+         double d = (double)i2 / geodeConfiguration.outerWallDistance.getMaxValue();
+diff --git a/net/minecraft/world/level/levelgen/structure/Structure.java b/net/minecraft/world/level/levelgen/structure/Structure.java
+index 8328e864c72b7a358d6bb1f33459b8c4df2ecb1a..a89574d48fa4a3f91655952ba1cd7224fc3057ce 100644
+--- a/net/minecraft/world/level/levelgen/structure/Structure.java
++++ b/net/minecraft/world/level/levelgen/structure/Structure.java
+@@ -249,6 +249,11 @@ public abstract class Structure {
+         }
+ 
+         private static WorldgenRandom makeRandom(long seed, ChunkPos chunkPos) {
++            // Leaf start - Matter - Secure Seed
++            if (io.canvasmc.canvas.Config.INSTANCE.secureSeed) {
++                return new su.plo.matter.WorldgenCryptoRandom(chunkPos.x, chunkPos.z, su.plo.matter.Globals.Salt.GENERATE_FEATURE, seed);
++            }
++            // Leaf end - Matter - Secure Seed
+             WorldgenRandom worldgenRandom = new WorldgenRandom(new LegacyRandomSource(0L));
+             worldgenRandom.setLargeFeatureSeed(seed, chunkPos.x, chunkPos.z);
+             return worldgenRandom;
+diff --git a/net/minecraft/world/level/levelgen/structure/placement/RandomSpreadStructurePlacement.java b/net/minecraft/world/level/levelgen/structure/placement/RandomSpreadStructurePlacement.java
+index ee0d9dddb36b6879fa113299e24f1aa3b2b151cc..91b2fcb3e35369bbc99733acce5c7bf6d2140ae8 100644
+--- a/net/minecraft/world/level/levelgen/structure/placement/RandomSpreadStructurePlacement.java
++++ b/net/minecraft/world/level/levelgen/structure/placement/RandomSpreadStructurePlacement.java
+@@ -67,8 +67,15 @@ public class RandomSpreadStructurePlacement extends StructurePlacement {
+     public ChunkPos getPotentialStructureChunk(long seed, int regionX, int regionZ) {
+         int i = Math.floorDiv(regionX, this.spacing);
+         int i1 = Math.floorDiv(regionZ, this.spacing);
+-        WorldgenRandom worldgenRandom = new WorldgenRandom(new LegacyRandomSource(0L));
+-        worldgenRandom.setLargeFeatureWithSalt(seed, i, i1, this.salt());
++        // Leaf start - Matter - Secure Seed
++        WorldgenRandom worldgenRandom;
++        if (io.canvasmc.canvas.Config.INSTANCE.secureSeed) {
++            worldgenRandom = new su.plo.matter.WorldgenCryptoRandom(i, i1, su.plo.matter.Globals.Salt.POTENTIONAL_FEATURE, this.salt);
++        } else {
++            worldgenRandom = new WorldgenRandom(new LegacyRandomSource(0L));
++            worldgenRandom.setLargeFeatureWithSalt(seed, i, i1, this.salt());
++        }
++        // Leaf end - Matter - Secure Seed
+         int i2 = this.spacing - this.separation;
+         int i3 = this.spreadType.evaluate(worldgenRandom, i2);
+         int i4 = this.spreadType.evaluate(worldgenRandom, i2);
+diff --git a/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java b/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
+index f2eb0572b9d97d97bc847082461515a852310dfc..5bdc23cd8d9e9b8b3872553ccc35be3b16f81c07 100644
+--- a/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
++++ b/net/minecraft/world/level/levelgen/structure/placement/StructurePlacement.java
+@@ -119,8 +119,16 @@ public abstract class StructurePlacement {
+     public abstract StructurePlacementType<?> type();
+ 
+     private static boolean probabilityReducer(long levelSeed, int regionX, int regionZ, int salt, float probability, @org.jetbrains.annotations.Nullable Integer saltOverride) { // Paper - Add missing structure set seed configs; ignore here
+-        WorldgenRandom worldgenRandom = new WorldgenRandom(new LegacyRandomSource(0L));
+-        worldgenRandom.setLargeFeatureWithSalt(levelSeed, regionX, regionZ, salt);
++        // Leaf start - Matter - Secure Seed
++        WorldgenRandom worldgenRandom;
++        if (io.canvasmc.canvas.Config.INSTANCE.secureSeed) {
++            worldgenRandom = new su.plo.matter.WorldgenCryptoRandom(regionX, regionZ, su.plo.matter.Globals.Salt.UNDEFINED, salt);
++        } else {
++            worldgenRandom = new WorldgenRandom(new LegacyRandomSource(0L));
++            worldgenRandom.setLargeFeatureWithSalt(levelSeed, regionX, regionZ, salt);
++        }
++        // Leaf end - Matter - Secure Seed
++
+         return worldgenRandom.nextFloat() < probability;
+     }
+ 
+diff --git a/net/minecraft/world/level/levelgen/structure/pools/JigsawPlacement.java b/net/minecraft/world/level/levelgen/structure/pools/JigsawPlacement.java
+index 1cfa0fcd28685736fcdce4aef817e4d4cc4061cb..0054a26f7c6c94214730f2b46e20c3192e4a0e76 100644
+--- a/net/minecraft/world/level/levelgen/structure/pools/JigsawPlacement.java
++++ b/net/minecraft/world/level/levelgen/structure/pools/JigsawPlacement.java
+@@ -64,7 +64,11 @@ public class JigsawPlacement {
+         ChunkGenerator chunkGenerator = context.chunkGenerator();
+         StructureTemplateManager structureTemplateManager = context.structureTemplateManager();
+         LevelHeightAccessor levelHeightAccessor = context.heightAccessor();
+-        WorldgenRandom worldgenRandom = context.random();
++        // Leaf start - Matter - Secure Seed
++        WorldgenRandom worldgenRandom = io.canvasmc.canvas.Config.INSTANCE.secureSeed
++            ? new su.plo.matter.WorldgenCryptoRandom(context.chunkPos().x, context.chunkPos().z, su.plo.matter.Globals.Salt.JIGSAW_PLACEMENT, 0)
++            : context.random();
++        // Leaf end - Matter - Secure Seed
+         Registry<StructureTemplatePool> registry = registryAccess.lookupOrThrow(Registries.TEMPLATE_POOL);
+         Rotation random = Rotation.getRandom(worldgenRandom);
+         StructureTemplatePool structureTemplatePool = startPool.unwrapKey()

--- a/canvas-server/paper-patches/base/0006-Leaf-Secure-seed-and-matter-seed-command.patch
+++ b/canvas-server/paper-patches/base/0006-Leaf-Secure-seed-and-matter-seed-command.patch
@@ -1,0 +1,42 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: MrHua269 <wangxyper@163.com>
+Date: Tue, 11 Feb 2025 12:03:38 +0800
+Subject: [PATCH] Leaf Secure seed and matter seed command
+
+Ported to Canvas by: Chesvin1 <Chesvin1@hotmail.com>
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+index 631bec0adee5b01bfb931c25195b949eaf2efd27..2871e097d05e972fe8e3f8d9923e44e13efba639 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftChunk.java
+@@ -196,7 +196,12 @@ public class CraftChunk implements Chunk {
+     @Override
+     public boolean isSlimeChunk() {
+         // 987234911L is taken from Slime when seeing if a slime can spawn in a chunk
+-        return this.level.paperConfig().entities.spawning.allChunksAreSlimeChunks || WorldgenRandom.seedSlimeChunk(this.getX(), this.getZ(), this.getWorld().getSeed(), level.spigotConfig.slimeSeed).nextInt(10) == 0; // Paper
++        // Leaf start - Matter - Secure Seed
++        boolean isSlimeChunk = io.canvasmc.canvas.Config.INSTANCE.secureSeed
++            ? level.getChunk(this.getX(), this.getZ()).isSlimeChunk()
++            : WorldgenRandom.seedSlimeChunk(this.getX(), this.getZ(), this.getWorld().getSeed(), level.spigotConfig.slimeSeed).nextInt(10) == 0; // Paper
++        return this.level.paperConfig().entities.spawning.allChunksAreSlimeChunks || isSlimeChunk;
++        // Leaf end - Matter - Secure Seed
+     }
+ 
+     @Override
+diff --git a/src/main/java/org/bukkit/craftbukkit/CraftServer.java b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+index 17190446f7db57343b9cd05c84e3338307dc9c98..4dde33c872d463bf17ba03e926de90e6988444b2 100644
+--- a/src/main/java/org/bukkit/craftbukkit/CraftServer.java
++++ b/src/main/java/org/bukkit/craftbukkit/CraftServer.java
+@@ -1363,7 +1363,11 @@ public final class CraftServer implements Server {
+             registryAccess = levelDataAndDimensions.dimensions().dimensionsRegistryAccess();
+         } else {
+             LevelSettings levelSettings;
+-            WorldOptions worldOptions = new WorldOptions(creator.seed(), creator.generateStructures(), creator.bonusChest());
++            // Leaf start - Matter - Secure Seed
++            WorldOptions worldOptions = io.canvasmc.canvas.Config.INSTANCE.secureSeed
++                ? new WorldOptions(creator.seed(), su.plo.matter.Globals.createRandomWorldSeed(), creator.generateStructures(), false)
++                : new WorldOptions(creator.seed(), creator.generateStructures(), creator.bonusChest());
++            // Leaf end - Matter - Secure Seed
+             WorldDimensions worldDimensions;
+ 
+             DedicatedServerProperties.WorldDimensionData properties = new DedicatedServerProperties.WorldDimensionData(GsonHelper.parse((creator.generatorSettings().isEmpty()) ? "{}" : creator.generatorSettings()), creator.type().name().toLowerCase(Locale.ROOT));

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -147,6 +147,13 @@ public class Config {
 
     public Chunks chunks = new Chunks();
 
+    @Comment({
+        "When enabled, feature placement (ores/structures/etc.) uses a 1024-bit secure seed.",
+        "Terrain and biome generation still use the normal 64-bit world seed.",
+        "Requires restart."
+    })
+    public boolean secureSeed = false;
+
     public static class Chunks {
         @Comment("Use euclidean distance squared for chunk task ordering. Makes the world load in what appears a circle rather than a diamond")
         public boolean useEuclideanDistanceSquared = true;

--- a/canvas-server/src/main/java/su/plo/matter/Globals.java
+++ b/canvas-server/src/main/java/su/plo/matter/Globals.java
@@ -1,0 +1,92 @@
+package su.plo.matter;
+
+import com.google.common.collect.Iterables;
+import io.canvasmc.canvas.Config;
+import java.math.BigInteger;
+import java.security.SecureRandom;
+import java.util.Optional;
+import net.minecraft.server.level.ServerLevel;
+
+public class Globals {
+    public static final int WORLD_SEED_LONGS = 16;
+    public static final int WORLD_SEED_BITS = WORLD_SEED_LONGS * 64;
+
+    public static final long[] worldSeed = new long[WORLD_SEED_LONGS];
+    public static final ThreadLocal<Integer> dimension = ThreadLocal.withInitial(() -> 0);
+
+    public enum Salt {
+        UNDEFINED,
+        BASTION_FEATURE,
+        WOODLAND_MANSION_FEATURE,
+        MINESHAFT_FEATURE,
+        BURIED_TREASURE_FEATURE,
+        NETHER_FORTRESS_FEATURE,
+        PILLAGER_OUTPOST_FEATURE,
+        GEODE_FEATURE,
+        NETHER_FOSSIL_FEATURE,
+        OCEAN_MONUMENT_FEATURE,
+        RUINED_PORTAL_FEATURE,
+        POTENTIONAL_FEATURE,
+        GENERATE_FEATURE,
+        JIGSAW_PLACEMENT,
+        STRONGHOLDS,
+        POPULATION,
+        DECORATION,
+        SLIME_CHUNK
+    }
+
+    public static void setupGlobals(ServerLevel world) {
+        if (!Config.INSTANCE.secureSeed) return;
+
+        long[] seed = world.getServer().getWorldData().worldGenOptions().featureSeed();
+        System.arraycopy(seed, 0, worldSeed, 0, WORLD_SEED_LONGS);
+        int worldIndex = Iterables.indexOf(world.getServer().levelKeys(), it -> it == world.dimension());
+        if (worldIndex == -1) {
+            worldIndex = world.getServer().levelKeys().size();
+        }
+        dimension.set(worldIndex);
+    }
+
+    public static long[] createRandomWorldSeed() {
+        long[] seed = new long[WORLD_SEED_LONGS];
+        SecureRandom rand = new SecureRandom();
+        for (int i = 0; i < WORLD_SEED_LONGS; i++) {
+            seed[i] = rand.nextLong();
+        }
+        return seed;
+    }
+
+    // 1024-bit string, so 16 * 64 long[]
+    public static Optional<long[]> parseSeed(String seedStr) {
+        if (seedStr.isEmpty()) return Optional.empty();
+
+        if (seedStr.length() != WORLD_SEED_BITS) {
+            throw new IllegalArgumentException("Secure seed length must be " + WORLD_SEED_BITS + "-bit but found " + seedStr.length() + "-bit.");
+        }
+
+        long[] seed = new long[WORLD_SEED_LONGS];
+
+        for (int i = 0; i < WORLD_SEED_LONGS; i++) {
+            int start = i * 64;
+            int end = start + 64;
+            String seedSection = seedStr.substring(start, end);
+
+            BigInteger seedInDecimal = new BigInteger(seedSection, 2);
+            seed[i] = seedInDecimal.longValue();
+        }
+
+        return Optional.of(seed);
+    }
+
+    // 16 * 64 long[], so 1024-bit string
+    public static String seedToString(long[] seed) {
+        StringBuilder sb = new StringBuilder();
+
+        for (long longV : seed) {
+            String binaryStr = String.format("%64s", Long.toBinaryString(longV)).replace(' ', '0');
+            sb.append(binaryStr);
+        }
+
+        return sb.toString();
+    }
+}

--- a/canvas-server/src/main/java/su/plo/matter/Hashing.java
+++ b/canvas-server/src/main/java/su/plo/matter/Hashing.java
@@ -1,0 +1,73 @@
+package su.plo.matter;
+
+public class Hashing {
+    // https://en.wikipedia.org/wiki/BLAKE_(hash_function)
+    // https://github.com/bcgit/bc-java/blob/master/core/src/main/java/org/bouncycastle/crypto/digests/Blake2bDigest.java
+
+    private final static long[] blake2b_IV = {
+        0x6a09e667f3bcc908L, 0xbb67ae8584caa73bL, 0x3c6ef372fe94f82bL,
+        0xa54ff53a5f1d36f1L, 0x510e527fade682d1L, 0x9b05688c2b3e6c1fL,
+        0x1f83d9abfb41bd6bL, 0x5be0cd19137e2179L
+    };
+
+    private final static byte[][] blake2b_sigma = {
+        {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+        {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3},
+        {11, 8, 12, 0, 5, 2, 15, 13, 10, 14, 3, 6, 7, 1, 9, 4},
+        {7, 9, 3, 1, 13, 12, 11, 14, 2, 6, 5, 10, 4, 0, 15, 8},
+        {9, 0, 5, 7, 2, 4, 10, 15, 14, 1, 11, 12, 6, 8, 3, 13},
+        {2, 12, 6, 10, 0, 11, 8, 3, 4, 13, 7, 5, 15, 14, 1, 9},
+        {12, 5, 1, 15, 14, 13, 4, 10, 0, 7, 6, 3, 9, 2, 8, 11},
+        {13, 11, 7, 14, 12, 1, 3, 9, 5, 0, 15, 4, 8, 6, 2, 10},
+        {6, 15, 14, 9, 11, 3, 0, 8, 12, 2, 13, 7, 1, 4, 10, 5},
+        {10, 2, 8, 4, 7, 6, 1, 5, 15, 11, 9, 14, 3, 12, 13, 0},
+        {0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11, 12, 13, 14, 15},
+        {14, 10, 4, 8, 9, 15, 13, 6, 1, 12, 0, 2, 11, 7, 5, 3}
+    };
+
+    public static long[] hashWorldSeed(long[] worldSeed) {
+        long[] result = blake2b_IV.clone();
+        result[0] ^= 0x01010040;
+        hash(worldSeed, result, new long[16], 0, false);
+        return result;
+    }
+
+    public static void hash(long[] message, long[] chainValue, long[] internalState, long messageOffset, boolean isFinal) {
+        assert message.length == 16;
+        assert chainValue.length == 8;
+        assert internalState.length == 16;
+
+        System.arraycopy(chainValue, 0, internalState, 0, chainValue.length);
+        System.arraycopy(blake2b_IV, 0, internalState, chainValue.length, 4);
+        internalState[12] = messageOffset ^ blake2b_IV[4];
+        internalState[13] = blake2b_IV[5];
+        if (isFinal) internalState[14] = ~blake2b_IV[6];
+        internalState[15] = blake2b_IV[7];
+
+        for (int round = 0; round < 12; round++) {
+            G(message[blake2b_sigma[round][0]], message[blake2b_sigma[round][1]], 0, 4, 8, 12, internalState);
+            G(message[blake2b_sigma[round][2]], message[blake2b_sigma[round][3]], 1, 5, 9, 13, internalState);
+            G(message[blake2b_sigma[round][4]], message[blake2b_sigma[round][5]], 2, 6, 10, 14, internalState);
+            G(message[blake2b_sigma[round][6]], message[blake2b_sigma[round][7]], 3, 7, 11, 15, internalState);
+            G(message[blake2b_sigma[round][8]], message[blake2b_sigma[round][9]], 0, 5, 10, 15, internalState);
+            G(message[blake2b_sigma[round][10]], message[blake2b_sigma[round][11]], 1, 6, 11, 12, internalState);
+            G(message[blake2b_sigma[round][12]], message[blake2b_sigma[round][13]], 2, 7, 8, 13, internalState);
+            G(message[blake2b_sigma[round][14]], message[blake2b_sigma[round][15]], 3, 4, 9, 14, internalState);
+        }
+
+        for (int i = 0; i < 8; i++) {
+            chainValue[i] ^= internalState[i] ^ internalState[i + 8];
+        }
+    }
+
+    private static void G(long m1, long m2, int posA, int posB, int posC, int posD, long[] internalState) {
+        internalState[posA] = internalState[posA] + internalState[posB] + m1;
+        internalState[posD] = Long.rotateRight(internalState[posD] ^ internalState[posA], 32);
+        internalState[posC] = internalState[posC] + internalState[posD];
+        internalState[posB] = Long.rotateRight(internalState[posB] ^ internalState[posC], 24); // replaces 25 of BLAKE
+        internalState[posA] = internalState[posA] + internalState[posB] + m2;
+        internalState[posD] = Long.rotateRight(internalState[posD] ^ internalState[posA], 16);
+        internalState[posC] = internalState[posC] + internalState[posD];
+        internalState[posB] = Long.rotateRight(internalState[posB] ^ internalState[posC], 63); // replaces 11 of BLAKE
+    }
+}

--- a/canvas-server/src/main/java/su/plo/matter/WorldgenCryptoRandom.java
+++ b/canvas-server/src/main/java/su/plo/matter/WorldgenCryptoRandom.java
@@ -1,0 +1,157 @@
+package su.plo.matter;
+
+import java.util.Arrays;
+import net.minecraft.util.Mth;
+import net.minecraft.util.RandomSource;
+import net.minecraft.world.level.levelgen.LegacyRandomSource;
+import net.minecraft.world.level.levelgen.WorldgenRandom;
+import org.jetbrains.annotations.NotNull;
+
+public class WorldgenCryptoRandom extends WorldgenRandom {
+    private static final long[] HASHED_ZERO_SEED = Hashing.hashWorldSeed(new long[Globals.WORLD_SEED_LONGS]);
+    private static final ThreadLocal<long[]> LAST_SEEN_WORLD_SEED = ThreadLocal.withInitial(() -> new long[Globals.WORLD_SEED_LONGS]);
+    private static final ThreadLocal<long[]> HASHED_WORLD_SEED = ThreadLocal.withInitial(() -> HASHED_ZERO_SEED);
+
+    private final long[] worldSeed = new long[Globals.WORLD_SEED_LONGS];
+    private final long[] randomBits = new long[8];
+    private int randomBitIndex;
+    private static final int MAX_RANDOM_BIT_INDEX = 64 * 8;
+    private static final int LOG2_MAX_RANDOM_BIT_INDEX = 9;
+    private long counter;
+    private final long[] message = new long[16];
+    private final long[] cachedInternalState = new long[16];
+
+    public WorldgenCryptoRandom(int x, int z, Globals.Salt typeSalt, long salt) {
+        super(new LegacyRandomSource(0L));
+        if (typeSalt != null) {
+            this.setSecureSeed(x, z, typeSalt, salt);
+        }
+    }
+
+    public void setSecureSeed(int x, int z, Globals.Salt typeSalt, long salt) {
+        System.arraycopy(Globals.worldSeed, 0, this.worldSeed, 0, Globals.WORLD_SEED_LONGS);
+        message[0] = ((long) x << 32) | ((long) z & 0xffffffffL);
+        message[1] = ((long) Globals.dimension.get() << 32) | ((long) salt & 0xffffffffL);
+        message[2] = typeSalt.ordinal();
+        message[3] = counter = 0;
+        randomBitIndex = MAX_RANDOM_BIT_INDEX;
+    }
+
+    private long[] getHashedWorldSeed() {
+        if (!Arrays.equals(worldSeed, LAST_SEEN_WORLD_SEED.get())) {
+            HASHED_WORLD_SEED.set(Hashing.hashWorldSeed(worldSeed));
+            System.arraycopy(worldSeed, 0, LAST_SEEN_WORLD_SEED.get(), 0, Globals.WORLD_SEED_LONGS);
+        }
+        return HASHED_WORLD_SEED.get();
+    }
+
+    private void moreRandomBits() {
+        message[3] = counter++;
+        System.arraycopy(getHashedWorldSeed(), 0, randomBits, 0, 8);
+        Hashing.hash(message, randomBits, cachedInternalState, 64, true);
+    }
+
+    private long getBits(int count) {
+        if (randomBitIndex >= MAX_RANDOM_BIT_INDEX) {
+            moreRandomBits();
+            randomBitIndex -= MAX_RANDOM_BIT_INDEX;
+        }
+
+        int alignment = randomBitIndex & 63;
+        if ((randomBitIndex >>> 6) == ((randomBitIndex + count) >>> 6)) {
+            long result = (randomBits[randomBitIndex >>> 6] >>> alignment) & ((1L << count) - 1);
+            randomBitIndex += count;
+            return result;
+        } else {
+            long result = (randomBits[randomBitIndex >>> 6] >>> alignment) & ((1L << (64 - alignment)) - 1);
+            randomBitIndex += count;
+            if (randomBitIndex >= MAX_RANDOM_BIT_INDEX) {
+                moreRandomBits();
+                randomBitIndex -= MAX_RANDOM_BIT_INDEX;
+            }
+            alignment = randomBitIndex & 63;
+            result <<= alignment;
+            result |= (randomBits[randomBitIndex >>> 6] >>> (64 - alignment)) & ((1L << alignment) - 1);
+
+            return result;
+        }
+    }
+
+    @Override
+    public @NotNull RandomSource fork() {
+        WorldgenCryptoRandom fork = new WorldgenCryptoRandom(0, 0, null, 0);
+
+        System.arraycopy(Globals.worldSeed, 0, fork.worldSeed, 0, Globals.WORLD_SEED_LONGS);
+        fork.message[0] = this.message[0];
+        fork.message[1] = this.message[1];
+        fork.message[2] = this.message[2];
+        fork.message[3] = this.message[3];
+        fork.randomBitIndex = this.randomBitIndex;
+        fork.counter = this.counter;
+        fork.nextLong();
+
+        return fork;
+    }
+
+    @Override
+    public int next(int bits) {
+        return (int) getBits(bits);
+    }
+
+    @Override
+    public void consumeCount(int count) {
+        randomBitIndex += count;
+        if (randomBitIndex >= MAX_RANDOM_BIT_INDEX * 2) {
+            randomBitIndex -= MAX_RANDOM_BIT_INDEX;
+            counter += randomBitIndex >>> LOG2_MAX_RANDOM_BIT_INDEX;
+            randomBitIndex &= MAX_RANDOM_BIT_INDEX - 1;
+            randomBitIndex += MAX_RANDOM_BIT_INDEX;
+        }
+    }
+
+    @Override
+    public int nextInt(int bound) {
+        int bits = Mth.ceillog2(bound);
+        int result;
+        do {
+            result = (int) getBits(bits);
+        } while (result >= bound);
+
+        return result;
+    }
+
+    @Override
+    public long nextLong() {
+        return getBits(64);
+    }
+
+    @Override
+    public double nextDouble() {
+        return getBits(53) * 0x1.0p-53;
+    }
+
+    @Override
+    public long setDecorationSeed(long worldSeed, int blockX, int blockZ) {
+        setSecureSeed(blockX, blockZ, Globals.Salt.POPULATION, 0);
+        return ((long) blockX << 32) | ((long) blockZ & 0xffffffffL);
+    }
+
+    @Override
+    public void setFeatureSeed(long populationSeed, int index, int step) {
+        setSecureSeed((int) (populationSeed >> 32), (int) populationSeed, Globals.Salt.DECORATION, index + 10000L * step);
+    }
+
+    @Override
+    public void setLargeFeatureSeed(long worldSeed, int chunkX, int chunkZ) {
+        super.setLargeFeatureSeed(worldSeed, chunkX, chunkZ);
+    }
+
+    @Override
+    public void setLargeFeatureWithSalt(long worldSeed, int regionX, int regionZ, int salt) {
+        super.setLargeFeatureWithSalt(worldSeed, regionX, regionZ, salt);
+    }
+
+    public static RandomSource seedSlimeChunk(int chunkX, int chunkZ) {
+        return new WorldgenCryptoRandom(chunkX, chunkZ, Globals.Salt.SLIME_CHUNK, 0);
+    }
+}


### PR DESCRIPTION
This ports Luminol (Leaf)'s secure feature seed implementation. Added a setting to enable feature/structure RNG that uses 1024‑bit seed while terrain/biomes remain tied to the normal 64‑bit world seed. 
This is useful to prevent seed cracking.

- Added `"secureSeed": false` setting to the config.
- `/seed` shows 1024-bit feature seed when secure seed is enabled.

- Original patch implementation is by @MrHua269 in Luminol, feature is originally from Leaf.