### PR TITLE
Add cross-region projectile redirect option, add support for rebuildPatches on macOS

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -253,8 +253,7 @@
 +            return this.getLookAngle();
 +        }
 +        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
-+    }
-+    // Canvas end - region threading
++    } // Canvas end - region threading
 +
      public Vec3 getHeadLookAngle() {
          return this.calculateViewVector(this.getXRot(), this.getYHeadRot());

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -254,6 +254,7 @@
 +        }
 +        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
 +    }
++
 +    // Canvas end - region threading
      public Vec3 getHeadLookAngle() {
          return this.calculateViewVector(this.getXRot(), this.getYHeadRot());

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -254,7 +254,6 @@
 +        }
 +        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
 +    }
-+
 +    // Canvas end - region threading
      public Vec3 getHeadLookAngle() {
          return this.calculateViewVector(this.getXRot(), this.getYHeadRot());

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -253,8 +253,9 @@
 +            return this.getLookAngle();
 +        }
 +        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
-+    } // Canvas end - region threading
++    }
 +
++    // Canvas end - region threading
      public Vec3 getHeadLookAngle() {
          return this.calculateViewVector(this.getXRot(), this.getYHeadRot());
      }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1,5 +1,16 @@
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
+@@ -260,6 +_,10 @@
+     private Vec3 deltaMovement = Vec3.ZERO;
+     private float yRot;
+     private float xRot;
++    // Canvas start - region threading
++    private volatile float canvas$threadSafeYRot;
++    private volatile float canvas$threadSafeXRot;
++    // Canvas end - region threading
+     public float yRotO;
+     public float xRotO;
+     private AABB bb = INITIAL_AABB;
 @@ -285,9 +_,14 @@
      public int tickCount;
      private int remainingFireTicks;
@@ -232,6 +243,22 @@
                  if (this.level.paperConfig().collisions.onlyPlayersCollide && !(entity instanceof ServerPlayer || this instanceof ServerPlayer)) return; // Paper - Collision option for requiring a player participant
                  double d = entity.getX() - this.getX();
                  double d1 = entity.getZ() - this.getZ();
+@@ -3436,6 +_,15 @@
+         return this.calculateViewVector(this.getXRot(), this.getYRot());
+     }
+ 
++    // Canvas start - region threading
++    public Vec3 canvas$getLookAngleThreadSafe() {
++        if (ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this)) {
++            return this.getLookAngle();
++        }
++        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
++    }
++    // Canvas end - region threading
++
+     public Vec3 getHeadLookAngle() {
+         return this.calculateViewVector(this.getXRot(), this.getYHeadRot());
+     }
 @@ -3778,6 +_,7 @@
      }
  
@@ -630,3 +657,19 @@
      }
  
      public double getFluidJumpThreshold() {
+@@ -5913,6 +_,7 @@
+             Util.logAndPauseIfInIde("Invalid entity rotation: " + yRot + ", discarding.");
+         } else {
+             this.yRot = yRot;
++            this.canvas$threadSafeYRot = yRot; // Canvas - region threading
+         }
+     }
+ 
+@@ -5925,6 +_,7 @@
+             Util.logAndPauseIfInIde("Invalid entity rotation: " + xRot + ", discarding.");
+         } else {
+             this.xRot = Math.clamp(xRot % 360.0F, -90.0F, 90.0F);
++            this.canvas$threadSafeXRot = this.xRot; // Canvas - region threading
+         }
+     }
+ 

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
@@ -73,3 +73,13 @@
      }
  
      protected void checkLeftOwner() {
+@@ -365,7 +_,8 @@
+             EntityHitResult entityHitResult = (EntityHitResult)result;
+             Entity entity = entityHitResult.getEntity();
+             if (entity.getType().is(EntityTypeTags.REDIRECTABLE_PROJECTILE) && entity instanceof Projectile projectile) {
+-                projectile.deflect(ProjectileDeflection.AIM_DEFLECT, this.getOwner(), this.owner, true);
++                Entity owner = io.canvasmc.canvas.Config.INSTANCE.projectiles.crossRegionRedirectableProjectileDeflection ? this.getOwnerRaw() : this.getOwner(); // Canvas - configurable cross-region redirect deflection
++                projectile.deflect(ProjectileDeflection.AIM_DEFLECT, owner, this.owner, true);
+             }
+ 
+             this.onHitEntity(entityHitResult);

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
@@ -78,8 +78,10 @@
              Entity entity = entityHitResult.getEntity();
              if (entity.getType().is(EntityTypeTags.REDIRECTABLE_PROJECTILE) && entity instanceof Projectile projectile) {
 -                projectile.deflect(ProjectileDeflection.AIM_DEFLECT, this.getOwner(), this.owner, true);
-+                Entity owner = io.canvasmc.canvas.Config.INSTANCE.projectiles.crossRegionRedirectableProjectileDeflection ? this.getOwnerRaw() : this.getOwner(); // Canvas - configurable cross-region redirect deflection
++                // Canvas start - configurable cross-region redirect deflection
++                Entity owner = io.canvasmc.canvas.Config.INSTANCE.projectiles.crossRegionRedirectableProjectileDeflection ? this.getOwnerRaw() : this.getOwner();
 +                projectile.deflect(ProjectileDeflection.AIM_DEFLECT, owner, this.owner, true);
++                // Canvas end - configurable cross-region redirect deflection
              }
  
              this.onHitEntity(entityHitResult);

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/ProjectileDeflection.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/ProjectileDeflection.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/entity/projectile/ProjectileDeflection.java
++++ b/net/minecraft/world/entity/projectile/ProjectileDeflection.java
+@@ -17,7 +_,7 @@
+     };
+     ProjectileDeflection AIM_DEFLECT = (projectile, entity, random) -> {
+         if (entity != null) {
+-            Vec3 lookAngle = entity.getLookAngle();
++            Vec3 lookAngle = entity.canvas$getLookAngleThreadSafe(); // Canvas - region threading
+             projectile.setDeltaMovement(lookAngle);
+             projectile.needsSync = true;
+         }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -531,6 +531,15 @@ public class Config {
             "Only works with projectiles thrown by players."
         })
         public List<String> loadChunks = new ArrayList<>();
+
+        @Comment({
+            "Restores vanilla redirect behavior for arrow hits on redirectable projectiles",
+            "(like wind charges and fireballs) across region threads.",
+            "For machines using this mechanic, it is recommended to set",
+            "\"max-arrow-despawn-invulnerability: disabled\" in paper-world-defaults.yml",
+            "To prevent the arrows from despawning."
+        })
+        public boolean crossRegionRedirectableProjectileDeflection = false;
     }
 
     @Comment({

--- a/rebuildPatches
+++ b/rebuildPatches
@@ -1,16 +1,21 @@
 #!/bin/bash
 
-# If running on macOS with old Bash (3.x), re-exec using Homebrew Bash
+# If running with old Bash (3.x), try Homebrew Bash on macOS first.
 if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
-  if command -v /opt/homebrew/bin/bash >/dev/null 2>&1; then
-    exec /opt/homebrew/bin/bash "$0" "$@"
-  elif command -v /usr/local/bin/bash >/dev/null 2>&1; then
-    exec /usr/local/bin/bash "$0" "$@"
-  else
-    echo "Error: Bash 4+ required but not found."
-    echo "Install with: brew install bash"
-    exit 1
+  if [ "$(uname -s)" = "Darwin" ]; then
+    if command -v /opt/homebrew/bin/bash >/dev/null 2>&1; then
+      exec /opt/homebrew/bin/bash "$0" "$@"
+    elif command -v /usr/local/bin/bash >/dev/null 2>&1; then
+      exec /usr/local/bin/bash "$0" "$@"
+    else
+      echo "Error: Bash 4+ required but not found."
+      echo "Install with: brew install bash"
+      exit 1
+    fi
   fi
+
+  echo "Error: Bash 4+ required."
+  exit 1
 fi
 
 set -e

--- a/rebuildPatches
+++ b/rebuildPatches
@@ -1,5 +1,18 @@
 #!/bin/bash
 
+# If running on macOS with old Bash (3.x), re-exec using Homebrew Bash
+if [ -z "${BASH_VERSINFO:-}" ] || [ "${BASH_VERSINFO[0]}" -lt 4 ]; then
+  if command -v /opt/homebrew/bin/bash >/dev/null 2>&1; then
+    exec /opt/homebrew/bin/bash "$0" "$@"
+  elif command -v /usr/local/bin/bash >/dev/null 2>&1; then
+    exec /usr/local/bin/bash "$0" "$@"
+  else
+    echo "Error: Bash 4+ required but not found."
+    echo "Install with: brew install bash"
+    exit 1
+  fi
+fi
+
 set -e
 
 force_run=false


### PR DESCRIPTION
Adds a config option to restore vanilla-style arrow redirect behavior for redirectable projectiles across region threads. 
macOS ships with an old and crusty Bash 3.x that doesn’t support associative arrays (which the script uses).
The script now:
Detects Bash < 4
Re-execs using Homebrew Bash if available
Shows a clear error if Bash 4+ isn’t installed