### PR TITLE
Add setter for destination world in EntityPortalAsyncEvent

### DIFF
--- a/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityPortalAsyncEvent.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityPortalAsyncEvent.java
@@ -18,7 +18,7 @@ public class EntityPortalAsyncEvent extends EntityEvent implements Cancellable {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final World from;
-    private final World to;
+    private World to;
     private final PortalType type;
 
     private boolean cancelled;
@@ -51,6 +51,15 @@ public class EntityPortalAsyncEvent extends EntityEvent implements Cancellable {
      */
     public World getTo() {
         return this.to;
+    }
+
+    /**
+     * Sets the location that this entity will move to
+     *
+     * @param to the location that this entity will move to
+     */
+    public void setTo(World to) {
+        this.to = to;
     }
 
     /**


### PR DESCRIPTION
This pull request updates the `EntityPortalAsyncEvent` class to allow modification of the destination world for an entity portal event. The most important changes are:

**Event mutability improvements:**

* Changed the `to` field in `EntityPortalAsyncEvent` from `final` to mutable, allowing it to be updated after event creation.
* Added a new `setTo(World to)` method to allow setting the destination world for the portal event.