### PR TITLE
Rewrite Vanilla pearl save

### DIFF
--- a/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityPortalAsyncEvent.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityPortalAsyncEvent.java
@@ -18,7 +18,7 @@ public class EntityPortalAsyncEvent extends EntityEvent implements Cancellable {
     private static final HandlerList HANDLER_LIST = new HandlerList();
 
     private final World from;
-    private final World to;
+    private World to;
     private final PortalType type;
 
     private boolean cancelled;
@@ -51,6 +51,15 @@ public class EntityPortalAsyncEvent extends EntityEvent implements Cancellable {
      */
     public World getTo() {
         return this.to;
+    }
+
+    /**
+     * Sets the location that this entity will move to
+     *
+     * @param to the location that this entity will move to
+     */
+    public void setTo(World to) {
+        this.to = to;
     }
 
     /**

--- a/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityPostTeleportAsyncEvent.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityPostTeleportAsyncEvent.java
@@ -11,8 +11,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Called when an entity is finished being teleported from one location to another.
  * <br>
- * This may be as a result of natural causes (Enderman, Shulker), pathfinding
- * (Wolf), or commands (/teleport).
+ * This may be as a result of natural causes (Enderman, Shulker), pathfinding (Wolf), or commands (/teleport).
  * <br>
  * This <b>*can*</b> be a player!
  */

--- a/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityTeleportAsyncEvent.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/event/EntityTeleportAsyncEvent.java
@@ -12,8 +12,7 @@ import org.jspecify.annotations.Nullable;
 /**
  * Called when an entity is about to be teleported from one location to another.
  * <br>
- * This may be as a result of natural causes (Enderman, Shulker), pathfinding
- * (Wolf), or commands (/teleport).
+ * This may be as a result of natural causes (Enderman, Shulker), pathfinding (Wolf), or commands (/teleport).
  * <br>
  * This <b>*can*</b> be a player!
  */
@@ -59,7 +58,8 @@ public class EntityTeleportAsyncEvent extends EntityEvent implements Cancellable
     /**
      * Sets the location that this entity moved to
      *
-     * @param to New Location this entity moved to
+     * @param to
+     *     New Location this entity moved to
      */
     public void setTo(Location to) {
         this.to = to.clone();

--- a/canvas-api/src/main/java/io/canvasmc/canvas/event/PlayerSaveEvent.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/event/PlayerSaveEvent.java
@@ -18,8 +18,7 @@ public class PlayerSaveEvent extends PlayerEvent {
     }
 
     /**
-     * If true, the player is being disconnected from the server,
-     * otherwise we are just running autosave
+     * If true, the player is being disconnected from the server, otherwise we are just running autosave
      *
      * @return if this is due to disconnect or autosave
      */

--- a/canvas-api/src/main/java/io/canvasmc/canvas/event/PlayerViewEndCreditsEvent.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/event/PlayerViewEndCreditsEvent.java
@@ -1,0 +1,66 @@
+package io.canvasmc.canvas.event;
+
+import org.bukkit.entity.Player;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerEvent;
+import org.jetbrains.annotations.ApiStatus;
+
+/**
+ * Called when the player enters the exit portal, allows controlling if the end credits will show or not
+ */
+public class PlayerViewEndCreditsEvent extends PlayerEvent {
+    private static final HandlerList HANDLERS = new HandlerList();
+
+    private final boolean willShowCredits;
+    private Result result = Result.DEFAULT;
+
+    @ApiStatus.Internal
+    public PlayerViewEndCreditsEvent(final Player player, boolean willShowCredits) {
+        super(player);
+        this.willShowCredits = willShowCredits;
+    }
+
+    public static HandlerList getHandlerList() {
+        return HANDLERS;
+    }
+
+    /**
+     * Gets the modified result based on if the event forces the credits to display or not display, or let Vanilla
+     * handle it
+     *
+     * @return the modified result
+     */
+    public boolean willShowCredits() {
+        return result == Result.DEFAULT ? willShowCredits : result == Result.ALLOW;
+    }
+
+    /**
+     * Sets whether the end credits should display.
+     * <p>
+     * <ul>
+     *     <li>If {@link org.bukkit.event.Event.Result#DEFAULT}, it will display the credits to the player based on {@link PlayerViewEndCreditsEvent#willVanillaShowCredits()}, meaning Vanilla will handle the credits display</li>
+     *     <li>If {@link org.bukkit.event.Event.Result#ALLOW}, it will force display the credits to the player</li>
+     *     <li>If {@link org.bukkit.event.Event.Result#DENY}, the player will not display the credits</li>
+     * </ul>
+     *
+     * @param result
+     *     the event result
+     */
+    public void setResult(final Result result) {
+        this.result = result;
+    }
+
+    /**
+     * Gets whether Vanilla would display the end credits or not
+     *
+     * @return the Vanilla result
+     */
+    public boolean willVanillaShowCredits() {
+        return willShowCredits;
+    }
+
+    @Override
+    public HandlerList getHandlers() {
+        return HANDLERS;
+    }
+}

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
@@ -66,3 +66,11 @@
          // halt all chunk systems first so that any in-progress chunk generation stops
          LOGGER.info("Halting chunk systems...");
          for (final ServerLevel world : MinecraftServer.getServer().getAllLevels()) {
+@@ -188,6 +_,7 @@
+         LOGGER.info("Finished pending teleports");
+ 
+         LOGGER.info("Saving all worlds");
++        MinecraftServer.getServer().pearls.save(); // Canvas - region threading
+         for (final ServerLevel world : MinecraftServer.getServer().getAllLevels()) {
+             LOGGER.info("Saving world data for world '" + WorldUtil.getWorldName(world) + "'");
+ 

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
@@ -82,7 +82,7 @@
 +        }
 +
 +        // wait for pearl save, and wait for connection shutdown
-+        MinecraftServer.getServer().pearls.save().join();
++        MinecraftServer.getServer().pearls.save(null).join();
 +        MinecraftServer.getServer().getConnection().stop();
 +    }
 +    // Canvas end - region threading

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
@@ -70,7 +70,7 @@
          LOGGER.info("Finished pending teleports");
  
          LOGGER.info("Saving all worlds");
-+        MinecraftServer.getServer().pearls.save(); // Canvas - region threading
++        MinecraftServer.getServer().pearls.save().join(); // Canvas - region threading
          for (final ServerLevel world : MinecraftServer.getServer().getAllLevels()) {
              LOGGER.info("Saving world data for world '" + WorldUtil.getWorldName(world) + "'");
  

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionShutdownThread.java.patch
@@ -16,14 +16,74 @@
                  } catch (final Throwable thr) {
                      LOGGER.error("Failed to close player inventory for player: " + player, thr);
                  }
-@@ -148,9 +_,16 @@
+@@ -148,9 +_,76 @@
              this.shuttingDown = null;
          }
      }
 +    // Canvas start - region threading
++
 +    private static volatile boolean canvas$isShutdown = false;
++
 +    public static boolean canvas$isShutdown() {
 +        return canvas$isShutdown;
++    }
++
++    private void savePlayers() {
++        net.minecraft.server.players.PlayerList playerList = MinecraftServer.getServer().getPlayerList();
++        LOGGER.info("Removing players");
++        // waiting for 100ms is a stupid fix
++        List<java.util.concurrent.CompletableFuture<Void>> futures = new ArrayList<>();
++        // prepare futures
++        for (final ServerPlayer serverPlayer : playerList.players) {
++            final net.minecraft.network.Connection connection = serverPlayer.connection.connection;
++            if (connection.channel == null || !connection.channel.isOpen()) continue;
++            java.util.concurrent.CompletableFuture<Void> future = new java.util.concurrent.CompletableFuture<>();
++            connection.channel.closeFuture().addListener(f -> future.complete(null));
++            futures.add(future);
++        }
++
++        // save pearls
++        for (final ServerLevel world : MinecraftServer.getServer().getAllLevels()) {
++            final List<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>>
++                regions = new ArrayList<>();
++            world.regioniser.computeForAllRegionsUnsynchronised(regions::add);
++
++            for (int i = 0, len = regions.size(); i < len; ++i) {
++                io.papermc.paper.threadedregions.ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>
++                    region = regions.get(i);
++                ChunkPos center = null;
++                try {
++                    this.shuttingDown = region;
++                    center = region.getCenterChunk();
++                    final RegionizedWorldData worldData = region.regioniser.world.worldRegionData.get();
++                    for (final ServerPlayer localPlayer : worldData.getLocalPlayers()) {
++                        // if pearl duplication fix is enabled, remove the pearl
++                        localPlayer.savePearls(io.canvasmc.canvas.Config.INSTANCE.fixes.pearlDuplication);
++                    }
++                } catch (Throwable thrown) {
++                    LOGGER.error("Failed to save pearls for region around chunk " + center + " in world '" + region.regioniser.world.getWorld().getName() + "'", thrown);
++                } finally {
++                    this.shuttingDown = null;
++                }
++            }
++        }
++
++        // now, remove players and wait
++        playerList.removeAll(MinecraftServer.getServer().isRestarting);
++
++        // wait for player removal
++        if (!futures.isEmpty()) {
++            if (io.canvasmc.canvas.util.CFUtil.waitFor(java.util.concurrent.CompletableFuture.allOf(futures.toArray(new java.util.concurrent.CompletableFuture[0])),
++                java.util.concurrent.TimeUnit.SECONDS, 20)) {
++                LOGGER.info("Players removed");
++            } else {
++                LOGGER.warn("Players did not all get removed within 20 seconds, proceeding with shutdown anyways");
++            }
++        }
++
++        // wait for pearl save, and wait for connection shutdown
++        MinecraftServer.getServer().pearls.save().join();
++        MinecraftServer.getServer().getConnection().stop();
 +    }
 +    // Canvas end - region threading
  
@@ -33,44 +93,15 @@
          // await scheduler termination
          LOGGER.info("Awaiting scheduler termination for 60s...");
          if (TickRegions.getScheduler().halt(true, TimeUnit.SECONDS.toNanos(60L))) {
-@@ -161,6 +_,32 @@
+@@ -161,6 +_,11 @@
          }
  
          MinecraftServer.getServer().stopServer(); // stop part 1: most logic, kicking players, plugins, etc
 +        // Canvas start - improve player removal logic
 +        // this.playerList.removeAll(this.isRestarting); // Paper
 +        // try { Thread.sleep(100); } catch (InterruptedException ex) {}
-+        net.minecraft.server.players.PlayerList playerList = MinecraftServer.getServer().getPlayerList();
-+        LOGGER.info("Removing players");
-+        // waiting for 100ms is a stupid fix
-+        List<java.util.concurrent.CompletableFuture<Void>> futures = new ArrayList<>();
-+        for (final ServerPlayer serverPlayer : playerList.players) {
-+            final net.minecraft.network.Connection connection = serverPlayer.connection.connection;
-+            if (connection.channel == null || !connection.channel.isOpen()) continue;
-+            java.util.concurrent.CompletableFuture<Void> future = new java.util.concurrent.CompletableFuture<>();
-+            connection.channel.closeFuture().addListener(f -> future.complete(null));
-+            futures.add(future);
-+        }
-+        // now, remove players and wait
-+        playerList.removeAll(MinecraftServer.getServer().isRestarting);
-+        if (!futures.isEmpty()) {
-+            if (io.canvasmc.canvas.util.CFUtil.waitFor(java.util.concurrent.CompletableFuture.allOf(futures.toArray(new java.util.concurrent.CompletableFuture[0])),
-+                java.util.concurrent.TimeUnit.SECONDS, 20)) {
-+                LOGGER.info("Players removed");
-+            } else {
-+                LOGGER.warn("Players did not all get removed within 20 seconds, proceeding with shutdown anyways");
-+            }
-+        }
-+        MinecraftServer.getServer().getConnection().stop();
++        this.savePlayers();
 +        // Canvas end - improve player removal logic
          // halt all chunk systems first so that any in-progress chunk generation stops
          LOGGER.info("Halting chunk systems...");
          for (final ServerLevel world : MinecraftServer.getServer().getAllLevels()) {
-@@ -188,6 +_,7 @@
-         LOGGER.info("Finished pending teleports");
- 
-         LOGGER.info("Saving all worlds");
-+        MinecraftServer.getServer().pearls.save().join(); // Canvas - region threading
-         for (final ServerLevel world : MinecraftServer.getServer().getAllLevels()) {
-             LOGGER.info("Saving world data for world '" + WorldUtil.getWorldName(world) + "'");
- 

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
@@ -15,6 +15,14 @@
          // call init event _before_ scheduling anything
          new RegionizedServerInitEvent().callEvent();
  
+@@ -371,6 +_,7 @@
+ 
+         // player list
+         MinecraftServer.getServer().getPlayerList().tick();
++        MinecraftServer.getServer().pearls.autosave(); // Canvas - region threading - save pearls with maps
+     }
+ 
+     private void tickPlayerSample() {
 @@ -411,9 +_,14 @@
              }
  
@@ -76,11 +84,3 @@
          // needs
          // worldborder tick
          // advancing the weather cycle
-@@ -478,6 +_,7 @@
-         world.moonrise$getChunkTaskScheduler().chunkHolderManager.processTicketUpdates(); // required to eventually process ticket updates
- 
-         this.autoSaveMaps(world);
-+        MinecraftServer.getServer().pearls.autosave(); // Canvas - region threading - save pearls with maps
-     }
- 
-     private void updateRaids(final ServerLevel world) {

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
@@ -76,3 +76,11 @@
          // needs
          // worldborder tick
          // advancing the weather cycle
+@@ -478,6 +_,7 @@
+         world.moonrise$getChunkTaskScheduler().chunkHolderManager.processTicketUpdates(); // required to eventually process ticket updates
+ 
+         this.autoSaveMaps(world);
++        MinecraftServer.getServer().pearls.autosave(); // Canvas - region threading - save pearls with maps
+     }
+ 
+     private void updateRaids(final ServerLevel world) {

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedServer.java.patch
@@ -19,7 +19,7 @@
  
          // player list
          MinecraftServer.getServer().getPlayerList().tick();
-+        MinecraftServer.getServer().pearls.autosave(); // Canvas - region threading - save pearls with maps
++        MinecraftServer.getServer().pearls.autosave(); // Canvas - region threading
      }
  
      private void tickPlayerSample() {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
+@@ -288,6 +_,7 @@
+     public boolean isIteratingOverLevels = false; // Paper - Throw exception on world create while being ticked
+     private final Set<String> pluginsBlockingSleep = new java.util.HashSet<>(); // Paper - API to allow/disallow tick sleeping
+     public static final long SERVER_INIT = System.nanoTime(); // Paper - Lag compensation
++    public final io.canvasmc.canvas.entity.EnderPearls pearls = io.canvasmc.canvas.entity.EnderPearls.read(); // Canvas - region threading
+     // Paper start - improve tick loop
+     public final ca.spottedleaf.moonrise.common.time.TickData tickTimes1s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(1L));
+     public final ca.spottedleaf.moonrise.common.time.TickData tickTimes5s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(5L));
 @@ -365,7 +_,7 @@
      // Paper end - improve tick loop
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/commands/SaveAllCommand.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/commands/SaveAllCommand.java.patch
@@ -32,7 +32,7 @@
 +                );
 +            });
          }
-+        MinecraftServer.getServer().pearls.save(); // Canvas - region threading
++        MinecraftServer.getServer().pearls.save().thenAccept((v) -> source.sendSuccess(() -> Component.literal("Saved pearl data"), true)); // Canvas - region threading
 +        // if no regions loaded, run callback
 +        source.sendSuccess(() -> Component.literal("Saving " + count.get() + " regions"), true);
 +        if (count.get() == 0) callback.run();

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/commands/SaveAllCommand.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/commands/SaveAllCommand.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/commands/SaveAllCommand.java
 +++ b/net/minecraft/server/commands/SaveAllCommand.java
-@@ -21,14 +_,32 @@
+@@ -21,14 +_,33 @@
      }
  
      private static int saveAll(CommandSourceStack source, boolean flush) throws CommandSyntaxException {
@@ -32,6 +32,7 @@
 +                );
 +            });
          }
++        MinecraftServer.getServer().pearls.save(); // Canvas - region threading
 +        // if no regions loaded, run callback
 +        source.sendSuccess(() -> Component.literal("Saving " + count.get() + " regions"), true);
 +        if (count.get() == 0) callback.run();

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/commands/SaveAllCommand.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/commands/SaveAllCommand.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/server/commands/SaveAllCommand.java
 +++ b/net/minecraft/server/commands/SaveAllCommand.java
-@@ -21,14 +_,33 @@
+@@ -21,14 +_,41 @@
      }
  
      private static int saveAll(CommandSourceStack source, boolean flush) throws CommandSyntaxException {
@@ -32,7 +32,15 @@
 +                );
 +            });
          }
-+        MinecraftServer.getServer().pearls.save().thenAccept((v) -> source.sendSuccess(() -> Component.literal("Saved pearl data"), true)); // Canvas - region threading
++        // Canvas start - region threading
++        MinecraftServer.getServer().pearls.save((result) -> {
++            if (result) {
++                source.sendSuccess(() -> Component.literal("Saved pearl data"), true);
++            } else {
++                source.sendFailure(Component.literal("Failed to save pearl data, check console for details"));
++            }
++        });
++        // Canvas end - region threading
 +        // if no regions loaded, run callback
 +        source.sendSuccess(() -> Component.literal("Saving " + count.get() + " regions"), true);
 +        if (count.get() == 0) callback.run();

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -231,7 +231,7 @@
 +                // use all the events location for this, they may have changed the world
 +                ServerLevel respawnAt = ((org.bukkit.craftbukkit.CraftWorld) respawnEvent.getRespawnLocation().getWorld()).getHandle();
 +                respawnAt.canvas$loadOrRunAtChunksAsync(
-+                    new BlockPos(spawnLoc.getBlockX(), spawnLoc.getBlockY(), spawnLoc.getBlockZ()),
++                    new BlockPos(respawnEvent.getRespawnLocation().getBlockX(), respawnEvent.getRespawnLocation().getBlockY(), respawnEvent.getRespawnLocation().getBlockZ()),
 +                    16, ca.spottedleaf.concurrentutil.util.Priority.HIGHER, finalize
 +                );
 +            } else {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -85,11 +85,30 @@
          if (!this.enderPearls.isEmpty()) {
              ValueOutput.ValueOutputList valueOutputList = output.childrenList("ender_pearls");
  
-@@ -772,7 +_,7 @@
+@@ -770,9 +_,27 @@
+             }
+         }
      }
++    // Canvas start - region threading
++
++    public void savePearls() {
++        for (ThrownEnderpearl thrownEnderpearl : enderPearls) {
++            if (thrownEnderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) continue;
++
++            Runnable task = () -> {
++                MinecraftServer.getServer().pearls.addPearl(this.uuid, thrownEnderpearl);
++                thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT);
++            };
++
++            ((ServerLevel) thrownEnderpearl.level()).canvas$loadOrRunAtChunksAsync(
++                thrownEnderpearl.blockPosition, 16, ca.spottedleaf.concurrentutil.util.Priority.NORMAL, task
++            );
++        }
++    }
++    // Canvas end - region threading
  
      public void loadAndSpawnEnderPearls(ValueInput input) {
--        input.childrenListOrEmpty("ender_pearls").forEach(this::loadAndSpawnEnderPearl);
+         input.childrenListOrEmpty("ender_pearls").forEach(this::loadAndSpawnEnderPearl);
 +        MinecraftServer.getServer().pearls.spawnPearls(this); // Canvas - region threading
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -266,7 +_,7 @@
+     private @Nullable BlockPos raidOmenPosition;
+     private Vec3 lastKnownClientMovement = Vec3.ZERO;
+     private Input lastClientInput = Input.EMPTY;
+-    private final Set<ThrownEnderpearl> enderPearls = new HashSet<>();
++    private final Set<ThrownEnderpearl> enderPearls = java.util.concurrent.ConcurrentHashMap.newKeySet(); // Canvas - region threading
+     private long timeEntitySatOnShoulder;
+     private CompoundTag shoulderEntityLeft = new CompoundTag();
+     private CompoundTag shoulderEntityRight = new CompoundTag();
 @@ -428,6 +_,9 @@
      public boolean sentListPacket = false;
      public boolean suppressTrackerForLogin = false; // Paper - Fire PlayerJoinEvent when Player is actually ready
@@ -68,6 +77,23 @@
      }
  
      private void saveParentVehicle(ValueOutput output) {
+@@ -755,6 +_,7 @@
+     }
+ 
+     private void saveEnderPearls(ValueOutput output) {
++        if (true) return; // Canvas - region threading
+         if (!this.enderPearls.isEmpty()) {
+             ValueOutput.ValueOutputList valueOutputList = output.childrenList("ender_pearls");
+ 
+@@ -772,7 +_,7 @@
+     }
+ 
+     public void loadAndSpawnEnderPearls(ValueInput input) {
+-        input.childrenListOrEmpty("ender_pearls").forEach(this::loadAndSpawnEnderPearl);
++        MinecraftServer.getServer().pearls.spawnPearls(this); // Canvas - region threading
+     }
+ 
+     private void loadAndSpawnEnderPearl(ValueInput input) {
 @@ -1400,6 +_,7 @@
          if (killCredit != null) {
              this.awardStat(Stats.ENTITY_KILLED_BY.get(killCredit.getType()));
@@ -291,28 +317,20 @@
          this.ejectPassengers();
  
          // Paper start - Workaround vehicle not tracking the passenger disconnection dismount
-@@ -3402,13 +_,19 @@
-         return getInputVector(new Vec3(f, 0.0, f1), 1.0F, this.getYRot());
+@@ -3403,11 +_,11 @@
      }
  
-+    // Canvas start - region threading
      public void registerEnderPearl(ThrownEnderpearl enderPearl) {
 -        //this.enderPearls.add(enderPearl); // Folia - region threading - do not track ender pearls
-+        this.scheduleToOrRun(() -> {
-+            this.enderPearls.add(enderPearl);
-+        });
++        this.enderPearls.add(enderPearl);
      }
  
      public void deregisterEnderPearl(ThrownEnderpearl enderPearl) {
 -        //this.enderPearls.remove(enderPearl); // Folia - region threading - do not track ender pearls
-+        this.scheduleToOrRun(() -> {
-+            this.enderPearls.remove(enderPearl);
-+        });
++        this.enderPearls.remove(enderPearl);
      }
-+    // Canvas end - region threading
  
      public Set<ThrownEnderpearl> getEnderPearls() {
-         return this.enderPearls;
 @@ -3453,7 +_,7 @@
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -85,20 +85,25 @@
          if (!this.enderPearls.isEmpty()) {
              ValueOutput.ValueOutputList valueOutputList = output.childrenList("ender_pearls");
  
-@@ -770,9 +_,27 @@
+@@ -770,9 +_,32 @@
              }
          }
      }
 +    // Canvas start - region threading
 +
-+    public void savePearls() {
++    public void savePearls(boolean removePearl) {
 +        for (ThrownEnderpearl thrownEnderpearl : enderPearls) {
 +            if (thrownEnderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) continue;
 +
 +            Runnable task = () -> {
 +                MinecraftServer.getServer().pearls.addPearl(this.uuid, thrownEnderpearl);
-+                thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT);
++                if (removePearl) thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT);
 +            };
++
++            if (io.papermc.paper.threadedregions.RegionShutdownThread.isShutdownThread()) {
++                task.run();
++                continue;
++            }
 +
 +            ((ServerLevel) thrownEnderpearl.level()).canvas$loadOrRunAtChunksAsync(
 +                thrownEnderpearl.blockPosition, 16, ca.spottedleaf.concurrentutil.util.Priority.NORMAL, task
@@ -336,16 +341,18 @@
          this.ejectPassengers();
  
          // Paper start - Workaround vehicle not tracking the passenger disconnection dismount
-@@ -3403,11 +_,11 @@
+@@ -3403,11 +_,13 @@
      }
  
      public void registerEnderPearl(ThrownEnderpearl enderPearl) {
 -        //this.enderPearls.add(enderPearl); // Folia - region threading - do not track ender pearls
++        if (!io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) return; // Canvas - restore vanilla ender pearl behavior
 +        this.enderPearls.add(enderPearl);
      }
  
      public void deregisterEnderPearl(ThrownEnderpearl enderPearl) {
 -        //this.enderPearls.remove(enderPearl); // Folia - region threading - do not track ender pearls
++        if (!io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) return; // Canvas - restore vanilla ender pearl behavior
 +        this.enderPearls.remove(enderPearl);
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -85,7 +85,7 @@
          if (!this.enderPearls.isEmpty()) {
              ValueOutput.ValueOutputList valueOutputList = output.childrenList("ender_pearls");
  
-@@ -770,9 +_,32 @@
+@@ -770,9 +_,30 @@
              }
          }
      }
@@ -105,9 +105,7 @@
 +                continue;
 +            }
 +
-+            ((ServerLevel) thrownEnderpearl.level()).canvas$loadOrRunAtChunksAsync(
-+                thrownEnderpearl.blockPosition, 16, ca.spottedleaf.concurrentutil.util.Priority.NORMAL, task
-+            );
++            thrownEnderpearl.scheduleToOrRun(task);
 +        }
 +    }
 +    // Canvas end - region threading

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -126,6 +126,19 @@
              this.createWitherRose(killCredit);
          }
  
+@@ -1607,7 +_,11 @@
+             Optional<Vec3> optional = RespawnAnchorBlock.findStandUpPosition(EntityType.PLAYER, level, blockPos);
+             Runnable consumeAnchorCharge = null; // Paper - Fix SPIGOT-5989 (don't use charge until after respawn event)
+             if (!flag && useCharge && optional.isPresent()) {
+-                consumeAnchorCharge = () -> level.setBlock(blockPos, blockState.setValue(RespawnAnchorBlock.CHARGE, blockState.getValue(RespawnAnchorBlock.CHARGE) - 1), Block.UPDATE_ALL); // Paper - Fix SPIGOT-5989 (don't use charge until after respawn event)
++                // Canvas start - region threading
++                consumeAnchorCharge = () -> level.canvas$loadOrRunAtChunksAsync(blockPos, 1, ca.spottedleaf.concurrentutil.util.Priority.NORMAL, () -> {
++                    level.setBlock(blockPos, blockState.setValue(net.minecraft.world.level.block.RespawnAnchorBlock.CHARGE, blockState.getValue(net.minecraft.world.level.block.RespawnAnchorBlock.CHARGE) - 1), net.minecraft.world.level.block.Block.UPDATE_ALL); // Paper - Fix SPIGOT-5989 (don't use charge until after respawn event)
++                });
++                // Canvas end - region threading
+             }
+             final Runnable finalConsumeAnchorCharge = consumeAnchorCharge; // Paper - Fix SPIGOT-5989
+ 
 @@ -1643,16 +_,27 @@
       * internally for {@link #respawn(java.util.function.Consumer, org.bukkit.event.player.PlayerRespawnEvent.RespawnReason)}
       */

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -229,7 +229,7 @@
      }
  
      @Override
-@@ -1925,12 +_,17 @@
+@@ -1925,12 +_,22 @@
                  return false;
              }
              this.wonGame = true;
@@ -241,6 +241,11 @@
 +            // the end credits, or else we get the player stuck in the
 +            // void, and they can't escape...
 +            this.canvas$isDisplayingEndCredits = !this.seenCredits && !this.level().paperConfig().misc.disableEndCredits; // ensure we respect paper config
++            io.canvasmc.canvas.event.PlayerViewEndCreditsEvent viewEndCreditsEvent = new io.canvasmc.canvas.event.PlayerViewEndCreditsEvent(
++                getBukkitEntity(), this.canvas$isDisplayingEndCredits
++            );
++            viewEndCreditsEvent.callEvent();
++            this.canvas$isDisplayingEndCredits = viewEndCreditsEvent.willShowCredits();
 +            this.exitEndCredits(); // note: this calls 'unRide()'
 +            if (this.canvas$isDisplayingEndCredits) {
                  this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.WIN_GAME, 0.0F));

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -33,23 +33,21 @@
      }
  
      public net.kyori.adventure.text.@Nullable Component remove(ServerPlayer player) { // CraftBukkit - return string // Paper - return Component
-@@ -556,7 +_,14 @@
-         for (ThrownEnderpearl thrownEnderpearl : player.getEnderPearls()) {
-             // Paper start - Allow using old ender pearl behavior
-             if (!thrownEnderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) {
+@@ -553,19 +_,14 @@
+ 
+         player.unRide();
+ 
+-        for (ThrownEnderpearl thrownEnderpearl : player.getEnderPearls()) {
+-            // Paper start - Allow using old ender pearl behavior
+-            if (!thrownEnderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) {
 -                thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
-+                // Canvas start - region threading
-+                ((ServerLevel) thrownEnderpearl.level()).canvas$loadOrRunAtChunksAsync(
-+                    thrownEnderpearl.blockPosition, 16, ca.spottedleaf.concurrentutil.util.Priority.NORMAL, () -> {
-+                        MinecraftServer.getServer().pearls.addPearl(player.getUUID(), thrownEnderpearl);
-+                        thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT);
-+                    }
-+                );
-+                // Canvas end - region threading
-             }
-             // Paper end - Allow using old ender pearl behavior
-         }
-@@ -566,6 +_,7 @@
+-            }
+-            // Paper end - Allow using old ender pearl behavior
+-        }
++        player.savePearls(); // Canvas - region threading
+ 
+         serverLevel.removePlayerImmediately(player, Entity.RemovalReason.UNLOADED_WITH_PLAYER);
+         player.retireScheduler(); // Paper - Folia schedulers
          player.getBukkitEntity().packetProcessor.close(); // Folia - region threading
          player.getAdvancements().stopListening();
          this.players.remove(player);

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -44,7 +44,7 @@
 -            }
 -            // Paper end - Allow using old ender pearl behavior
 -        }
-+        player.savePearls(); // Canvas - region threading
++        player.savePearls(true); // Canvas - region threading
  
          serverLevel.removePlayerImmediately(player, Entity.RemovalReason.UNLOADED_WITH_PLAYER);
          player.retireScheduler(); // Paper - Folia schedulers

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -33,15 +33,16 @@
      }
  
      public net.kyori.adventure.text.@Nullable Component remove(ServerPlayer player) { // CraftBukkit - return string // Paper - return Component
-@@ -556,7 +_,13 @@
+@@ -556,7 +_,14 @@
          for (ThrownEnderpearl thrownEnderpearl : player.getEnderPearls()) {
              // Paper start - Allow using old ender pearl behavior
              if (!thrownEnderpearl.level().paperConfig().misc.legacyEnderPearlBehavior) {
 -                thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
 +                // Canvas start - region threading
-+                io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
-+                    thrownEnderpearl.level().getMinecraftWorld(), thrownEnderpearl.chunkPosition().x, thrownEnderpearl.chunkPosition().z, () -> {
-+                        thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT); // CraftBukkit - add Bukkit remove cause
++                ((ServerLevel) thrownEnderpearl.level()).canvas$loadOrRunAtChunksAsync(
++                    thrownEnderpearl.blockPosition, 16, ca.spottedleaf.concurrentutil.util.Priority.NORMAL, () -> {
++                        MinecraftServer.getServer().pearls.addPearl(player.getUUID(), thrownEnderpearl);
++                        thrownEnderpearl.setRemoved(Entity.RemovalReason.UNLOADED_WITH_PLAYER, org.bukkit.event.entity.EntityRemoveEvent.Cause.PLAYER_QUIT);
 +                    }
 +                );
 +                // Canvas end - region threading

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java.patch
@@ -1,11 +1,10 @@
 --- a/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
 +++ b/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
-@@ -52,11 +_,17 @@
+@@ -52,11 +_,15 @@
      }
  
      private void deregisterFromCurrentOwner() {
 -        // Folia - region threading - we remove the registration logic, we do not need to fetch the owner
-+        if (!io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) return; // Canvas - restore vanilla ender pearl behavior
 +        if (this.getOwner() instanceof ServerPlayer serverPlayer) {
 +            serverPlayer.deregisterEnderPearl(this);
 +        }
@@ -13,7 +12,6 @@
  
      private void registerToCurrentOwner() {
 -        // Folia - region threading - we remove the registration logic, we do not need to fetch the owner
-+        if (!io.canvasmc.canvas.Config.INSTANCE.restoreVanillaEnderPearlBehavior) return; // Canvas - restore vanilla ender pearl behavior
 +        if (this.getOwner() instanceof ServerPlayer serverPlayer) {
 +            serverPlayer.registerEnderPearl(this);
 +        }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -447,6 +447,17 @@ public class Config {
             "Steep surface rule condition only works on the north and east faces of slopes"
         })
         public boolean mc258859 = false;
+
+        @Comment({
+            "In Vanilla, pearls can be duplicated during shutdown because pearls are saved to its owning player data",
+            "and in the chunk data. Meaning, when the chunk is loaded, it loads that pearl, and when the player is loaded",
+            "it loads the pearl in the player data.",
+            "",
+            "This fixes that, so that when 'restoreVanillaEnderPearlBehavior' is enabled, it unloads the pearl during shutdown",
+            "so that the duplication doesn't occur. With that configuration disabled, it just loads the pearl from the",
+            "chunk like normal."
+        })
+        public boolean pearlDuplication = false;
     }
 
     @Comment({
@@ -716,6 +727,6 @@ public class Config {
     @Comment("The server mod name displayed in server listings and client info")
     public String serverModName = io.papermc.paper.ServerBuildInfo.buildInfo().brandName();
 
-    @Comment("Restores vanilla ender pearl behavior to match Paper, which is disabled in Folia.")
+    @Comment("Restores Vanilla ender pearl behavior to match Paper, which is disabled in Folia.")
     public boolean restoreVanillaEnderPearlBehavior = false;
 }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -2,6 +2,7 @@ package io.canvasmc.canvas.entity;
 
 import ca.spottedleaf.concurrentutil.util.Priority;
 import com.mojang.serialization.Codec;
+import com.mojang.serialization.DataResult;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
 import io.canvasmc.canvas.Config;
 import io.canvasmc.canvas.util.Codecs;
@@ -19,6 +20,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Function;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
@@ -41,10 +43,8 @@ import org.jspecify.annotations.NonNull;
 public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
     private static final AtomicLong LAST_AUTOSAVE = new AtomicLong(System.nanoTime());
     public static final Path SAVE_PATH = Paths.get("pearls.dat");
-    public static final Codec<Pearl> PEARL_CODEC = RecordCodecBuilder.create(
-        instance -> instance.group(
-            CompoundTag.CODEC.fieldOf("Serialized").forGetter(Pearl::serialized)
-        ).apply(instance, Pearl::new)
+    public static final Codec<Pearl> PEARL_CODEC = CompoundTag.CODEC.comapFlatMap(
+        (Function<CompoundTag, DataResult<Pearl>>) compoundTag -> DataResult.success(new Pearl(compoundTag)), pearl -> pearl.serialized
     );
     public static final Codec<EnderPearls> CODEC = RecordCodecBuilder.create(
         instance -> instance.group(

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -21,6 +21,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Function;
+import it.unimi.dsi.fastutil.booleans.BooleanConsumer;
 import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
@@ -40,6 +41,7 @@ import net.minecraft.world.level.Level;
 import net.minecraft.world.level.storage.TagValueOutput;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 
 public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
     private static final AtomicLong LAST_AUTOSAVE = new AtomicLong(System.nanoTime());
@@ -72,19 +74,24 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
         return new EnderPearls(new ConcurrentHashMap<>());
     }
 
-    public @NonNull CompletableFuture<Void> save() {
-        CompletableFuture<Void> future = new CompletableFuture<>();
+    public @NonNull CompletableFuture<Boolean> save(@Nullable BooleanConsumer callback) {
+        CompletableFuture<Boolean> future = new CompletableFuture<>();
         Util.ioPool().execute(() -> {
             try {
                 Tag tag = CODEC.encodeStart(NbtOps.INSTANCE, this).getOrThrow();
                 NbtIo.writeCompressed((CompoundTag) tag, SAVE_PATH);
-                future.complete(null);
+                future.complete(true);
             } catch (Throwable thrown) {
-                future.complete(null);
-                throw new RuntimeException("Couldn't save pearls", thrown);
+                future.completeExceptionally(thrown);
             }
         });
-        return future;
+        return future.handle((result, thrown) -> {
+            if (result == null || !result) {
+                Config.LOGGER.warn("Could not save to pearls.dat", thrown);
+            }
+            if (callback != null) callback.accept(thrown == null);
+            return result;
+        });
     }
 
     public void spawnPearls(final @NonNull ServerPlayer player) {
@@ -115,7 +122,7 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
         final long currTime = System.nanoTime();
         final long last = LAST_AUTOSAVE.get();
         if ((currTime - last) > periodNanos && LAST_AUTOSAVE.compareAndSet(last, currTime)) {
-            save();
+            save(null);
         }
     }
 

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -90,7 +90,11 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
         });
     }
 
-    public void addPearl(final UUID uuid, final ThrownEnderpearl thrownEnderpearl) {
+    public void addPearl(final UUID uuid, final @NonNull ThrownEnderpearl thrownEnderpearl) {
+        if (thrownEnderpearl.isRemoved()) {
+            Config.LOGGER.warn("Trying to add removed ender pearl, skipping");
+            return;
+        }
         List<Pearl> pearls = pearls().computeIfAbsent(uuid, (ignored) -> new CopyOnWriteArrayList<>());
         Pearl encoded = Pearl.of(thrownEnderpearl);
         pearls.remove(encoded); // remove if it's already in the list, we don't want duplicates

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -25,6 +25,7 @@ import net.minecraft.nbt.CompoundTag;
 import net.minecraft.nbt.NbtAccounter;
 import net.minecraft.nbt.NbtIo;
 import net.minecraft.nbt.NbtOps;
+import net.minecraft.nbt.Tag;
 import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
@@ -73,14 +74,16 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
 
     public @NonNull CompletableFuture<Void> save() {
         CompletableFuture<Void> future = new CompletableFuture<>();
-        Util.ioPool().execute(() -> CODEC.encodeStart(NbtOps.INSTANCE, this).resultOrPartial(Config.LOGGER::error).ifPresent(tag -> {
+        Util.ioPool().execute(() -> {
             try {
-                future.complete(null);
+                Tag tag = CODEC.encodeStart(NbtOps.INSTANCE, this).getOrThrow();
                 NbtIo.writeCompressed((CompoundTag) tag, SAVE_PATH);
-            } catch (IOException e) {
-                throw new RuntimeException("Couldn't save pearls", e);
+                future.complete(null);
+            } catch (Throwable thrown) {
+                future.complete(null);
+                throw new RuntimeException("Couldn't save pearls", thrown);
             }
-        }));
+        });
         return future;
     }
 

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -96,7 +96,7 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
 
     public void addPearl(final UUID uuid, final @NonNull ThrownEnderpearl thrownEnderpearl) {
         if (thrownEnderpearl.isRemoved()) {
-            Config.LOGGER.warn("Trying to add removed ender pearl, skipping");
+            Config.LOGGER.warn("Trying to add removed ({}) ender pearl, skipping", thrownEnderpearl.getRemovalReason(), new Throwable());
             return;
         }
         List<Pearl> pearls = pearls().computeIfAbsent(uuid, (ignored) -> new CopyOnWriteArrayList<>());

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -58,7 +58,7 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
     }
 
     public static EnderPearls read() {
-        if (Files.exists(SAVE_PATH)) {
+        if (Config.INSTANCE.restoreVanillaEnderPearlBehavior && Files.exists(SAVE_PATH)) {
             try {
                 CompoundTag tag = Objects.requireNonNull(NbtIo.readCompressed(SAVE_PATH, NbtAccounter.unlimitedHeap()), "NBT cannot be null")
                     .asCompound().orElseThrow(UnknownError::new);

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -162,6 +162,7 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
                 world.canvas$loadOrRunAtChunksAsync(entity.blockPosition, 16, Priority.NORMAL, () -> {
                     world.addFreshEntityWithPassengers(entity);
                     ServerPlayer.placeEnderPearlTicket(world, entity.chunkPosition());
+                    Config.LOGGER.debug("Spawned saved pearl in world ({})", world.dimension().identifier());
                 });
             }
             else {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -1,0 +1,175 @@
+package io.canvasmc.canvas.entity;
+
+import ca.spottedleaf.concurrentutil.util.Priority;
+import com.mojang.serialization.Codec;
+import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.canvasmc.canvas.Config;
+import io.canvasmc.canvas.util.Codecs;
+import io.papermc.paper.threadedregions.TickRegionScheduler;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.Paths;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicLong;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.NbtOps;
+import net.minecraft.server.MinecraftServer;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.ProblemReporter;
+import net.minecraft.util.Util;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.EntityProcessor;
+import net.minecraft.world.entity.EntitySpawnReason;
+import net.minecraft.world.entity.EntityType;
+import net.minecraft.world.entity.projectile.throwableitemprojectile.ThrownEnderpearl;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.level.storage.TagValueOutput;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.NonNull;
+
+public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
+    private static final AtomicLong LAST_AUTOSAVE = new AtomicLong(System.nanoTime());
+    public static final Path SAVE_PATH = Paths.get("pearls.dat");
+    public static final Codec<Pearl> PEARL_CODEC = RecordCodecBuilder.create(
+        instance -> instance.group(
+            CompoundTag.CODEC.fieldOf("Serialized").forGetter(Pearl::serialized)
+        ).apply(instance, Pearl::new)
+    );
+    public static final Codec<EnderPearls> CODEC = RecordCodecBuilder.create(
+        instance -> instance.group(
+            Codec.unboundedMap(
+                Codecs.UUID_CODEC, Codecs.copyOnWriteArrayListCodec(PEARL_CODEC.listOf())
+            ).optionalFieldOf("Data", new ConcurrentHashMap<>()).forGetter(EnderPearls::pearls)
+        ).apply(instance, EnderPearls::new)
+    );
+
+    public EnderPearls(Map<UUID, List<Pearl>> pearls) {
+        this.pearls = new ConcurrentHashMap<>(pearls);
+    }
+
+    public static EnderPearls read() {
+        if (Files.exists(SAVE_PATH)) {
+            try {
+                CompoundTag tag = Objects.requireNonNull(NbtIo.readCompressed(SAVE_PATH, NbtAccounter.unlimitedHeap()), "NBT cannot be null")
+                    .asCompound().orElseThrow(UnknownError::new);
+                return CODEC.decode(NbtOps.INSTANCE, tag).getOrThrow().getFirst();
+            } catch (Throwable e) {
+                throw new RuntimeException("Couldn't read pearl save data", e);
+            }
+        }
+        return new EnderPearls(new ConcurrentHashMap<>());
+    }
+
+    public void save() {
+        Util.ioPool().execute(() -> CODEC.encodeStart(NbtOps.INSTANCE, this).resultOrPartial(Config.LOGGER::error).ifPresent(tag -> {
+            try {
+                NbtIo.writeCompressed((CompoundTag) tag, SAVE_PATH);
+            } catch (IOException e) {
+                throw new RuntimeException("Couldn't save pearls", e);
+            }
+        }));
+    }
+
+    public void spawnPearls(final @NonNull ServerPlayer player) {
+        pearls.computeIfPresent(player.getUUID(), (uuid, enderPearls) -> {
+            for (final Pearl enderPearl : new ArrayList<>(enderPearls)) {
+                enderPearl.spawn();
+                enderPearls.remove(enderPearl);
+            }
+            return null;
+        });
+    }
+
+    public void addPearl(final UUID uuid, final ThrownEnderpearl thrownEnderpearl) {
+        List<Pearl> pearls = pearls().computeIfAbsent(uuid, (ignored) -> new CopyOnWriteArrayList<>());
+        Pearl encoded = Pearl.of(thrownEnderpearl);
+        pearls.remove(encoded); // remove if it's already in the list, we don't want duplicates
+        pearls.add(encoded);
+    }
+
+    public void autosave() {
+        final int autoSavePeriod = MinecraftServer.getServer().autosavePeriod;
+        if (autoSavePeriod <= 0) return;
+        final long periodNanos = autoSavePeriod * TickRegionScheduler.getTimeBetweenTicks();
+        final long currTime = System.nanoTime();
+        final long last = LAST_AUTOSAVE.get();
+        if ((currTime - last) > periodNanos && LAST_AUTOSAVE.compareAndSet(last, currTime)) {
+            save();
+        }
+    }
+
+    /**
+     * The serializable ender pearl instance, containing a {@link net.minecraft.nbt.CompoundTag} which is the main save
+     * data, formatted as:
+     * <pre>{@code
+     * {
+     *     "uuid": <the entity uuid>,
+     *     "data": <the entity data, without the id>,
+     *     "world": <dimension>
+     * }
+     * }</pre>
+     *
+     * @param serialized
+     *     the serialized save data
+     *
+     * @author dueris
+     */
+    public record Pearl(CompoundTag serialized) {
+
+        @Contract("_ -> new")
+        public static @NonNull Pearl of(@NonNull ThrownEnderpearl pearl) {
+            final CompoundTag tag;
+            try (final ProblemReporter.ScopedCollector problemReporter = new ProblemReporter.ScopedCollector(
+                () -> "pearl-serialize", Config.LOGGER
+            )) {
+                final TagValueOutput tagValueOutput = TagValueOutput.createWithContext(
+                    problemReporter,
+                    pearl.registryAccess()
+                );
+
+                tagValueOutput.store("uuid", Codecs.UUID_CODEC, pearl.getUUID());
+                tagValueOutput.store("world", Level.RESOURCE_KEY_CODEC, pearl.level().dimension());
+                pearl.save(tagValueOutput.child("data"));
+
+                tag = tagValueOutput.buildResult();
+            }
+            return new Pearl(tag);
+        }
+
+        public void spawn() {
+            final CompoundTag data = serialized.getCompound("data").orElseThrow();
+            final ServerLevel world = MinecraftServer.getServer().getLevel(serialized.read("world", Level.RESOURCE_KEY_CODEC).orElseThrow());
+            if (world == null) {
+                Config.LOGGER.error("World ({}) did not exist, skipping pearl spawn", serialized.getString("world"));
+                return;
+            }
+            Entity entity = EntityType.loadEntityRecursive(data, world, EntitySpawnReason.LOAD, EntityProcessor.NOP);
+            if (entity != null) {
+                world.canvas$loadOrRunAtChunksAsync(entity.blockPosition, 16, Priority.NORMAL, () -> {
+                    world.addFreshEntityWithPassengers(entity);
+                    ServerPlayer.placeEnderPearlTicket(world, entity.chunkPosition());
+                });
+            }
+            else {
+                Config.LOGGER.warn("Failed to spawn player ender pearl in world ({}), skipping", world.dimension().identifier().toDebugFileName());
+            }
+        }
+
+        @Override
+        public boolean equals(final Object o) {
+            // if uuids match, same pearl
+            return o instanceof Pearl(CompoundTag otherSerialized) &&
+                otherSerialized.read("uuid", Codecs.UUID_CODEC).orElseThrow().equals(serialized.read("uuid", Codecs.UUID_CODEC).orElseThrow());
+        }
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/entity/EnderPearls.java
@@ -15,6 +15,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
@@ -70,14 +71,17 @@ public record EnderPearls(Map<UUID, List<Pearl>> pearls) {
         return new EnderPearls(new ConcurrentHashMap<>());
     }
 
-    public void save() {
+    public @NonNull CompletableFuture<Void> save() {
+        CompletableFuture<Void> future = new CompletableFuture<>();
         Util.ioPool().execute(() -> CODEC.encodeStart(NbtOps.INSTANCE, this).resultOrPartial(Config.LOGGER::error).ifPresent(tag -> {
             try {
+                future.complete(null);
                 NbtIo.writeCompressed((CompoundTag) tag, SAVE_PATH);
             } catch (IOException e) {
                 throw new RuntimeException("Couldn't save pearls", e);
             }
         }));
+        return future;
     }
 
     public void spawnPearls(final @NonNull ServerPlayer player) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/Codecs.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/Codecs.java
@@ -4,6 +4,8 @@ import com.google.common.util.concurrent.AtomicDouble;
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.DataResult;
 import java.util.List;
+import java.util.UUID;
+import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicIntegerArray;
@@ -15,6 +17,16 @@ import net.minecraft.world.phys.AABB;
 import org.jetbrains.annotations.NotNull;
 
 public interface Codecs {
+    Codec<UUID> UUID_CODEC = Codec.STRING
+        .comapFlatMap(s -> {
+            // try-catch so we don't swallow malformed uuids
+            try {
+                return DataResult.success(UUID.fromString(s));
+            } catch (Throwable thrown) {
+                return DataResult.error(thrown::getMessage);
+            }
+        }, UUID::toString);
+
     Codec<AtomicInteger> ATOMIC_INTEGER = Codec.INT
         .comapFlatMap(i -> DataResult.success(new AtomicInteger(i)), AtomicInteger::get);
 
@@ -50,6 +62,19 @@ public interface Codecs {
                 return java.util.Arrays.stream(result).boxed().toList();
             }
         );
+    Codec<AABB> AABB_CODEC = Codec.DOUBLE
+        .listOf()
+        .comapFlatMap(
+            list -> Util.fixedSize(list, 6).map(listx -> new AABB(listx.getFirst(), listx.get(1), listx.get(2), listx.get(3), listx.get(4), listx.get(5))),
+            aabb -> List.of(aabb.minX, aabb.minY, aabb.minZ, aabb.maxX, aabb.maxY, aabb.maxZ)
+        );
+
+    static <T> Codec<List<T>> copyOnWriteArrayListCodec(@NotNull Codec<List<T>> innerCodec) {
+        return innerCodec.comapFlatMap(
+            l -> DataResult.success(new CopyOnWriteArrayList<>(l)),
+            (l) -> l
+        );
+    }
 
     static <T> Codec<AtomicReference<T>> atomicReferenceCodec(@NotNull Codec<T> innerCodec) {
         return innerCodec.comapFlatMap(
@@ -57,11 +82,4 @@ public interface Codecs {
             AtomicReference::get
         );
     }
-
-    Codec<AABB> AABB_CODEC = Codec.DOUBLE
-        .listOf()
-        .comapFlatMap(
-            list -> Util.fixedSize(list, 6).map(listx -> new AABB(listx.getFirst(), listx.get(1), listx.get(2), listx.get(3), listx.get(4), listx.get(5))),
-            aabb -> List.of(aabb.minX, aabb.minY, aabb.minZ, aabb.maxX, aabb.maxY, aabb.maxZ)
-        );
 }


### PR DESCRIPTION
Note, this also contains a new event, was meant to be merged with main, but doesn't entirely matter, having a review on that is always good.

Ender pearl saving was removed in Folia due to not being region threading safe, Canvas added back this feature in a semi-safe way, that reenabled the Vanilla mechanic for it. How this works is on save of the player, it saves all pearls registered to the player to the player NBT, and then discards the pearls on leave. Then, on join, it reads this list of pearls and loads them all back in.

Given how region threading works, this was never fully safe, and with Canvas' old patch, it was mostly safe, but could have a few issues given it would try and save the entity off the owning region of the ender pearl(assuming the pearl was in a different region).

The new method makes it so that *ONLY* on leave it will save the pearls to a server-wide map of `UUID -> Pearls`. This is then saved to `pearls.dat` in the root folder of the server. When the player leaves, all pearls are added to the map on their owning region before being discarded for `UNLOADED_WITH_PLAYER`. On the global tick, the server will attempt to write to disk for autosave(same time interval as maps for autosave), with the `save-all` command, and on shutdown it will write to disk. This is all done through the utility IO pool. On join, each pearl is decoded, and then using Canvas utilities, spawns the pearl in on join, and then clears the current list in the save data(since we just spawned all of them, none of them need to be in the save data anymore).

Here is an example of the full save data with 2 ender pearls and 1 player:
```nbt
"": {
	Data: {
		a4804847-858e-3278-941e-ab3175b15a81: [
			{
				world: "minecraft:overworld"
				data: {
					Motion: [ -0.628238237796933, -0.40603269619311716, -0.3219544256987014, ]
					Owner: ints(-1535096761, -2054278536, -1809929423, 1974557313)
					Bukkit.updateLevel: 2
					Paper.SpawnReason: DEFAULT
					LeftOwner: 1B
					Invulnerable: 0B
					OnGround: 0B
					Air: 300S
					fall_distance: 0.0
					PortalCooldown: 0
					Rotation: [ -117.1339F, -22.048866F, ]
					Item: {
						count: 1
						id: "minecraft:ender_pearl"
					}
					HasBeenShot: 1B
					Pos: [ 663.1843190963243, 96.00907378288356, 512.669722277999, ]
					WorldUUIDMost: -8792826753600697354L
					Fire: 0S
					Spigot.ticksLived: 44
					id: "minecraft:ender_pearl"
					Paper.OriginWorld: ints(-2047239513, 1813269494, -1438231611, 529178733)
					UUID: ints(-1233549937, -1355593494, -1826402158, 433873289)
					WorldUUIDLeast: -6177157732789215123L
					Paper.Origin: [ 697.7743819781084, 85.52000000327826, 530.3961565508305, ]
				}
				uuid: b679858f-af33-48ea-9323-509219dc6189
			},
			{
				world: "minecraft:overworld"
				data: {
					Motion: [ -0.7994316921474096, 0.27617184953909873, -0.02501631957102539, ]
					Owner: ints(-1535096761, -2054278536, -1809929423, 1974557313)
					Bukkit.updateLevel: 2
					Paper.SpawnReason: DEFAULT
					LeftOwner: 1B
					Invulnerable: 0B
					OnGround: 0B
					Air: 300S
					fall_distance: 0.0
					PortalCooldown: 0
					Rotation: [ -91.79234F, 25.57844F, ]
					Item: {
						count: 1
						id: "minecraft:ender_pearl"
					}
					HasBeenShot: 1B
					Pos: [ 677.192424848533, 100.78509063173341, 529.7520929966734, ]
					WorldUUIDMost: -8792826753600697354L
					Fire: 0S
					Spigot.ticksLived: 23
					id: "minecraft:ender_pearl"
					Paper.OriginWorld: ints(-2047239513, 1813269494, -1438231611, 529178733)
					UUID: ints(-568573281, 1065110786, -1935914657, -112458905)
					WorldUUIDLeast: -6177157732789215123L
					Paper.Origin: [ 697.7743819781084, 85.52000000327826, 530.3961565508305, ]
				}
				uuid: de1c429f-3f7c-4d02-8c9c-495ff94c0367
			},
		]
	}
}
```
This makes this significantly more region threading safe, given everything is now scheduled properly, and saved properly, on the correct context, in a more efficient and safe manner.

Needs production testing