### PR TITLE
Fix large cross-region single-tick movement by rerouting to async teleport

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -68,7 +68,7 @@
                  Vec3 vec32 = this.position();
                  Vec3 vec33 = vec32.add(vec3);
 +                // Canvas start - safely reroute very large cross-region movement
-+                if (vec3.lengthSqr() >= (32.0D * 32.0D)
++                if (vec3.lengthSqr() >= (30.0D * 30.0D)
 +                    && !this.isVehicle()
 +                    && !this.isPassenger()
 +                    && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, vec3, 0)

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -63,12 +63,34 @@
          }
  
          this.firstTick = false;
+@@ -1115,6 +_,21 @@
+         final Vec3 originalMovement = movement; // Paper - Expose pre-collision velocity
+         ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread("Cannot move an entity off-main"); // Folia - region threading
+         if (this.noPhysics) {
++            // Canvas start - safely reroute very large cross-region movement
++            Vec3 vec32 = this.position();
++            if (movement.lengthSqr() >= (30.0D * 30.0D)
++                && !this.isVehicle()
++                && !this.isPassenger()
++                && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, movement, 0)
++                && this.level() instanceof ServerLevel serverLevel
++                && this.teleportAsync(
++                serverLevel, vec32.add(movement), null, null, this.getDeltaMovement(),
++                org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN,
++                TELEPORT_FLAG_LOAD_CHUNK, null
++            )) {
++                return;
++            }
++            // Canvas end - safely reroute very large cross-region movement
+             this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
+             this.horizontalCollision = false;
+             this.verticalCollision = false;
 @@ -1163,6 +_,20 @@
  
                  Vec3 vec32 = this.position();
                  Vec3 vec33 = vec32.add(vec3);
 +                // Canvas start - safely reroute very large cross-region movement
-+                if (vec3.lengthSqr() >= (32.0D * 32.0D)
++                if (vec3.lengthSqr() >= (30.0D * 30.0D)
 +                    && !this.isVehicle()
 +                    && !this.isPassenger()
 +                    && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, vec3, 0)
@@ -275,8 +297,8 @@
 +        }
 +        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
 +    }
-+
 +    // Canvas end - region threading
++
      public Vec3 getHeadLookAngle() {
          return this.calculateViewVector(this.getXRot(), this.getYHeadRot());
      }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -68,7 +68,7 @@
                  Vec3 vec32 = this.position();
                  Vec3 vec33 = vec32.add(vec3);
 +                // Canvas start - safely reroute very large cross-region movement
-+                if (vec3.lengthSqr() >= (128.0D * 128.0D)
++                if (vec3.lengthSqr() >= (32.0D * 32.0D)
 +                    && !this.isVehicle()
 +                    && !this.isPassenger()
 +                    && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, vec3, 0)

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -63,49 +63,40 @@
          }
  
          this.firstTick = false;
-@@ -1115,6 +_,21 @@
+@@ -1115,6 +_,17 @@
          final Vec3 originalMovement = movement; // Paper - Expose pre-collision velocity
          ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread("Cannot move an entity off-main"); // Folia - region threading
          if (this.noPhysics) {
-+            // Canvas start - safely reroute very large cross-region movement
++            // Canvas start - safely abort tick when very large movement crosses region ownership
 +            Vec3 vec32 = this.position();
++            Vec3 vec33 = vec32.add(movement);
 +            if (movement.lengthSqr() >= (30.0D * 30.0D)
++                && !Double.isNaN(vec33.x) && !Double.isNaN(vec33.y) && !Double.isNaN(vec33.z)
 +                && !this.isVehicle()
 +                && !this.isPassenger()
-+                && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, movement, 0)
-+                && this.level() instanceof ServerLevel serverLevel
-+                && this.teleportAsync(
-+                serverLevel, vec32.add(movement), null, null, this.getDeltaMovement(),
-+                org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN,
-+                TELEPORT_FLAG_LOAD_CHUNK, null
-+            )) {
-+                return;
++                && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, movement, 0)) {
++                throw new io.canvasmc.canvas.entity.EntityMoveOutOfRegionException(this, type, movement);
 +            }
-+            // Canvas end - safely reroute very large cross-region movement
++            // Canvas end - safely abort tick when very large movement crosses region ownership
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
              this.horizontalCollision = false;
              this.verticalCollision = false;
-@@ -1163,6 +_,23 @@
+@@ -1163,6 +_,18 @@
  
                  Vec3 vec32 = this.position();
                  Vec3 vec33 = vec32.add(vec3);
-+                // Canvas start - safely reroute very large cross-region movement
++                // Canvas start - safely abort tick when very large movement crosses region ownership
 +                // This is after collide(movement) so we evaluate resolved displacement, not raw input.
 +                // Moonrise collision lookups treat out-of-region/unloaded chunks as blocking, so this point avoids
 +                // applying a large cross-region setPos while preserving normal collision resolution first.
 +                if (vec3.lengthSqr() >= (30.0D * 30.0D)
++                    && !Double.isNaN(vec33.x) && !Double.isNaN(vec33.y) && !Double.isNaN(vec33.z)
 +                    && !this.isVehicle()
 +                    && !this.isPassenger()
-+                    && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, vec3, 0)
-+                    && this.level() instanceof ServerLevel serverLevel
-+                    && this.teleportAsync(
-+                    serverLevel, vec33, null, null, this.getDeltaMovement(),
-+                    org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN,
-+                    TELEPORT_FLAG_LOAD_CHUNK, null
-+                )) {
-+                    return;
++                    && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, vec3, 0)) {
++                    throw new io.canvasmc.canvas.entity.EntityMoveOutOfRegionException(this, type, vec3);
 +                }
-+                // Canvas end - safely reroute very large cross-region movement
++                // Canvas end - safely abort tick when very large movement crosses region ownership
                  this.addMovementThisTick(new Entity.Movement(vec32, vec33, movement));
                  this.setPos(vec33);
              }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -286,22 +286,6 @@
                  if (this.level.paperConfig().collisions.onlyPlayersCollide && !(entity instanceof ServerPlayer || this instanceof ServerPlayer)) return; // Paper - Collision option for requiring a player participant
                  double d = entity.getX() - this.getX();
                  double d1 = entity.getZ() - this.getZ();
-@@ -3436,6 +_,15 @@
-         return this.calculateViewVector(this.getXRot(), this.getYRot());
-     }
- 
-+    // Canvas start - region threading
-+    public Vec3 canvas$getLookAngleThreadSafe() {
-+        if (ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this)) {
-+            return this.getLookAngle();
-+        }
-+        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
-+    }
-+    // Canvas end - region threading
-+
-     public Vec3 getHeadLookAngle() {
-         return this.calculateViewVector(this.getXRot(), this.getYHeadRot());
-     }
 @@ -3778,6 +_,7 @@
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -286,6 +286,22 @@
                  if (this.level.paperConfig().collisions.onlyPlayersCollide && !(entity instanceof ServerPlayer || this instanceof ServerPlayer)) return; // Paper - Collision option for requiring a player participant
                  double d = entity.getX() - this.getX();
                  double d1 = entity.getZ() - this.getZ();
+@@ -3436,6 +_,15 @@
+         return this.calculateViewVector(this.getXRot(), this.getYRot());
+     }
+ 
++    // Canvas start - region threading
++    public Vec3 canvas$getLookAngleThreadSafe() {
++        if (ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this)) {
++            return this.getLookAngle();
++        }
++        return this.calculateViewVector(this.canvas$threadSafeXRot, this.canvas$threadSafeYRot);
++    }
++
++    // Canvas end - region threading
+     public Vec3 getHeadLookAngle() {
+         return this.calculateViewVector(this.getXRot(), this.getYHeadRot());
+     }
 @@ -3778,6 +_,7 @@
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -63,6 +63,27 @@
          }
  
          this.firstTick = false;
+@@ -1163,6 +_,20 @@
+ 
+                 Vec3 vec32 = this.position();
+                 Vec3 vec33 = vec32.add(vec3);
++                // Canvas start - safely reroute very large cross-region movement
++                if (vec3.lengthSqr() >= (128.0D * 128.0D)
++                    && !this.isVehicle()
++                    && !this.isPassenger()
++                    && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.level(), vec32, vec3, 0)
++                    && this.level() instanceof ServerLevel serverLevel
++                    && this.teleportAsync(
++                    serverLevel, vec33, null, null, this.getDeltaMovement(),
++                    org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN,
++                    TELEPORT_FLAG_LOAD_CHUNK, null
++                )) {
++                    return;
++                }
++                // Canvas end - safely reroute very large cross-region movement
+                 this.addMovementThisTick(new Entity.Movement(vec32, vec33, movement));
+                 this.setPos(vec33);
+             }
 @@ -1689,6 +_,11 @@
          boolean flag1 = this.level instanceof ServerLevel serverLevel
              && serverLevel.getServer().debugSubscribers().hasAnySubscriberFor(DebugSubscriptions.ENTITY_BLOCK_INTERSECTIONS);

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -85,11 +85,14 @@
              this.setPos(this.getX() + movement.x, this.getY() + movement.y, this.getZ() + movement.z);
              this.horizontalCollision = false;
              this.verticalCollision = false;
-@@ -1163,6 +_,20 @@
+@@ -1163,6 +_,23 @@
  
                  Vec3 vec32 = this.position();
                  Vec3 vec33 = vec32.add(vec3);
 +                // Canvas start - safely reroute very large cross-region movement
++                // This is after collide(movement) so we evaluate resolved displacement, not raw input.
++                // Moonrise collision lookups treat out-of-region/unloaded chunks as blocking, so this point avoids
++                // applying a large cross-region setPos while preserving normal collision resolution first.
 +                if (vec3.lengthSqr() >= (30.0D * 30.0D)
 +                    && !this.isVehicle()
 +                    && !this.isPassenger()

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -68,6 +68,38 @@
  
          regionizedWorldData.seTtickingBlockEntities(false); // Folia - regionised ticking
          regionizedWorldData.currentPrimedTnt = 0; // Spigot // Folia - region threading
+@@ -1463,6 +_,31 @@
+     public <T extends Entity> void guardEntityTick(Consumer<T> action, T entity) {
+         try {
+             action.accept(entity);
++        } catch (io.canvasmc.canvas.entity.EntityMoveOutOfRegionException moveOutOfRegionException) {
++            // Canvas start - reroute cross-region movement after tick unwind
++            final net.minecraft.world.entity.Entity movingEntity = moveOutOfRegionException.entity();
++            if (movingEntity.isRemoved()) {
++                this.moonrise$midTickTasks(); // Paper - rewrite chunk system
++                return;
++            }
++
++            final net.minecraft.world.phys.Vec3 currentPosition = movingEntity.position();
++            final net.minecraft.world.phys.Vec3 destinationPosition = currentPosition.add(moveOutOfRegionException.movement());
++            movingEntity.getBukkitEntity().taskScheduler.schedule(
++                entityFresh -> entityFresh.teleportAsync(
++                    (net.minecraft.server.level.ServerLevel)entityFresh.level(),
++                    destinationPosition,
++                    entityFresh.getYRot(),
++                    entityFresh.getXRot(),
++                    entityFresh.getDeltaMovement(),
++                    org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.UNKNOWN,
++                    net.minecraft.world.entity.Entity.TELEPORT_FLAG_LOAD_CHUNK,
++                    null
++                ),
++                null,
++                1L
++            );
++            // Canvas end - reroute cross-region movement after tick unwind
+         } catch (Throwable var6) {
+             // Paper start - Prevent block entity and entity crashes
+             final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
 @@ -1855,6 +_,35 @@
      public List<Entity> getPushableEntities(Entity entity, AABB boundingBox) {
          return this.getEntities(entity, boundingBox, EntitySelector.pushableBy(entity));

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -68,18 +68,13 @@
  
          regionizedWorldData.seTtickingBlockEntities(false); // Folia - regionised ticking
          regionizedWorldData.currentPrimedTnt = 0; // Spigot // Folia - region threading
-@@ -1463,6 +_,31 @@
+@@ -1463,6 +_,26 @@
      public <T extends Entity> void guardEntityTick(Consumer<T> action, T entity) {
          try {
              action.accept(entity);
++        // Canvas start - reroute cross-region movement after tick unwind
 +        } catch (io.canvasmc.canvas.entity.EntityMoveOutOfRegionException moveOutOfRegionException) {
-+            // Canvas start - reroute cross-region movement after tick unwind
 +            final net.minecraft.world.entity.Entity movingEntity = moveOutOfRegionException.entity();
-+            if (movingEntity.isRemoved()) {
-+                this.moonrise$midTickTasks(); // Paper - rewrite chunk system
-+                return;
-+            }
-+
 +            final net.minecraft.world.phys.Vec3 currentPosition = movingEntity.position();
 +            final net.minecraft.world.phys.Vec3 destinationPosition = currentPosition.add(moveOutOfRegionException.movement());
 +            movingEntity.getBukkitEntity().taskScheduler.schedule(
@@ -96,7 +91,7 @@
 +                null,
 +                1L
 +            );
-+            // Canvas end - reroute cross-region movement after tick unwind
++        // Canvas end - reroute cross-region movement after tick unwind
          } catch (Throwable var6) {
              // Paper start - Prevent block entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EntityMoveOutOfRegionException.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EntityMoveOutOfRegionException.java
@@ -1,0 +1,34 @@
+package io.canvasmc.canvas.entity;
+
+public final class EntityMoveOutOfRegionException extends RuntimeException {
+    private final net.minecraft.world.entity.Entity entity;
+    private final net.minecraft.world.entity.MoverType moverType;
+    private final net.minecraft.world.phys.Vec3 movement;
+
+    public EntityMoveOutOfRegionException(
+        net.minecraft.world.entity.Entity entity,
+        net.minecraft.world.entity.MoverType moverType,
+        net.minecraft.world.phys.Vec3 movement
+    ) {
+        this.entity = entity;
+        this.moverType = moverType;
+        this.movement = movement;
+    }
+
+    public net.minecraft.world.entity.Entity entity() {
+        return this.entity;
+    }
+
+    public net.minecraft.world.entity.MoverType moverType() {
+        return this.moverType;
+    }
+
+    public net.minecraft.world.phys.Vec3 movement() {
+        return this.movement;
+    }
+
+    @Override
+    public Throwable fillInStackTrace() {
+        return this;
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EntityMoveOutOfRegionException.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EntityMoveOutOfRegionException.java
@@ -1,29 +1,33 @@
 package io.canvasmc.canvas.entity;
 
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.MoverType;
+import net.minecraft.world.phys.Vec3;
+
 public final class EntityMoveOutOfRegionException extends RuntimeException {
-    private final net.minecraft.world.entity.Entity entity;
-    private final net.minecraft.world.entity.MoverType moverType;
-    private final net.minecraft.world.phys.Vec3 movement;
+    private final Entity entity;
+    private final MoverType moverType;
+    private final Vec3 movement;
 
     public EntityMoveOutOfRegionException(
-        net.minecraft.world.entity.Entity entity,
-        net.minecraft.world.entity.MoverType moverType,
-        net.minecraft.world.phys.Vec3 movement
+        Entity entity,
+        MoverType moverType,
+        Vec3 movement
     ) {
         this.entity = entity;
         this.moverType = moverType;
         this.movement = movement;
     }
 
-    public net.minecraft.world.entity.Entity entity() {
+    public Entity entity() {
         return this.entity;
     }
 
-    public net.minecraft.world.entity.MoverType moverType() {
+    public MoverType moverType() {
         return this.moverType;
     }
 
-    public net.minecraft.world.phys.Vec3 movement() {
+    public Vec3 movement() {
         return this.movement;
     }
 


### PR DESCRIPTION
Prevent cross-region concurrent modification from extreme single-tick movement (for example, pearl guns launching entities across thousands of blocks).
In Entity#move, detect large movement (>= 30 blocks in one tick) that is not fully owned by the current tick region.
For eligible entities (non-vehicle, non-passenger), reroute movement to teleportAsync(..., TELEPORT_FLAG_LOAD_CHUNK) and return early on success.

This is important because a very large movement in a single tick can cross region boundaries and cause unsafe cross-region access. 

A similar fix has also been added to Luminol. 
https://github.com/LuminolMC/Luminol/commit/2616bd9df6270a232cd424f84dae9715a32088a8#diff-c4059dd53771ddb7a2352f44a3783e957ba495a0d4d910dc4b16639ea4787f83R1-R80
However it had several issues which have also been fixed:
- Could get entities stuck (preventMoving not always cleared).
- Teleport call could fail for passengers/vehicles.
- Checked only destination region, not full path.
- Triggered too broadly (not just huge jumps).
- Used unsafe ServerLevel cast.