### PR TITLE
Affinity Scheduler

### DIFF
--- a/canvas-server/build.gradle.kts.patch
+++ b/canvas-server/build.gradle.kts.patch
@@ -58,7 +58,7 @@
      }
  }
  val log4jPlugins = sourceSets.create("log4jPlugins") {
-@@ -151,10 +_,10 @@
+@@ -151,12 +_,13 @@
  }
  
  dependencies {
@@ -71,7 +71,10 @@
 +    implementation("org.jline:jline-terminal-jni:3.29.0") // fall back to jni on java 21
      implementation("net.minecrell:terminalconsoleappender:1.3.0")
      implementation("net.kyori:adventure-text-serializer-ansi")
++    implementation("net.openhft:affinity:2026.2")
  
+     /*
+       Required to add the missing Log4j2Plugins.dat file from log4j-core
 @@ -164,8 +_,8 @@
        all its classes to check if they are plugins.
        Scanning takes about 1-2 seconds so adding this speeds up the server start.

--- a/canvas-server/minecraft-patches/base/0007-Improve-Region-Scheduler.patch
+++ b/canvas-server/minecraft-patches/base/0007-Improve-Region-Scheduler.patch
@@ -83,7 +83,7 @@ index 71260702b8ba260001a5f1c1e935dd5b8717f3d7..2a22b44ca43ccaa296e56bb7b89baf80
  public final class TickRegionScheduler {
  
 -    private static final Logger LOGGER = LogUtils.getLogger();
-+    private static final Logger LOGGER = LogUtils.getClassLogger(); // Canvas - region threading
++    public static final Logger LOGGER = LogUtils.getClassLogger(); // Canvas - region threading
      private static final ThreadMXBean THREAD_MX_BEAN = ManagementFactory.getThreadMXBean();
      private static final boolean MEASURE_CPU_TIME;
      static {
@@ -91,7 +91,7 @@ index 71260702b8ba260001a5f1c1e935dd5b8717f3d7..2a22b44ca43ccaa296e56bb7b89baf80
  
      public static enum SchedulerType {
          EDF,
-+        CRS, // Canvas - add CRS scheduler
++        AFFINITY, // Canvas - add AFFINITY scheduler
          WORK_STEALING;
      }
  
@@ -654,7 +654,7 @@ index ded991859a6a94693cce183b3bf380a9241a2976..e1ff2e27e1647a4b9bf9b265e17f8fc8
      public static final TicketType<Long> TELEPORT_HOLD_TICKET = ca.spottedleaf.moonrise.patches.chunk_system.ticket.ChunkSystemTicketType.create("folia:teleport_hold_ticket", Long::compareTo);
      public static final TicketType REGION_SCHEDULER_API_HOLD = register("folia:region_scheduler_api_hold", 0L, FLAG_LOADING | FLAG_SIMULATION);
      // Folia end - region threading
-+    public static final TicketType REGION_PROFILING_HOLD = register("canvas:region_profiler_hold", NO_TIMEOUT, FLAG_LOADING | FLAG_SIMULATION); // Canvas - region threading
++    public static final TicketType REGION_PROFILING_HOLD = register("canvas:region_profiler_hold", NO_TIMEOUT, FLAG_LOADING | FLAG_SIMULATION | FLAG_KEEP_DIMENSION_ACTIVE); // Canvas - region threading
  
      private static TicketType register(String name, long timeout, @TicketType.Flags int flags) {
          return Registry.register(BuiltInRegistries.TICKET_TYPE, name, new TicketType(timeout, flags));

--- a/canvas-server/minecraft-patches/base/0007-Improve-Region-Scheduler.patch
+++ b/canvas-server/minecraft-patches/base/0007-Improve-Region-Scheduler.patch
@@ -397,7 +397,7 @@ index 50cf0f76be33a671c8143abd778a4a18dd2a8400..599b1bc4eea196adf59b8d9f8607d5f9
              ret.currentTick = this.currentTick;
              ret.lastTickStart = this.lastTickStart;
              ret.tickSchedule.setLastPeriod(this.tickSchedule.getLastPeriod());
-+            io.canvasmc.canvas.tick.SchedulerUtil.getHandle().tryTransferPinningState(ret, this); // Canvas - region profiler
++            io.canvasmc.canvas.tick.SchedulerUtil.getHandle().tryTransferPinningState(this, ret); // Canvas - region profiler
  
              return ret;
          }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -158,6 +158,13 @@ public class Config {
 
     public static class Scheduler {
         @Comment({
+            "The maximum amount of time, in milliseconds, a thread will delay the execution of a scheduled task",
+            "before allowing other threads to steal it for execution.",
+            "Note: A smaller value reduces task start delays but increases potential task stealing between threads"
+        })
+        public long stealThresholdMillis = 3L;
+
+        @Comment({
             "Buffer time (in milliseconds) before tick deadline to stop executing intermediate tasks.",
             "Ensures runTick() can start on time, at the deadline. Higher = safer, lower = more work done.",
             "Default: 0.1ms"

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -170,6 +170,12 @@ public class Config {
             "or help identify deadline missing issues"
         })
         public long overloadedLogMillis = 5_000L;
+
+        @Comment("Thread affinity for the AFFINITY scheduler provided by Canvas. By using this, you could pin the threads of region scheduler to cpu cores")
+        public List<String> tickRegionAffinity = new ArrayList<>();
+
+        @Comment("Enables pinning threads of the AFFINITY region scheduler to cpu cores")
+        public boolean enableAffinitySchedulerCpuAffinity = false;
     }
 
     public Chunks chunks = new Chunks();

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -158,13 +158,6 @@ public class Config {
 
     public static class Scheduler {
         @Comment({
-            "The maximum amount of time, in milliseconds, a thread will delay the execution of a scheduled task",
-            "before allowing other threads to steal it for execution.",
-            "Note: A smaller value reduces task start delays but increases potential task stealing between threads"
-        })
-        public long stealThresholdMillis = 3L;
-
-        @Comment({
             "Buffer time (in milliseconds) before tick deadline to stop executing intermediate tasks.",
             "Ensures runTick() can start on time, at the deadline. Higher = safer, lower = more work done.",
             "Default: 0.1ms"

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/FoliaTickStatistics.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/FoliaTickStatistics.java
@@ -19,7 +19,7 @@ public class FoliaTickStatistics implements TickStatistics {
     private static double getTpsFor(TimeSpan span) {
         // we must include global tick, and all regions
         if (isRunningIndependentRegion()) {
-            return getTpsFor(SparkRegionProfilerExtension.SCHEDULE_HANDLE_CACHE.get(), span);
+            return getTpsFor(SparkRegionProfilerExtension.STATE.get().regionScheduleHandle(), span);
         }
         DoubleArrayList tpsCounts = new DoubleArrayList();
         tpsCounts.add(getTpsFor(RegionizedServer.getGlobalTickData(), span));

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/FoliaWorldInfoProvider.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/FoliaWorldInfoProvider.java
@@ -45,7 +45,6 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
 
     @Override
     public CountsResult pollCounts() {
-        MinecraftServer.LOGGER.info("Polling FoliaWorldInfoProvider");
         if (SparkRegionProfilerExtension.isProfiling()) {
             // we need tile entities, chunks, entities, and players
             // if this isn't a region pinner, this is the global tick

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/FoliaWorldInfoProvider.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/FoliaWorldInfoProvider.java
@@ -1,10 +1,8 @@
 package io.canvasmc.canvas.spark;
 
 import ca.spottedleaf.concurrentutil.util.Priority;
-import ca.spottedleaf.moonrise.common.util.CoordinateUtils;
-import com.mojang.datafixers.util.Pair;
+import io.canvasmc.canvas.spark.profiler.RegionScheduleHandlePinner;
 import io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension;
-import io.canvasmc.canvas.util.COWLongArrayList;
 import io.papermc.paper.threadedregions.RegionizedServer;
 import io.papermc.paper.threadedregions.RegionizedWorldData;
 import java.util.ArrayList;
@@ -21,7 +19,9 @@ import java.util.stream.Collectors;
 import me.lucko.spark.paper.common.platform.world.AbstractChunkInfo;
 import me.lucko.spark.paper.common.platform.world.CountMap;
 import me.lucko.spark.paper.common.platform.world.WorldInfoProvider;
+import net.minecraft.server.MinecraftServer;
 import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.chunk.LevelChunk;
 import org.bukkit.Bukkit;
 import org.bukkit.Chunk;
@@ -32,6 +32,7 @@ import org.bukkit.craftbukkit.CraftChunk;
 import org.bukkit.craftbukkit.CraftWorld;
 import org.bukkit.entity.Entity;
 import org.bukkit.entity.EntityType;
+import org.jspecify.annotations.NonNull;
 
 public class FoliaWorldInfoProvider implements WorldInfoProvider {
     private final FoliaSparkPlugin plugin;
@@ -44,41 +45,47 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
 
     @Override
     public CountsResult pollCounts() {
-        // Note: if we are ending a profiler, this will be cached, otherwise this is current
-        Pair<ServerLevel, COWLongArrayList> profilerResultCache = SparkRegionProfilerExtension.PROFILING_RESULTS_CACHE.get();
-        if (profilerResultCache != null) {
-            ServerLevel world = profilerResultCache.getFirst();
-            COWLongArrayList chunkKeys = profilerResultCache.getSecond();
-            // use first entry, this shouldn't ever be null or out of bounds
-            final int chunkX = CoordinateUtils.getChunkX(chunkKeys.getArray()[0]);
-            final int chunkZ = CoordinateUtils.getChunkZ(chunkKeys.getArray()[0]);
-            CompletableFuture<CountsResult> result = new CompletableFuture<>();
+        MinecraftServer.LOGGER.info("Polling FoliaWorldInfoProvider");
+        if (SparkRegionProfilerExtension.isProfiling()) {
+            // we need tile entities, chunks, entities, and players
+            // if this isn't a region pinner, this is the global tick
+            if (SparkRegionProfilerExtension.STATE.get().handlePinner() instanceof RegionScheduleHandlePinner.RegionPinner pinner) {
+                final ServerLevel world = pinner.world();
+                final ChunkPos target = pinner.getCenter();
 
-            // schedule to region we were profiling at
-            RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
-                world, chunkX, chunkZ, () -> {
-                    // we are scheduled to the region here, fetch localized information
-                    RegionizedWorldData localWorldData = world.getCurrentWorldData();
+                final CompletableFuture<CountsResult> result = new CompletableFuture<>();
 
-                    int players = localWorldData.getPlayerCount();
-                    int entities = localWorldData.getEntityCount();
-                    int chunks = localWorldData.getChunkCount();
-                    int tileEntities = 0;
+                // schedule to region we were profiling at
+                RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
+                    world, target.x, target.z, () -> {
+                        // we are scheduled to the region here, fetch localized information
+                        RegionizedWorldData localWorldData = world.getCurrentWorldData();
 
-                    // we only use block ticking chunks, matches with what spark does for global polling
-                    for (final LevelChunk tickingChunk : localWorldData.getTickingChunks()) {
-                        tileEntities += tickingChunk.canvas$getAllBlockEntities().length;
-                    }
+                        int players = localWorldData.getPlayerCount();
+                        int entities = localWorldData.getEntityCount();
+                        int chunks = localWorldData.getChunkCount();
+                        int tileEntities = 0;
 
-                    result.complete(new CountsResult(players, entities, tileEntities, chunks));
-                }, Priority.BLOCKING // highest possible priority, we need this information now please
-            );
+                        // we only use block ticking chunks, matches with what spark does for global polling
+                        for (final LevelChunk tickingChunk : localWorldData.getTickingChunks()) {
+                            tileEntities += tickingChunk.canvas$getAllBlockEntities().length;
+                        }
 
-            try {
-                // timeout 5 seconds like FoliaChunkInfo#getEntityCounts
-                return result.get(5, TimeUnit.SECONDS);
-            } catch (InterruptedException | TimeoutException | ExecutionException e) {
-                throw new RuntimeException("Couldn't fetch localized world data", e);
+                        result.complete(new CountsResult(players, entities, tileEntities, chunks));
+                    }, Priority.BLOCKING // highest possible priority, we need this information now please
+                );
+
+                try {
+                    // timeout 5 seconds like FoliaChunkInfo#getEntityCounts
+                    return result.get(5, TimeUnit.SECONDS);
+                } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                    throw new RuntimeException("Couldn't fetch localized world data", e);
+                }
+            }
+            else {
+                // global tick owns nothing. we *could* have players be populated with connections it's
+                // handling, but that isn't entirely accurate, especially at the interval it polls at
+                return new CountsResult(0, 0, 0, 0);
             }
         }
         int players = this.server.getOnlinePlayers().size();
@@ -101,36 +108,35 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
         ChunksResult<FoliaChunkInfo> data = new ChunksResult<>();
 
         // Note: if we are ending a profiler, this will be cached, otherwise this is current
-        Pair<ServerLevel, COWLongArrayList> profilerResultCache = SparkRegionProfilerExtension.PROFILING_RESULTS_CACHE.get();
-        if (profilerResultCache != null) {
-            ServerLevel world = profilerResultCache.getFirst();
-            COWLongArrayList chunkKeys = profilerResultCache.getSecond();
-            // use first entry, this shouldn't ever be null or out of bounds
-            final int chunkX = CoordinateUtils.getChunkX(chunkKeys.getArray()[0]);
-            final int chunkZ = CoordinateUtils.getChunkZ(chunkKeys.getArray()[0]);
-            CompletableFuture<List<FoliaChunkInfo>> result = new CompletableFuture<>();
+        if (SparkRegionProfilerExtension.isProfiling()) {
+            if (SparkRegionProfilerExtension.STATE.get().handlePinner() instanceof RegionScheduleHandlePinner.RegionPinner pinner) {
+                final ServerLevel world = pinner.world();
+                final ChunkPos target = pinner.getCenter();
+                final CompletableFuture<List<FoliaChunkInfo>> result = new CompletableFuture<>();
 
-            // schedule to region we were profiling at
-            RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
-                world, chunkX, chunkZ, () -> {
-                    List<FoliaChunkInfo> retVal = new ArrayList<>();
-                    RegionizedWorldData worldData = world.getCurrentWorldData();
-                    for (final LevelChunk nmsChunk : worldData.getChunks()) {
-                        Chunk chunk = new CraftChunk(nmsChunk);
-                        retVal.add(new FoliaChunkInfo(chunk, world.getWorld(), this.plugin));
-                    }
-                    result.complete(retVal);
-                }, Priority.BLOCKING // highest possible priority, we need this information now please
-            );
+                RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
+                    world, target.x, target.z, () -> {
+                        List<FoliaChunkInfo> chunks = new ArrayList<>();
+                        RegionizedWorldData worldData = world.getCurrentWorldData();
+                        for (final LevelChunk nms : worldData.getChunks()) {
+                            chunks.add(new FoliaChunkInfo(new CraftChunk(nms), world.getWorld(), this.plugin));
+                        }
+                        result.complete(chunks);
+                    }, Priority.BLOCKING
+                );
 
-            try {
-                // timeout 5 seconds like FoliaChunkInfo#getEntityCounts
-                data.put(world.getWorld().getName(), result.get(5, TimeUnit.SECONDS));
-                return data;
-            } catch (InterruptedException | TimeoutException | ExecutionException e) {
-                throw new RuntimeException("Couldn't fetch localized world data", e);
+                try {
+                    // timeout 5 seconds like FoliaChunkInfo#getEntityCounts
+                    data.put(world.getWorld().getName(), result.get(5, TimeUnit.SECONDS));
+                    return data;
+                } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                    throw new RuntimeException("Couldn't fetch localized world data", e);
+                }
             }
+            else return new ChunksResult<>(); // global tick, doesn't own chunks
         }
+
+        // non-specific region profiler, just fetch everything (god I hate this)
         for (World world : this.server.getWorlds()) {
             Chunk[] chunks = world.getLoadedChunks();
 
@@ -174,7 +180,7 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
         return data;
     }
 
-    @SuppressWarnings({"removal", "UnstableApiUsage"})
+    @SuppressWarnings({"removal"})
     @Override
     public Collection<DataPackInfo> pollDataPacks() {
         return this.server.getDatapackManager().getEnabledPacks().stream()
@@ -186,17 +192,17 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
             .collect(Collectors.toList());
     }
 
-    static final class FoliaChunkInfo extends AbstractChunkInfo<EntityType> {
+    public static final class FoliaChunkInfo extends AbstractChunkInfo<EntityType> {
         private final CompletableFuture<CountMap<EntityType>> entityCounts;
 
-        FoliaChunkInfo(Chunk chunk, World world, FoliaSparkPlugin plugin) {
+        FoliaChunkInfo(@NonNull Chunk chunk, World world, FoliaSparkPlugin plugin) {
             super(chunk.getX(), chunk.getZ());
 
             Executor executor = task -> RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(((CraftWorld) world).getHandle(), getX(), getZ(), task, Priority.BLOCKING);
             this.entityCounts = CompletableFuture.supplyAsync(() -> calculate(chunk), executor);
         }
 
-        private CountMap<EntityType> calculate(Chunk chunk) {
+        private @NonNull CountMap<EntityType> calculate(@NonNull Chunk chunk) {
             CountMap<EntityType> entityCounts = new CountMap.EnumKeyed<>(EntityType.class);
             for (Entity entity : chunk.getEntities()) {
                 if (entity != null) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/RegionScheduleHandlePinner.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/RegionScheduleHandlePinner.java
@@ -207,9 +207,9 @@ public interface RegionScheduleHandlePinner {
         public void unpin(Consumer<SchedulableTick> finalizer) {
             final long[] curr = gatherChunksToProfile();
 
-            long packed = curr[0];
-            int chunkX = (int) packed;
-            int chunkZ = (int) (packed >> 32);
+            final ChunkPos center = getCenter();
+            final int chunkX = center.x;
+            final int chunkZ = center.z;
 
             // Note: this should be loaded already, however we run this safe version just to be sure
             world.canvas$loadOrRunAtChunksAsync(

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/RegionScheduleHandlePinner.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/RegionScheduleHandlePinner.java
@@ -2,26 +2,30 @@ package io.canvasmc.canvas.spark.profiler;
 
 import ca.spottedleaf.concurrentutil.scheduler.SchedulableTick;
 import ca.spottedleaf.concurrentutil.util.Priority;
+import ca.spottedleaf.moonrise.common.util.CoordinateUtils;
+import ca.spottedleaf.moonrise.common.util.TickThread;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.Dynamic2CommandExceptionType;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import io.canvasmc.canvas.tick.CRSThreadPool;
-import io.canvasmc.canvas.util.COWLongArrayList;
+import io.canvasmc.canvas.tick.AffinitySchedulerThreadPool;
 import io.papermc.paper.threadedregions.RegionizedServer;
 import io.papermc.paper.threadedregions.ThreadedRegionizer;
 import io.papermc.paper.threadedregions.TickRegionScheduler;
 import io.papermc.paper.threadedregions.TickRegions;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
+import it.unimi.dsi.fastutil.longs.LongArrayList;
+import it.unimi.dsi.fastutil.longs.LongComparator;
 import net.minecraft.core.BlockPos;
 import net.minecraft.server.level.ChunkMap;
 import net.minecraft.server.level.ColumnPos;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.Ticket;
 import net.minecraft.server.level.TicketType;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.border.WorldBorder;
 import org.jetbrains.annotations.NotNull;
+import org.jspecify.annotations.NonNull;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -47,7 +51,7 @@ public interface RegionScheduleHandlePinner {
      * @throws CommandSyntaxException
      *     if an error occurs in setup and should be sent as an error to the sender
      */
-    void pin(BiConsumer<TickRegionScheduler.RegionScheduleHandle, CRSThreadPool.TickThreadRunner> finalizer, CRSThreadPool crsThreadPool) throws CommandSyntaxException;
+    void pin(BiConsumer<TickRegionScheduler.RegionScheduleHandle, AffinitySchedulerThreadPool.TickThreadRunner> finalizer) throws CommandSyntaxException;
 
     /**
      * Wraps up pinning for the current {@link RegionScheduleHandlePinner}. This should do the following:
@@ -65,7 +69,7 @@ public interface RegionScheduleHandlePinner {
      * @throws CommandSyntaxException
      *     if an error occurs in completion and should be sent as an error to the sender
      */
-    void unpin(Consumer<SchedulableTick> finalizer, CRSThreadPool crsThreadPool) throws CommandSyntaxException;
+    void unpin(Consumer<SchedulableTick> finalizer) throws CommandSyntaxException;
 
     /**
      * Fetches the logger for this region pinner, used for debugging purposes
@@ -86,11 +90,55 @@ public interface RegionScheduleHandlePinner {
      *     the world we are operating on
      */
     record RegionPinner(ColumnPos fromPos, ColumnPos toPos, ServerLevel world) implements RegionScheduleHandlePinner {
-        public static final COWLongArrayList PROFILING_CHUNKS = new COWLongArrayList();
-        public static final AtomicReference<ServerLevel> PROFILING_LEVEL = new AtomicReference<>();
+        public @NonNull ChunkPos getCenter() {
+            final LongArrayList chunks = LongArrayList.wrap(gatherChunksToProfile());
+
+            final LongComparator comparator = (final long k1, final long k2) -> {
+                final int x1 = CoordinateUtils.getChunkX(k1);
+                final int x2 = CoordinateUtils.getChunkX(k2);
+
+                final int z1 = CoordinateUtils.getChunkZ(k1);
+                final int z2 = CoordinateUtils.getChunkZ(k2);
+
+                final int zCompare = Integer.compare(z1, z2);
+                if (zCompare != 0) {
+                    return zCompare;
+                }
+
+                return Integer.compare(x1, x2);
+            };
+            chunks.sort(comparator);
+
+            final long middle = chunks.getLong(chunks.size() >> 1);
+
+            return new ChunkPos(CoordinateUtils.getChunkX(middle), CoordinateUtils.getChunkZ(middle));
+        }
+
+        // note: this is unchecked, no validation of the border or chunk count
+        public long[] gatherChunksToProfile() {
+            LongArrayList ret = new LongArrayList();
+            // note: this is the BLOCK pos, not to be confused with the CHUNK pos
+            int minX = Math.min(fromPos.x(), toPos.x());
+            int minZ = Math.min(fromPos.z(), toPos.z());
+            int maxX = Math.max(fromPos.x(), toPos.x());
+            int maxZ = Math.max(fromPos.z(), toPos.z());
+
+            // convert to section coordinates
+            int minChunkX = minX >> 4;
+            int minChunkZ = minZ >> 4;
+            int maxChunkX = maxX >> 4;
+            int maxChunkZ = maxZ >> 4;
+
+            for (int chunkX = minChunkX; chunkX <= maxChunkX; chunkX++) {
+                for (int chunkZ = minChunkZ; chunkZ <= maxChunkZ; chunkZ++) {
+                    ret.add(CoordinateUtils.getChunkKey(chunkX, chunkZ));
+                }
+            }
+            return ret.toLongArray();
+        }
 
         @Override
-        public void pin(final BiConsumer<TickRegionScheduler.RegionScheduleHandle, CRSThreadPool.TickThreadRunner> finalizer, CRSThreadPool crsThreadPool) throws CommandSyntaxException {
+        public void pin(final BiConsumer<TickRegionScheduler.RegionScheduleHandle, AffinitySchedulerThreadPool.TickThreadRunner> finalizer) throws CommandSyntaxException {
             // note: this is the BLOCK pos, not to be confused with the CHUNK pos
             int minX = Math.min(fromPos.x(), toPos.x());
             int minZ = Math.min(fromPos.z(), toPos.z());
@@ -126,7 +174,6 @@ public interface RegionScheduleHandlePinner {
                     final long longCoord = ((long) chunkZ << 32) | (chunkX & 0xFFFFFFFFL);
                     Ticket ticket = new Ticket(TicketType.REGION_PROFILING_HOLD, ChunkMap.FORCED_TICKET_LEVEL);
                     world.chunkSource.ticketStorage.addTicket(longCoord, ticket);
-                    PROFILING_CHUNKS.add(longCoord);
                 }
             }
 
@@ -135,15 +182,21 @@ public interface RegionScheduleHandlePinner {
 
             // load chunks and schedule finalizing
             world.canvas$loadOrRunAtChunksAsync(
-                minChunkX, minChunkZ, maxChunkX, maxChunkZ, Priority.HIGHEST, () -> {
-                    PROFILING_LEVEL.set(world); // set the level
+                // minX, maxX, minZ, maxZ
+                minChunkX, maxChunkX, minChunkZ, maxChunkZ, Priority.HIGHEST, () -> {
                     final ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region =
                         world.regioniser.getRegionAtSynchronised(minChunkX, minChunkZ);
                     if (region == null) {
                         throw new IllegalStateException("Region must be present at the profiling coordinates");
                     }
+                    if (!TickThread.isTickThreadFor(world, minChunkX, minChunkZ, maxChunkX, maxChunkZ)) {
+                        throw new IllegalStateException("Not ticking on scheduled region");
+                    }
+                    if (region != TickRegionScheduler.getCurrentRegion()) {
+                        throw new IllegalStateException("Not current region? Running region around " + region.getCenterChunk() + ", but scheduled to region owning " + getCenter());
+                    }
                     final TickRegionScheduler.RegionScheduleHandle schedulingHandle = region.getData().getRegionSchedulingHandle();
-                    final CRSThreadPool.TickThreadRunner thread = crsThreadPool.getCurrentTickThreadRunner();
+                    final AffinitySchedulerThreadPool.TickThreadRunner thread = ((AffinitySchedulerThreadPool) TickRegions.getScheduler().scheduler).getCurrentTickThreadRunner();
 
                     finalizer.accept(schedulingHandle, thread);
                 }
@@ -151,18 +204,15 @@ public interface RegionScheduleHandlePinner {
         }
 
         @Override
-        public void unpin(Consumer<SchedulableTick> finalizer, CRSThreadPool crsThreadPool) {
-            final long[] curr = PROFILING_CHUNKS.getArray();
-            final ServerLevel level = PROFILING_LEVEL.getAndSet(null);
-            if (level == null)
-                throw new IllegalStateException("World was null when attempting to end region profiling");
+        public void unpin(Consumer<SchedulableTick> finalizer) {
+            final long[] curr = gatherChunksToProfile();
 
             long packed = curr[0];
             int chunkX = (int) packed;
             int chunkZ = (int) (packed >> 32);
 
             // Note: this should be loaded already, however we run this safe version just to be sure
-            level.canvas$loadOrRunAtChunksAsync(
+            world.canvas$loadOrRunAtChunksAsync(
                 // offset by 8 to get the middle block of the chunk
                 new BlockPos((chunkX << 4) + 8, 0, (chunkZ << 4) + 8),
                 16,
@@ -178,9 +228,8 @@ public interface RegionScheduleHandlePinner {
                     // - clear PROFILING_CHUNKS
                     for (long longCoord : curr) {
                         Ticket ticket = new Ticket(TicketType.REGION_PROFILING_HOLD, ChunkMap.FORCED_TICKET_LEVEL);
-                        level.chunkSource.ticketStorage.removeTicket(longCoord, ticket);
+                        world.chunkSource.ticketStorage.removeTicket(longCoord, ticket);
                     }
-                    PROFILING_CHUNKS.clear();
                 }
             );
         }
@@ -199,9 +248,9 @@ public interface RegionScheduleHandlePinner {
      */
     class GlobalTickPinner implements RegionScheduleHandlePinner {
         @Override
-        public void pin(BiConsumer<TickRegionScheduler.RegionScheduleHandle, CRSThreadPool.TickThreadRunner> finalizer, CRSThreadPool crsThreadPool) throws CommandSyntaxException {
+        public void pin(BiConsumer<TickRegionScheduler.RegionScheduleHandle, AffinitySchedulerThreadPool.TickThreadRunner> finalizer) throws CommandSyntaxException {
             TickRegionScheduler.RegionScheduleHandle schedulingHandle = RegionizedServer.getGlobalTickData();
-            final CRSThreadPool.TickThreadRunner thread = ((CRSThreadPool.ScheduledState) schedulingHandle.state).getOwnedBy();
+            final AffinitySchedulerThreadPool.TickThreadRunner thread = ((AffinitySchedulerThreadPool) TickRegions.getScheduler().scheduler).getCurrentTickThreadRunner();
 
             if (thread == null) {
                 throw new IllegalStateException("Region scheduling handle returned null task or runner");
@@ -211,9 +260,13 @@ public interface RegionScheduleHandlePinner {
         }
 
         @Override
-        public void unpin(@NotNull Consumer<SchedulableTick> finalizer, CRSThreadPool crsThreadPool) {
+        public void unpin(@NotNull Consumer<SchedulableTick> finalizer) {
             TickRegionScheduler.RegionScheduleHandle schedulingHandle = RegionizedServer.getGlobalTickData();
-            finalizer.accept(schedulingHandle);
+            if (RegionizedServer.isGlobalTickThread()) {
+                finalizer.accept(schedulingHandle);
+            } else RegionizedServer.getInstance().addTask(() -> {
+                finalizer.accept(schedulingHandle);
+            });
         }
 
         @Override

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/SparkRegionProfilerExtension.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/SparkRegionProfilerExtension.java
@@ -2,36 +2,28 @@ package io.canvasmc.canvas.spark.profiler;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
-import com.mojang.datafixers.util.Pair;
-import io.canvasmc.canvas.util.COWLongArrayList;
-import io.canvasmc.canvas.tick.CRSThreadPool;
+import io.canvasmc.canvas.tick.AffinitySchedulerThreadPool;
+import io.canvasmc.canvas.tick.SchedulerUtil;
 import io.papermc.paper.threadedregions.RegionizedServer;
 import io.papermc.paper.threadedregions.TickRegionScheduler;
 import io.papermc.paper.threadedregions.TickRegions;
 import io.papermc.paper.util.MCUtil;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Consumer;
-import net.minecraft.server.level.ServerLevel;
 
-// TODO - wow this needs cleanup
 public class SparkRegionProfilerExtension {
-    public static final SimpleCommandExceptionType ERROR_ALREADY_PROFILING =
+    private static final SimpleCommandExceptionType ERROR_ALREADY_PROFILING =
         new SimpleCommandExceptionType(net.minecraft.network.chat.Component.literal("Server already running a region profiler!"));
-    public static final SimpleCommandExceptionType ERROR_NOT_CRS =
-        new SimpleCommandExceptionType(net.minecraft.network.chat.Component.literal("Region Specific Profiling(RSP) is unavailable during this runtime due to the requirement of using the CRS scheduler. Please change your scheduler configuration in paper-global to \"CRS\" to enable RSP"));
-    public static final SimpleCommandExceptionType ERROR_NOT_SUPPORTED =
-        new SimpleCommandExceptionType(net.minecraft.network.chat.Component.literal("Region Specific Profiling(RSP) is unavailable during this runtime due to the CRS scheduler not supporting pinning at this time. Too little threads allocated?"));
-    public static final SimpleCommandExceptionType ERROR_NOT_PROFILING =
+    private static final SimpleCommandExceptionType ERROR_NOT_PROFILING =
         new SimpleCommandExceptionType(net.minecraft.network.chat.Component.literal("Server isn't running a region profile currently!"));
-    public static final AtomicReference<CRSThreadPool.TickThreadRunner> TRACKING_THREAD = new AtomicReference<>();
-    public static final AtomicReference<RegionScheduleHandlePinner> CURRENT_PINNER = new AtomicReference<>();
-    /**
-     * This is purely for Spark to fetch region
-     * information and tick information during profiling
-     * Its more of a temporary storage than anything
-     */
-    public static final AtomicReference<Pair<ServerLevel, COWLongArrayList>> PROFILING_RESULTS_CACHE = new AtomicReference<>();
-    public static final AtomicReference<TickRegionScheduler.RegionScheduleHandle> SCHEDULE_HANDLE_CACHE = new AtomicReference<>();
+    private static final SimpleCommandExceptionType ERROR_NOT_SUPPORTED =
+        new SimpleCommandExceptionType(net.minecraft.network.chat.Component.literal("Region Specific Profiling(RSP) is unavailable during this runtime due to the active scheduler not supporting pinning at this time."));
+
+    public static final AtomicReference<ProfilingState> STATE = new AtomicReference<>();
+
+    public static boolean isProfiling() {
+        return STATE.get() != null;
+    }
 
     /**
      * Ends pinning of the currently profiling region
@@ -45,15 +37,11 @@ public class SparkRegionProfilerExtension {
         Consumer<String> sendFailure,
         Runnable unpinCallback
     ) {
-        if (!(TickRegions.getScheduler().scheduler instanceof CRSThreadPool crsScheduler)) {
-            sendFailure.accept(ERROR_NOT_CRS.create().getRawMessage().getString());
-            return;
-        }
-        if (!crsScheduler.doesSupportPinning()) {
+        if (!SchedulerUtil.doesSupportRegionProfiler()) {
             sendFailure.accept(ERROR_NOT_SUPPORTED.create().getRawMessage().getString());
             return;
         }
-        if (TRACKING_THREAD.get() == null) {
+        if (!isProfiling()) {
             // we aren't profiling, don't bother canceling
             sendFailure.accept(ERROR_NOT_PROFILING.create().getRawMessage().getString());
             return;
@@ -64,12 +52,11 @@ public class SparkRegionProfilerExtension {
         unpinCallback.run();
         RegionizedServer.getInstance().addTask(() -> {
             try {
-                CURRENT_PINNER.getAndSet(null).unpin((scheduleHandle) -> {
-                    TRACKING_THREAD.set(null); // clear tracking thread
-                    ((CRSThreadPool.ScheduledState) scheduleHandle.state).unpin(crsScheduler);
-                    PROFILING_RESULTS_CACHE.set(null);
-                    SCHEDULE_HANDLE_CACHE.set(null);
-                }, crsScheduler);
+                STATE.getAndSet(null).handlePinner.unpin((scheduleHandle) -> {
+                    AffinitySchedulerThreadPool.TickThreadRunner threadRunner = ((AffinitySchedulerThreadPool) TickRegions.getScheduler().scheduler).getCurrentTickThreadRunner();
+                    threadRunner.unlink();
+                    sendMessage.accept("Completed profiler unpin and cleared state");
+                });
             } catch (CommandSyntaxException ex) {
                 sendFailure.accept(ex.getRawMessage().getString());
             }
@@ -90,34 +77,34 @@ public class SparkRegionProfilerExtension {
         RegionScheduleHandlePinner pinner,
         Runnable pinCallback
     ) {
-        if (!(TickRegions.getScheduler().scheduler instanceof CRSThreadPool crsScheduler)) {
-            sendFailure.accept(ERROR_NOT_CRS.create().getRawMessage().getString());
-            return;
-        }
-        if (!crsScheduler.doesSupportPinning()) {
+        if (!SchedulerUtil.doesSupportRegionProfiler()) {
             sendFailure.accept(ERROR_NOT_SUPPORTED.create().getRawMessage().getString());
             return;
         }
         RegionizedServer.getInstance().addTask(() -> {
             try {
-                if (TRACKING_THREAD.get() != null) {
+                if (isProfiling()) {
                     // we are already profiling, don't do another one
                     throw ERROR_ALREADY_PROFILING.create();
                 }
                 sendMessage.accept("Beginning region schedule handle pin with '" + pinner.getClass().getSimpleName() + "'");
                 pinner.pin((schedulingHandle, thread) -> {
                     // pin the actual region tick to the runner
-                    TRACKING_THREAD.set(thread);
-                    ((CRSThreadPool.ScheduledState) schedulingHandle.state).pin(thread.id, crsScheduler);
+                    STATE.set(new ProfilingState(schedulingHandle, pinner, thread));
+                    thread.link((AffinitySchedulerThreadPool.ScheduledState) schedulingHandle.state, false);
                     sendMessage.accept("Completed scheduler setup for region pin profiling");
-                    CURRENT_PINNER.set(pinner);
-                    SCHEDULE_HANDLE_CACHE.set(schedulingHandle);
                     // schedule async, since spark runs its operations in this pool
                     MCUtil.scheduleAsyncTask(pinCallback);
-                }, crsScheduler);
+                });
             } catch (CommandSyntaxException ex) {
                 sendFailure.accept(ex.getRawMessage().getString());
             }
         });
     }
+
+    public record ProfilingState(
+        TickRegionScheduler.RegionScheduleHandle regionScheduleHandle,
+        RegionScheduleHandlePinner handlePinner,
+        AffinitySchedulerThreadPool.TickThreadRunner threadRunner
+    ) {}
 }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/package-info.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/package-info.java
@@ -74,7 +74,7 @@
  * Splits introduce complexity. Given chunks can be loaded and unloaded, the area being
  * profiled is kept loaded. This means we can encounter splits, however they can also
  * happen for a wide number of other reasons. So, we store the chunks being profiled in
- * {@link io.canvasmc.canvas.spark.profiler.RegionScheduleHandlePinner.RegionPinner#PROFILING_CHUNKS}, so when a split occurs we can mark the region
+ * {@link io.canvasmc.canvas.spark.profiler.RegionScheduleHandlePinner.RegionPinner#gatherChunksToProfile()}, so when a split occurs we can mark the region
  * with those chunks as the one needing to be pinned. The original one will be unpinned,
  * and profiling will continue as normal.
  * </p>
@@ -125,7 +125,7 @@
  * <p>
  * Utilizing our spark plugin internals, we create an interchangeable system that swaps
  * between REGEX pattern-based matching and thread name matching, since
- * {@link io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension#TRACKING_THREAD} can provide us with the {@link io.canvasmc.canvas.tick.CRSThreadPool.TickThreadRunner}
+ * {@link io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension#STATE} can provide us with the {@link io.canvasmc.canvas.tick.AffinitySchedulerThreadPool.TickThreadRunner}
  * we are actively profiling. When there are no regions pinned, the system defaults to
  * the standard REGEX pattern, {@code "Region Scheduler Thread #\d+"}.
  * </p>

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
@@ -7,9 +7,11 @@ import ca.spottedleaf.concurrentutil.util.ConcurrentUtil;
 import ca.spottedleaf.concurrentutil.util.TimeUtil;
 import io.canvasmc.canvas.Config;
 import io.canvasmc.canvas.util.CpuTopology;
+import io.canvasmc.canvas.util.queue.FastHeapPriorityQueue;
 import net.openhft.affinity.Affinity;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
 import java.lang.invoke.VarHandle;
 import java.time.Duration;
 import java.util.ArrayList;
@@ -56,17 +58,20 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
     private final TickThreadRunner[] runners;
     private final Thread[] threads;
     private final LinkedSortedSet<ScheduledState> awaiting = new LinkedSortedSet<>(TICK_COMPARATOR_BY_TIME);
-    private final TickPriorityQueue<ScheduledState> queued = new TickPriorityQueue<>(100, TICK_COMPARATOR_BY_TIME, ScheduledState.class);
+    private final FastHeapPriorityQueue<ScheduledState> globalQueue = new FastHeapPriorityQueue<>(100, TICK_COMPARATOR_BY_TIME, ScheduledState.class);
     private final BitSet idleThreads;
 
     private final Object scheduleLock = new Object();
     private final long runTaskBuff;
+    private final long stealThresh;
     private final BooleanSupplier linkingSupported;
 
     private volatile boolean halted;
+    private int nextSteal = 0;
 
-    public AffinitySchedulerThreadPool(final int threads, final ThreadFactory threadFactory, long runTaskBuff, BooleanSupplier linkingSupported) {
+    public AffinitySchedulerThreadPool(final int threads, final ThreadFactory threadFactory, long runTaskBuff, long stealThresh, BooleanSupplier linkingSupported) {
         this.runTaskBuff = runTaskBuff;
+        this.stealThresh = stealThresh;
         this.linkingSupported = linkingSupported;
         final BitSet idleThreads = new BitSet(threads);
         for (int i = 0; i < threads; ++i) {
@@ -132,10 +137,6 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
             })
             .forEach(affinitySet::set);
         return affinitySet;
-    }
-
-    public BooleanSupplier getLinkingSupported() {
-        return linkingSupported;
     }
 
     public void start() {
@@ -233,6 +234,66 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
         return ret.toArray(new Thread[0]);
     }
 
+    public @Nullable ScheduledState poll(final @NonNull TickThreadRunner runner) {
+        final long now = System.nanoTime();
+
+        ScheduledState globalHead = globalQueue.peek();
+        ScheduledState localHead = runner.localQueue.peek();
+
+        if (globalHead != null && globalHead == localHead) {
+            throw new IllegalStateException("Global queue and local queue contain same element");
+        } else {
+            // if local is overdue at all, just use that, we shouldn't be
+            // trying to take others if it is overdue already
+            if (localHead != null && localHead.isOverdue(now)) {
+                return runner.localQueue.poll();
+            }
+            // try the same thing before, but with global head
+            if (globalHead != null && globalHead.isOverdue(now)) {
+                return globalQueue.poll();
+            }
+        }
+
+        ScheduledState best = null;
+        boolean bestIsLocal = false;
+
+        if (localHead != null && globalHead != null) {
+            if (TICK_COMPARATOR_BY_TIME.compare(localHead, globalHead) <= 0) {
+                best = localHead;
+                bestIsLocal = true;
+            } else {
+                best = globalHead;
+            }
+        } else if (localHead != null) {
+            best = localHead;
+            bestIsLocal = true;
+        } else if (globalHead != null) {
+            best = globalHead;
+        }
+
+        if (nextSteal >= runners.length) {
+            nextSteal = 0;
+        }
+
+        final TickThreadRunner stealingFrom = runners[nextSteal++];
+
+        if (stealingFrom != runner) {
+            final ScheduledState stealCandidate = stealingFrom.localQueue.peek();
+            if (stealCandidate != null && stealCandidate.isStealable(now)) {
+                if (best == null ||
+                    TICK_COMPARATOR_BY_TIME.compare(stealCandidate, best) < 0) {
+                    return stealingFrom.localQueue.poll();
+                }
+            }
+        }
+
+        if (best != null) {
+            return bestIsLocal ? runner.localQueue.poll() : globalQueue.poll();
+        }
+
+        return null;
+    }
+
     private void insertFresh(final ScheduledState task) {
         final TickThreadRunner[] runners = this.runners;
 
@@ -250,7 +311,7 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
         }
 
         // add to queue, will be picked up later
-        this.queued.offer(task);
+        this.globalQueue.offer(task);
     }
 
     private void takeTask(final @NonNull ScheduledState tick) {
@@ -264,11 +325,11 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
         if (reschedule != null) {
             // we don't wanna send this to the queue if linked
             if (runner.linked == null || runner.linked != reschedule) {
-                this.queued.offer(reschedule);
+                runner.localQueue.offer(reschedule);
             }
         }
         // if linked, return that, don't even bother polling
-        final ScheduledState ret = runner.linked != null ? runner.linked : this.queued.poll();
+        final ScheduledState ret = runner.linked != null ? runner.linked : this.poll(runner);
         if (ret == null && runner.linked == null) {
             this.idleThreads.set(runner.id);
         } else {
@@ -303,6 +364,7 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
 
     @Override
     public void notifyTasks(final @NonNull SchedulableTick task) {
+        if (task.state == null) return;
         ((ScheduledState) task.state).markedWithTasks.set(true);
     }
 
@@ -343,6 +405,15 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
         private boolean isScheduled() {
             return this.scheduled.get() == SCHEDULE_STATE_SCHEDULED;
         }
+
+        // this ignores steal threshold
+        public boolean isOverdue(long nanos) {
+            return (this.tick.getScheduledStart() - nanos) <= 0L;
+        }
+
+        public boolean isStealable(long nanos) {
+            return (this.tick.getScheduledStart() - nanos) + schedulerOwnedBy.stealThresh <= 0L;
+        }
     }
 
     public static final class TickThreadRunner implements Runnable {
@@ -379,6 +450,7 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
         private volatile TickThreadRunnerState state = new TickThreadRunnerState(null, STATE_IDLE);
         private static final VarHandle STATE_HANDLE = ConcurrentUtil.getVarHandle(TickThreadRunner.class, "state", TickThreadRunnerState.class);
 
+        private final FastHeapPriorityQueue<ScheduledState> localQueue = new FastHeapPriorityQueue<>(20, TICK_COMPARATOR_BY_TIME, ScheduledState.class);
         private volatile ScheduledState linked;
 
         // if swapping, the one we are swapping with must be unscheduled
@@ -390,7 +462,7 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
                 if (task.ownedBy != this && !isSwapping) {
                     throw new IllegalStateException("Cannot link task not owned by runner(" + this + "), owned by (" + task.ownedBy + ")");
                 }
-                if (task.awaitingLink != null || scheduler.queued.contains(task)) {
+                if (task.awaitingLink != null) {
                     throw new IllegalStateException("Cannot link queued/awaiting task");
                 }
                 if (this.linked != null) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
@@ -5,6 +5,9 @@ import ca.spottedleaf.concurrentutil.scheduler.Scheduler;
 import ca.spottedleaf.concurrentutil.set.LinkedSortedSet;
 import ca.spottedleaf.concurrentutil.util.ConcurrentUtil;
 import ca.spottedleaf.concurrentutil.util.TimeUtil;
+import io.canvasmc.canvas.Config;
+import io.canvasmc.canvas.util.CpuTopology;
+import net.openhft.affinity.Affinity;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NonNull;
 import java.lang.invoke.VarHandle;
@@ -19,6 +22,8 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
 import java.util.function.BooleanSupplier;
+
+import static io.canvasmc.canvas.Config.LOGGER;
 
 /**
  * Scheduler thread pool implementation that uses EDF scheduling, based off {@link ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool}
@@ -69,15 +74,64 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
         }
         this.idleThreads = idleThreads;
 
+        final BitSet affinitySet;
+        if (Config.INSTANCE.scheduler.enableAffinitySchedulerCpuAffinity) {
+            if (!CpuTopology.isLinux()) {
+                LOGGER.warn("Affinity setting is only supported on Linux");
+                affinitySet = new BitSet();
+            }
+            else {
+                affinitySet = getAffinity(Config.INSTANCE.scheduler.tickRegionAffinity);
+            }
+        }
+        else affinitySet = new BitSet();
+        if (!affinitySet.isEmpty()) {
+            if (affinitySet.cardinality() < threads) throw new IllegalArgumentException("Affinity setting needs 1 allocated core per tick thread");
+            LOGGER.info("Affinity scheduler now bound to: {}", affinitySet);
+        }
+
         final TickThreadRunner[] runners = new TickThreadRunner[threads];
         final Thread[] t = new Thread[threads];
         for (int i = 0; i < threads; ++i) {
-            runners[i] = new TickThreadRunner(i, this);
+            int cpuId = affinitySet.isEmpty() ? -1 : affinitySet.nextSetBit(0);
+            if (cpuId != -1) affinitySet.clear(cpuId);
+            runners[i] = new TickThreadRunner(i, this, cpuId);
             t[i] = threadFactory.newThread(runners[i]);
         }
 
         this.threads = t;
         this.runners = runners;
+    }
+
+    private @NonNull BitSet getAffinity(@NonNull List<String> affinity) {
+        if (affinity.isEmpty()) {
+            LOGGER.warn("No affinity set configured, backing off, logging CPU topology:\n{}", CpuTopology.compileOutput());
+            return new BitSet();
+        }
+        int maxAvailable = Runtime.getRuntime().availableProcessors();
+        BitSet affinitySet = new BitSet(affinity.size());
+        affinity.stream()
+            .mapToInt(str -> {
+                try {
+                    return Integer.parseInt(str);
+                } catch (NumberFormatException ignored) {
+                    LOGGER.error("Unable to parse cpu id {} to a valid number, falling back to 0.", str);
+                    return -1;
+                }
+            })
+            .distinct()
+            .filter(cpuId -> {
+                // don't log parse error cpus
+                if (cpuId == -1) return false;
+                if (cpuId >= 0 && cpuId < maxAvailable) {
+                    return true;
+                } else {
+                    LOGGER.error("Invalid cpu id {}, ignoring.", cpuId);
+                    return false;
+                }
+            })
+            .forEach(affinitySet::set);
+        return affinitySet;
     }
 
     public BooleanSupplier getLinkingSupported() {
@@ -319,6 +373,7 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
 
         public final int id;
         public final AffinitySchedulerThreadPool scheduler;
+        private final int affinity;
 
         private volatile Thread thread;
         private volatile TickThreadRunnerState state = new TickThreadRunnerState(null, STATE_IDLE);
@@ -378,9 +433,10 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
 
         private static record TickThreadRunnerState(ScheduledState stateTarget, int state) {}
 
-        public TickThreadRunner(final int id, final AffinitySchedulerThreadPool scheduler) {
+        public TickThreadRunner(final int id, final AffinitySchedulerThreadPool scheduler, final int affinity) {
             this.id = id;
             this.scheduler = scheduler;
+            this.affinity = affinity;
         }
 
         public Thread getRunnerThread() {
@@ -460,6 +516,10 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
         @Override
         public void run() {
             this.thread = Thread.currentThread();
+            if (affinity != -1) {
+                Affinity.setAffinity(affinity);
+                LOGGER.debug("{} bound to CPU {}", this, affinity);
+            }
 
             main_state_loop:
             for (;;) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
@@ -1,0 +1,558 @@
+package io.canvasmc.canvas.tick;
+
+import ca.spottedleaf.concurrentutil.scheduler.SchedulableTick;
+import ca.spottedleaf.concurrentutil.scheduler.Scheduler;
+import ca.spottedleaf.concurrentutil.set.LinkedSortedSet;
+import ca.spottedleaf.concurrentutil.util.ConcurrentUtil;
+import ca.spottedleaf.concurrentutil.util.TimeUtil;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.NonNull;
+import java.lang.invoke.VarHandle;
+import java.time.Duration;
+import java.util.ArrayList;
+import java.util.BitSet;
+import java.util.Comparator;
+import java.util.List;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.locks.LockSupport;
+import java.util.function.BooleanSupplier;
+
+/**
+ * Scheduler thread pool implementation that uses EDF scheduling, based off {@link ca.spottedleaf.concurrentutil.scheduler.EDFSchedulerThreadPool}
+ * <p>
+ *     Intermediate task execution is supported in this scheduler.
+ * </p>
+ * <p>
+ *     NUMA aware scheduling is not supported in this scheduler.
+ * </p>
+ * <p>
+ *     CPU affinity is supported in this scheduler
+ * </p>
+ * @author dueris, spottedleaf
+ */
+public final class AffinitySchedulerThreadPool extends Scheduler {
+
+    private static final Comparator<ScheduledState> TICK_COMPARATOR_BY_TIME = (final ScheduledState s1, final ScheduledState s2) -> {
+        final SchedulableTick t1 = s1.tick;
+        final SchedulableTick t2 = s2.tick;
+
+        final int timeCompare = TimeUtil.compareTimes(t1.scheduledStart, t2.scheduledStart);
+        if (timeCompare != 0) {
+            return timeCompare;
+        }
+
+        // compare these if the start time comparison returns 0
+        return Long.compare(t1.id, t2.id);
+    };
+
+    private final TickThreadRunner[] runners;
+    private final Thread[] threads;
+    private final LinkedSortedSet<ScheduledState> awaiting = new LinkedSortedSet<>(TICK_COMPARATOR_BY_TIME);
+    private final TickPriorityQueue<ScheduledState> queued = new TickPriorityQueue<>(100, TICK_COMPARATOR_BY_TIME, ScheduledState.class);
+    private final BitSet idleThreads;
+
+    private final Object scheduleLock = new Object();
+    private final long runTaskBuff;
+    private final BooleanSupplier linkingSupported;
+
+    private volatile boolean halted;
+
+    public AffinitySchedulerThreadPool(final int threads, final ThreadFactory threadFactory, long runTaskBuff, BooleanSupplier linkingSupported) {
+        this.runTaskBuff = runTaskBuff;
+        this.linkingSupported = linkingSupported;
+        final BitSet idleThreads = new BitSet(threads);
+        for (int i = 0; i < threads; ++i) {
+            idleThreads.set(i);
+        }
+        this.idleThreads = idleThreads;
+
+        final TickThreadRunner[] runners = new TickThreadRunner[threads];
+        final Thread[] t = new Thread[threads];
+        for (int i = 0; i < threads; ++i) {
+            runners[i] = new TickThreadRunner(i, this);
+            t[i] = threadFactory.newThread(runners[i]);
+        }
+
+        this.threads = t;
+        this.runners = runners;
+    }
+
+    public BooleanSupplier getLinkingSupported() {
+        return linkingSupported;
+    }
+
+    public void start() {
+        for (final Thread thread : this.threads) {
+            thread.start();
+        }
+    }
+
+    public @NonNull TickThreadRunner getCurrentTickThreadRunner() {
+        Thread curr = Thread.currentThread();
+        for (final TickThreadRunner runner : this.runners) {
+            if (runner.thread == curr) {
+                return runner;
+            }
+        }
+        throw new IllegalStateException("Couldn't locate current tick thread runner");
+    }
+
+    @Override
+    public void halt() {
+        this.halted = true;
+        for (final Thread thread : this.threads) {
+            // force response to halt
+            LockSupport.unpark(thread);
+        }
+    }
+
+    @Override
+    public boolean join(final long msToWait) {
+        try {
+            return this.join(msToWait, false);
+        } catch (final InterruptedException ex) {
+            throw new IllegalStateException(ex);
+        }
+    }
+
+    @Override
+    public boolean joinInterruptable(final long msToWait) throws InterruptedException {
+        return this.join(msToWait, true);
+    }
+
+    private boolean join(final long msToWait, final boolean interruptable) throws InterruptedException {
+        final long nsToWait = TimeUnit.MILLISECONDS.toNanos(msToWait);
+        final long start = System.nanoTime();
+        final long deadline = start + nsToWait;
+        boolean interrupted = false;
+        try {
+            for (final Thread thread : this.threads) {
+                while (thread.isAlive()) {
+                    try {
+                        if (msToWait > 0L) {
+                            final long current = System.nanoTime();
+                            if (current - deadline >= 0L) {
+                                return false;
+                            }
+                            thread.join(Duration.ofNanos(deadline - current));
+                        } else {
+                            thread.join();
+                        }
+                    } catch (final InterruptedException ex) {
+                        if (interruptable) {
+                            throw ex;
+                        }
+                        interrupted = true;
+                    }
+                }
+            }
+
+            return true;
+        } finally {
+            if (interrupted) {
+                Thread.currentThread().interrupt();
+            }
+        }
+    }
+
+    public Thread[] getThreads() {
+        return this.threads.clone();
+    }
+
+    @Override
+    public Thread[] getCoreThreads() {
+        return this.getThreads();
+    }
+
+    @Override
+    public Thread @NonNull [] getAliveThreads() {
+        final List<Thread> ret = new ArrayList<>(this.threads.length);
+        for (final Thread thread : this.threads) {
+            if (thread.isAlive()) {
+                ret.add(thread);
+            }
+        }
+
+        return ret.toArray(new Thread[0]);
+    }
+
+    private void insertFresh(final ScheduledState task) {
+        final TickThreadRunner[] runners = this.runners;
+
+        final int firstIdleThread = this.idleThreads.nextSetBit(0);
+
+        if (firstIdleThread != -1) {
+            final TickThreadRunner runner = runners[firstIdleThread];
+            if (runner.linked == null) {
+                // push to idle thread
+                this.idleThreads.clear(firstIdleThread);
+                task.awaitingLink = this.awaiting.addLast(task);
+                runner.acceptTask(task);
+                return;
+            }
+        }
+
+        // add to queue, will be picked up later
+        this.queued.offer(task);
+    }
+
+    private void takeTask(final @NonNull ScheduledState tick) {
+        if (!this.awaiting.remove(tick.awaitingLink)) {
+            throw new IllegalStateException("Task is not in awaiting");
+        }
+        tick.awaitingLink = null;
+    }
+
+    private ScheduledState returnTask(final TickThreadRunner runner, final ScheduledState reschedule) {
+        if (reschedule != null) {
+            // we don't wanna send this to the queue if linked
+            if (runner.linked == null || runner.linked != reschedule) {
+                this.queued.offer(reschedule);
+            }
+        }
+        // if linked, return that, don't even bother polling
+        final ScheduledState ret = runner.linked != null ? runner.linked : this.queued.poll();
+        if (ret == null && runner.linked == null) {
+            this.idleThreads.set(runner.id);
+        } else {
+            ret.awaitingLink = this.awaiting.addLast(ret);
+        }
+
+        return ret;
+    }
+
+    @Override
+    public void schedule(final SchedulableTick task) {
+        synchronized (this.scheduleLock) {
+            final ScheduledState state = new ScheduledState(task);
+            if (!task.setState(state)) {
+                throw new IllegalStateException("Task " + task + " is already scheduled or cancelled");
+            }
+
+            if (!state.tryMarkScheduled()) {
+                throw new IllegalStateException();
+            }
+
+            state.schedulerOwnedBy = this;
+
+            this.insertFresh(state);
+        }
+    }
+
+    @Override
+    public boolean cancel(final @NonNull SchedulableTick task) {
+        throw new UnsupportedOperationException("Unsupported in AFFINITY Scheduler");
+    }
+
+    @Override
+    public void notifyTasks(final @NonNull SchedulableTick task) {
+        ((ScheduledState) task.state).markedWithTasks.set(true);
+    }
+
+    public static final class ScheduledState {
+        private final SchedulableTick tick;
+
+        private static final int SCHEDULE_STATE_NOT_SCHEDULED = 0;
+        private static final int SCHEDULE_STATE_SCHEDULED = 1;
+        private static final int SCHEDULE_STATE_CANCELLED = 2;
+
+        private final AtomicInteger scheduled = new AtomicInteger();
+        private AffinitySchedulerThreadPool schedulerOwnedBy;
+        private TickThreadRunner ownedBy;
+        private final AtomicBoolean markedWithTasks = new AtomicBoolean(false);
+
+        public boolean compareHasTasks() {
+            if (markedWithTasks.get()) {
+                markedWithTasks.set(false);
+                return true;
+            }
+            return tick.hasTasks();
+        }
+
+        private LinkedSortedSet.Link<ScheduledState> awaitingLink;
+
+        private ScheduledState(final SchedulableTick tick) {
+            this.tick = tick;
+        }
+
+        private boolean tryMarkScheduled() {
+            return this.scheduled.compareAndSet(SCHEDULE_STATE_NOT_SCHEDULED, SCHEDULE_STATE_SCHEDULED);
+        }
+
+        private boolean tryMarkCancelled() {
+            return this.scheduled.compareAndSet(SCHEDULE_STATE_SCHEDULED, SCHEDULE_STATE_CANCELLED);
+        }
+
+        private boolean isScheduled() {
+            return this.scheduled.get() == SCHEDULE_STATE_SCHEDULED;
+        }
+    }
+
+    public static final class TickThreadRunner implements Runnable {
+
+        /**
+         * There are no tasks in this thread's runqueue, so it is parked.
+         * <p>
+         * stateTarget = null
+         * </p>
+         */
+        private static final int STATE_IDLE = 0;
+
+        /**
+         * The runner is waiting to tick a task, as it has no intermediate tasks to execute.
+         * <p>
+         * stateTarget = the task awaiting tick
+         * </p>
+         */
+        private static final int STATE_AWAITING_TICK = 1;
+
+        /**
+         * The runner is executing a tick for one of the tasks that was in its runqueue.
+         * <p>
+         * stateTarget = the task being ticked
+         * </p>
+         */
+        private static final int STATE_EXECUTING_TICK = 2;
+
+        public final int id;
+        public final AffinitySchedulerThreadPool scheduler;
+
+        private volatile Thread thread;
+        private volatile TickThreadRunnerState state = new TickThreadRunnerState(null, STATE_IDLE);
+        private static final VarHandle STATE_HANDLE = ConcurrentUtil.getVarHandle(TickThreadRunner.class, "state", TickThreadRunnerState.class);
+
+        private volatile ScheduledState linked;
+
+        // if swapping, the one we are swapping with must be unscheduled
+        public void link(final @NonNull ScheduledState task, boolean isSwapping) {
+            synchronized (scheduler.scheduleLock) {
+                if (!scheduler.linkingSupported.getAsBoolean()) {
+                    throw new IllegalStateException("Linking not supported in this environment");
+                }
+                if (task.ownedBy != this && !isSwapping) {
+                    throw new IllegalStateException("Cannot link task not owned by runner(" + this + "), owned by (" + task.ownedBy + ")");
+                }
+                if (task.awaitingLink != null || scheduler.queued.contains(task)) {
+                    throw new IllegalStateException("Cannot link queued/awaiting task");
+                }
+                if (this.linked != null) {
+                    throw new IllegalStateException("Runner already linked");
+                }
+
+                this.linked = task;
+
+                if (scheduler.idleThreads.get(id)) {
+                    scheduler.idleThreads.clear(id);
+                    task.awaitingLink = scheduler.awaiting.addLast(task);
+                    acceptTask(task);
+                }
+            }
+        }
+
+        // must be called during tick or run tasks
+        public void unlink() {
+            synchronized (scheduler.scheduleLock) {
+                this.linked = null;
+            }
+        }
+
+        @Contract(pure = true)
+        public boolean isLinkedTo(final @NonNull SchedulableTick from) {
+            return from.state instanceof ScheduledState scheduledState && scheduledState == this.linked;
+        }
+
+        private void setStatePlain(final TickThreadRunnerState state) {
+            STATE_HANDLE.set(this, state);
+        }
+
+        private void setStateOpaque(final TickThreadRunnerState state) {
+            STATE_HANDLE.setOpaque(this, state);
+        }
+
+        private void setStateVolatile(final TickThreadRunnerState state) {
+            STATE_HANDLE.setVolatile(this, state);
+        }
+
+        private static record TickThreadRunnerState(ScheduledState stateTarget, int state) {}
+
+        public TickThreadRunner(final int id, final AffinitySchedulerThreadPool scheduler) {
+            this.id = id;
+            this.scheduler = scheduler;
+        }
+
+        public Thread getRunnerThread() {
+            return this.thread;
+        }
+
+        private void acceptTask(final @NonNull ScheduledState task) {
+            if (task.ownedBy != null) {
+                throw new IllegalStateException("Already owned by another runner");
+            }
+            task.ownedBy = this;
+            final TickThreadRunnerState state = this.state;
+            if (state.state != STATE_IDLE) {
+                throw new IllegalStateException("Cannot accept task in state " + state);
+            }
+            this.setStateVolatile(new TickThreadRunnerState(task, STATE_AWAITING_TICK));
+            LockSupport.unpark(this.getRunnerThread());
+        }
+
+        private void replaceTask(final ScheduledState task) {
+            final TickThreadRunnerState state = this.state;
+            if (state.state != STATE_AWAITING_TICK) {
+                throw new IllegalStateException("Cannot replace task in state " + state);
+            }
+            if (task.ownedBy != null) {
+                throw new IllegalStateException("Already owned by another runner");
+            }
+            if (this.linked != null) {
+                throw new IllegalStateException("Cannot replace task with linked runner");
+            }
+            task.ownedBy = this;
+
+            state.stateTarget.ownedBy = null;
+
+            this.setStateVolatile(new TickThreadRunnerState(task, STATE_AWAITING_TICK));
+            LockSupport.unpark(this.getRunnerThread());
+        }
+
+        private void forceIdle() {
+            final TickThreadRunnerState state = this.state;
+            if (state.state != STATE_AWAITING_TICK) {
+                throw new IllegalStateException("Cannot replace task in state " + state);
+            }
+            state.stateTarget.ownedBy = null;
+            this.setStateOpaque(new TickThreadRunnerState(null, STATE_IDLE));
+            // no need to unpark
+        }
+
+        private boolean takeTask(final TickThreadRunnerState state, final ScheduledState task) {
+            synchronized (this.scheduler.scheduleLock) {
+                if (this.state != state) {
+                    return false;
+                }
+                this.setStatePlain(new TickThreadRunnerState(task, STATE_EXECUTING_TICK));
+                this.scheduler.takeTask(task);
+                return true;
+            }
+        }
+
+        private void returnTask(final @NonNull ScheduledState task, final boolean reschedule) {
+            synchronized (this.scheduler.scheduleLock) {
+                task.ownedBy = null;
+
+                final ScheduledState newWait = this.scheduler.returnTask(this, reschedule && task.isScheduled() ? task : null);
+                if (newWait == null) {
+                    this.setStatePlain(new TickThreadRunnerState(null, STATE_IDLE));
+                } else {
+                    if (newWait.ownedBy != null) {
+                        throw new IllegalStateException("Already owned by another runner");
+                    }
+                    newWait.ownedBy = this;
+                    this.setStatePlain(new TickThreadRunnerState(newWait, STATE_AWAITING_TICK));
+                }
+            }
+        }
+
+        @Override
+        public void run() {
+            this.thread = Thread.currentThread();
+
+            main_state_loop:
+            for (;;) {
+                final TickThreadRunnerState startState = this.state;
+                final int startStateType = startState.state;
+                final ScheduledState startStateTask =  startState.stateTarget;
+
+                if (this.scheduler.halted) {
+                    return;
+                }
+
+                switch (startStateType) {
+                    case STATE_IDLE: {
+                        while (this.state.state == STATE_IDLE) {
+                            Thread.interrupted();
+                            LockSupport.park();
+                            if (this.scheduler.halted) {
+                                return;
+                            }
+                        }
+                        continue main_state_loop;
+                    }
+
+                    case STATE_AWAITING_TICK: {
+                        final long deadline = startStateTask.tick.getScheduledStart();
+
+                        for (; ; ) {
+                            if (this.state != startState) {
+                                continue main_state_loop;
+                            }
+                            final long diff = deadline - System.nanoTime();
+                            if (diff <= 0L) {
+                                break;
+                            }
+                            // we are parking, which is fine, however, we
+                            // CAN do mid-tick tasks here instead, which makes us
+                            // much more productive
+                            if ((diff > scheduler.runTaskBuff) && // if we are less than the buffer, then don't try run mid-tick-tasks
+                                (startStateTask.compareHasTasks() || startStateTask.tick.hasTasks())) {
+                                // try and take the tick task like it's a normal tick
+                                if (!this.takeTask(startState, startStateTask)) {
+                                    // just park like normal, couldn't take task
+                                    LockSupport.parkNanos(startState, diff);
+                                    continue; // done parking, or we got woken up, so we continue so it loops back to check the diff
+                                }
+                                // task is taken, wonderful
+                                final long bufferedDeadline = deadline - scheduler.runTaskBuff;
+                                final boolean taskRes = startStateTask.tick.runTasks(
+                                    () -> !scheduler.halted && (bufferedDeadline - System.nanoTime()) <= 0L
+                                );
+                                // return the task to the global queue. we will try and take it later(if rescheduled), which CAN be picked up
+                                // by a different thread, but if that does happen, it doesn't entirely matter
+                                this.returnTask(startStateTask, taskRes);
+                                // either this was rescheduled, which means it won't run on the next tick,
+                                // or it finished all tasks, and we reloop again. we return to the main state loop,
+                                // though in the case of the tick being picked up by a different thread
+                                continue main_state_loop;
+                            }
+                            LockSupport.parkNanos(startState, diff);
+                            if (scheduler.halted) {
+                                return;
+                            }
+                        }
+
+                        if (!this.takeTask(startState, startStateTask)) {
+                            // couldn't take task, continue loop
+                            continue main_state_loop;
+                        }
+
+                        try {
+                            final boolean reschedule = startStateTask.tick.runTick();
+                            this.returnTask(startStateTask, reschedule);
+                        } catch (Exception e) {
+                            throw new RuntimeException("Unable to tick task", e);
+                        }
+
+                        continue main_state_loop; // finished tick, continue
+                    }
+
+                    case STATE_EXECUTING_TICK: {
+                        throw new IllegalStateException("Tick execution must be set by runner thread, not by any other thread");
+                    }
+
+                    default: {
+                        throw new IllegalStateException("Unknown state: " + startState);
+                    }
+                }
+            }
+        }
+
+        @Override
+        public String toString() {
+            return "AffinityRunner#" + id;
+        }
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
@@ -84,7 +84,7 @@ public class SchedulerUtil {
 
         boolean isRunningRegionProfilerOnThread(final long threadId, final String threadName);
 
-        void tryTransferPinningState(TickRegionScheduler.@NonNull RegionScheduleHandle ret, TickRegionScheduler.RegionScheduleHandle to);
+        void tryTransferPinningState(TickRegionScheduler.@NonNull RegionScheduleHandle from, TickRegionScheduler.RegionScheduleHandle to);
 
         void onRegionMerge(TickRegions.TickRegionData from, TickRegions.TickRegionData to, ServerLevel world);
 
@@ -107,7 +107,7 @@ public class SchedulerUtil {
         }
 
         @Override
-        public void tryTransferPinningState(final TickRegionScheduler.@NonNull RegionScheduleHandle ret, final TickRegionScheduler.RegionScheduleHandle to) {
+        public void tryTransferPinningState(final TickRegionScheduler.@NonNull RegionScheduleHandle from, final TickRegionScheduler.RegionScheduleHandle to) {
         }
 
         @Override

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
@@ -162,6 +162,9 @@ public class SchedulerUtil {
             tryTransferPinningState(from.tickHandle, to.tickHandle);
         }
 
+        // note: we can safely cast to region pinner here, since if we are linked at this point
+        //       then it wouldn't be a global tick, it would be a region tick we are profiling
+        //       because the global tick can't call split
         @Override
         public void onRegionSplit(final TickRegions.TickRegionData from, final Long2ReferenceOpenHashMap<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>> into, final ServerLevel world) {
             if (!isRunningRegionProfiler()) return;

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
@@ -8,7 +8,6 @@ import ca.spottedleaf.moonrise.common.util.MoonriseConstants;
 import io.canvasmc.canvas.Config;
 import io.canvasmc.canvas.spark.profiler.RegionScheduleHandlePinner;
 import io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension;
-import io.papermc.paper.threadedregions.RegionizedServer;
 import io.papermc.paper.threadedregions.ThreadedRegionizer;
 import io.papermc.paper.threadedregions.TickRegionScheduler;
 import io.papermc.paper.threadedregions.TickRegions;
@@ -17,8 +16,6 @@ import java.util.concurrent.ThreadFactory;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.world.level.ChunkPos;
 import org.jspecify.annotations.NonNull;
-
-import static io.canvasmc.canvas.Config.LOGGER;
 
 public class SchedulerUtil {
     private static SchedulerHandler HANDLER;
@@ -30,14 +27,29 @@ public class SchedulerUtil {
         return HANDLER;
     }
 
+    public static boolean doesSupportRegionProfiler() {
+        final Scheduler scheduler = TickRegions.getScheduler().scheduler;
+        if (scheduler instanceof AffinitySchedulerThreadPool) {
+            // if has less than 2 threads, pinning would kill the server
+            return TickRegions.getScheduler().scheduler.getCoreThreads().length >= 2;
+        }
+        return false;
+    }
+
     public static void startScheduler() {
         final Scheduler scheduler = TickRegions.getScheduler().scheduler;
         if (scheduler instanceof EDFSchedulerThreadPool edfSchedulerThreadPool) {
+            TickRegionScheduler.LOGGER.info("Starting EDF region scheduler");
             edfSchedulerThreadPool.start();
         }
-        if (scheduler instanceof CRSThreadPool crsThreadPool) {
-            crsThreadPool.start();
+        if (scheduler instanceof AffinitySchedulerThreadPool affinitySchedulerThreadPool) {
+            TickRegionScheduler.LOGGER.info("Starting AFFINITY region scheduler");
+            affinitySchedulerThreadPool.start();
         }
+        if (doesSupportRegionProfiler()) {
+            TickRegionScheduler.LOGGER.info("Region profiling marked as supported in this environment");
+        }
+        else TickRegionScheduler.LOGGER.warn("Region profiling not supported in this environment");
     }
 
     public static @NonNull Scheduler decideScheduler(final TickRegionScheduler.@NonNull SchedulerType schedulerType, final int initialThreads, final ThreadFactory threadFactory) {
@@ -54,17 +66,12 @@ public class SchedulerUtil {
                 HANDLER = new NullHandler();
                 return scheduler;
             }
-            case CRS: {
+            case AFFINITY: {
                 long runBufferNanos = (long) (Config.INSTANCE.scheduler.runTasksBufferMillis * 1_000_000L);
-                long stealThresh = Config.INSTANCE.scheduler.stealThresholdMillis * 1_000_000L;
-                CRSThreadPool scheduler = new CRSThreadPool(initialThreads, threadFactory, runBufferNanos, stealThresh);
-                // configure if we can use CRS pinning
-                if (initialThreads < 2) {
-                    LOGGER.warn("Too little threads allocated, cannot enable region profiling capabilities");
-                    scheduler.markPinningUnsupported();
-                }
-                HANDLER = new CRSHandler();
-                return scheduler;
+                HANDLER = new AffinityHandler();
+                return new AffinitySchedulerThreadPool(
+                    initialThreads, threadFactory, runBufferNanos, SchedulerUtil::doesSupportRegionProfiler
+                );
             }
             default: {
                 throw new IllegalStateException("Unknown scheduler type: " + schedulerType);
@@ -72,7 +79,7 @@ public class SchedulerUtil {
         }
     }
 
-    public interface SchedulerHandler {
+    public sealed interface SchedulerHandler permits NullHandler, AffinityHandler {
         boolean isRunningRegionProfiler();
 
         boolean isRunningRegionProfilerOnThread(final long threadId, final String threadName);
@@ -88,7 +95,7 @@ public class SchedulerUtil {
         void onRegionInactive(final ThreadedRegionizer.@NonNull ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region);
     }
 
-    public static class NullHandler implements SchedulerHandler {
+    public static final class NullHandler implements SchedulerHandler {
         @Override
         public boolean isRunningRegionProfiler() {
             return false;
@@ -120,83 +127,67 @@ public class SchedulerUtil {
         }
     }
 
-    @Deprecated(forRemoval = true)
-    public static class CRSHandler implements SchedulerHandler {
+    public static final class AffinityHandler implements SchedulerHandler {
         @Override
         public boolean isRunningRegionProfiler() {
-            if (TickRegions.getScheduler().scheduler instanceof CRSThreadPool) {
-                CRSThreadPool.TickThreadRunner threadRunner =
-                    SparkRegionProfilerExtension.TRACKING_THREAD.get();
-                return threadRunner != null;
-            }
-            return false;
+            return SparkRegionProfilerExtension.isProfiling();
         }
 
         @Override
         public boolean isRunningRegionProfilerOnThread(final long threadId, final String threadName) {
-            if (TickRegions.getScheduler().scheduler instanceof CRSThreadPool) {
-                CRSThreadPool.TickThreadRunner threadRunner =
-                    SparkRegionProfilerExtension.TRACKING_THREAD.get();
-                return threadRunner.backingThread.getName().equalsIgnoreCase(threadName);
+            if (isRunningRegionProfiler()) {
+                AffinitySchedulerThreadPool.TickThreadRunner threadRunner = SparkRegionProfilerExtension.STATE.get().threadRunner();
+                return threadRunner.getRunnerThread().getName().equalsIgnoreCase(threadName);
             }
             return false;
         }
 
         @Override
-        public void tryTransferPinningState(final TickRegionScheduler.@NonNull RegionScheduleHandle ret, final TickRegionScheduler.RegionScheduleHandle to) {
-            if (ret.state instanceof CRSThreadPool.ScheduledState crsState)
-                crsState.pin(((CRSThreadPool.ScheduledState) to.state).getPinnedThreadId(), crsState.schedulerOwnedBy);
+        public void tryTransferPinningState(final TickRegionScheduler.@NonNull RegionScheduleHandle from, final TickRegionScheduler.RegionScheduleHandle to) {
+            if (!isRunningRegionProfiler() || !(TickRegions.getScheduler().scheduler instanceof AffinitySchedulerThreadPool affinitySchedulerThreadPool)) {
+                return;
+            }
+            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = affinitySchedulerThreadPool.getCurrentTickThreadRunner();
+            // if not linked to the previous, don't try and change
+            if (!threadRunner.isLinkedTo(from)) return;
+            threadRunner.unlink();
+            threadRunner.link((AffinitySchedulerThreadPool.ScheduledState) to.state, true);
         }
 
         @Override
-        public void onRegionMerge(final TickRegions.@NonNull TickRegionData from, final TickRegions.TickRegionData to, final ServerLevel world) {
-            TickRegionScheduler.RegionScheduleHandle scheduleHandle = from.getRegionSchedulingHandle();
-            CRSThreadPool.TickThreadRunner tickThreadRunner = SparkRegionProfilerExtension.TRACKING_THREAD.get();
-            if (scheduleHandle.state != null && ((CRSThreadPool.ScheduledState) scheduleHandle.state).isPinned() && tickThreadRunner != null) {
-                ChunkPos pos = new ChunkPos(RegionScheduleHandlePinner.RegionPinner.PROFILING_CHUNKS.getArray()[0]);
-                RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
-                    world, pos.x, pos.z, () -> {
-                        ((CRSThreadPool.ScheduledState) scheduleHandle.state).unpin(tickThreadRunner.scheduler);
-                        ((CRSThreadPool.ScheduledState) TickRegionScheduler.getCurrentTickingTask().state).pin(tickThreadRunner.id, tickThreadRunner.scheduler);
-                    }
-                );
-            }
+        public void onRegionMerge(final TickRegions.TickRegionData from, final TickRegions.TickRegionData to, final ServerLevel world) {
+            if (!isRunningRegionProfiler()) return;
+            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = SparkRegionProfilerExtension.STATE.get().threadRunner();
+            if (!threadRunner.isLinkedTo(from.tickHandle)) return;
+            tryTransferPinningState(from.tickHandle, to.tickHandle);
         }
 
         @Override
-        public void onRegionSplit(final TickRegions.@NonNull TickRegionData from, final Long2ReferenceOpenHashMap<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>> into, final ServerLevel world) {
-            TickRegionScheduler.RegionScheduleHandle scheduleHandle = from.getRegionSchedulingHandle();
-            CRSThreadPool.TickThreadRunner tickThreadRunner =
-                SparkRegionProfilerExtension.TRACKING_THREAD.get();
-            if (scheduleHandle.state != null && ((CRSThreadPool.ScheduledState) scheduleHandle.state).isPinned() && tickThreadRunner != null) {
-                // a profiler IS running, ON THIS REGION, split time!!
-                // we know this is safe because if this is pinned, we have a profiling set of chunks
-                long[] curr = RegionScheduleHandlePinner.RegionPinner.PROFILING_CHUNKS.getArray();
-                ChunkPos entry0 = new ChunkPos(curr[0]);
-                RegionizedServer.getInstance().taskQueue.queueTickTaskQueue(
-                    world, entry0.x, entry0.z, () -> {
-                        ((CRSThreadPool.ScheduledState) scheduleHandle.state).unpin(tickThreadRunner.scheduler);
-                        ((CRSThreadPool.ScheduledState) TickRegionScheduler.getCurrentTickingTask().state).pin(tickThreadRunner.id, tickThreadRunner.scheduler);
-                    }
-                );
-            }
+        public void onRegionSplit(final TickRegions.TickRegionData from, final Long2ReferenceOpenHashMap<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>> into, final ServerLevel world) {
+            if (!isRunningRegionProfiler()) return;
+            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = SparkRegionProfilerExtension.STATE.get().threadRunner();
+            if (!threadRunner.isLinkedTo(from.tickHandle)) return;
+            ChunkPos center = ((RegionScheduleHandlePinner.RegionPinner) SparkRegionProfilerExtension.STATE.get().handlePinner()).getCenter();
+            tryTransferPinningState(from.tickHandle, into.get(center.longKey).getData().tickHandle);
         }
 
+        // both destroy and inactive only happen on split and merge
         @Override
         public void onRegionDestroy(final ThreadedRegionizer.@NonNull ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region) {
-            TickRegionScheduler.RegionScheduleHandle scheduleHandle = region.getData().getRegionSchedulingHandle();
-            CRSThreadPool.TickThreadRunner tickThreadRunner = SparkRegionProfilerExtension.TRACKING_THREAD.get();
-            if (tickThreadRunner != null && scheduleHandle.state != null && ((CRSThreadPool.ScheduledState) scheduleHandle.state).isPinned()) {
-                ((CRSThreadPool.ScheduledState) scheduleHandle.state).unpin(tickThreadRunner.scheduler);
-            }
+            tryDestroyLink(region);
         }
 
         @Override
         public void onRegionInactive(final ThreadedRegionizer.@NonNull ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region) {
+            tryDestroyLink(region);
+        }
+
+        private void tryDestroyLink(final ThreadedRegionizer.@NonNull ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region) {
             final TickRegions.TickRegionData data = region.getData();
-            CRSThreadPool.TickThreadRunner tickThreadRunner = SparkRegionProfilerExtension.TRACKING_THREAD.get();
-            if (tickThreadRunner != null && data.tickHandle.state != null && ((CRSThreadPool.ScheduledState) data.tickHandle.state).isPinned()) {
-                ((CRSThreadPool.ScheduledState) data.tickHandle.state).unpin(tickThreadRunner.scheduler);
+            if (!isRunningRegionProfiler()) return;
+            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = SparkRegionProfilerExtension.STATE.get().threadRunner();
+            if (data.tickHandle.state != null && threadRunner.isLinkedTo(data.tickHandle)) {
+                threadRunner.unlink();
             }
         }
     }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
@@ -68,9 +68,10 @@ public class SchedulerUtil {
             }
             case AFFINITY: {
                 long runBufferNanos = (long) (Config.INSTANCE.scheduler.runTasksBufferMillis * 1_000_000L);
+                long stealThresh = Config.INSTANCE.scheduler.stealThresholdMillis * 1_000_000L;
                 HANDLER = new AffinityHandler();
                 return new AffinitySchedulerThreadPool(
-                    initialThreads, threadFactory, runBufferNanos, SchedulerUtil::doesSupportRegionProfiler
+                    initialThreads, threadFactory, runBufferNanos, stealThresh, SchedulerUtil::doesSupportRegionProfiler
                 );
             }
             default: {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/StealingQueueSchedulerThreadPool.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/StealingQueueSchedulerThreadPool.java
@@ -11,12 +11,10 @@ import java.util.ArrayList;
 import java.util.BitSet;
 import java.util.Comparator;
 import java.util.List;
-import java.util.PriorityQueue;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
-import java.util.function.Predicate;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -26,7 +24,7 @@ import org.jspecify.annotations.Nullable;
  * that supports intermediate task execution and task pinning
  */
 @Deprecated(forRemoval = true)
-public final class CRSThreadPool extends Scheduler {
+public final class StealingQueueSchedulerThreadPool extends Scheduler {
 
     private static final Comparator<ScheduledState> TICK_COMPARATOR_BY_TIME = (final ScheduledState s1, final ScheduledState s2) -> {
         final SchedulableTick t1 = s1.tick;
@@ -60,7 +58,7 @@ public final class CRSThreadPool extends Scheduler {
      * @param threadFactory Specified thread factory
      * @see #start()
      */
-    public CRSThreadPool(final int threads, final ThreadFactory threadFactory, long runTaskBuff, long stealThresh) {
+    public StealingQueueSchedulerThreadPool(final int threads, final ThreadFactory threadFactory, long runTaskBuff, long stealThresh) {
         final BitSet idleThreads = new BitSet(threads);
         for (int i = 0; i < threads; ++i) {
             idleThreads.set(i);
@@ -329,7 +327,7 @@ public final class CRSThreadPool extends Scheduler {
 
     @Override
     public boolean cancel(final @NonNull SchedulableTick task) {
-        throw new UnsupportedOperationException("Unsupported in CRS Scheduler");
+        throw new UnsupportedOperationException("Unsupported in StealingQueue Scheduler");
     }
 
     @Override
@@ -361,7 +359,7 @@ public final class CRSThreadPool extends Scheduler {
         private static final int SCHEDULE_STATE_CANCELLED = 2;
         private final SchedulableTick tick;
         private final AtomicInteger scheduled = new AtomicInteger();
-        public CRSThreadPool schedulerOwnedBy;
+        public StealingQueueSchedulerThreadPool schedulerOwnedBy;
         private TickThreadRunner ownedBy;
         private int pinnedThreadId = PINNED_NOT_SET;
         private @Nullable Integer assocPartition = null;
@@ -421,7 +419,7 @@ public final class CRSThreadPool extends Scheduler {
             return (int) PINNED_THREAD_ID_HANDLE.getVolatile(this);
         }
 
-        public void setPinnedThreadId(final int threadId, final CRSThreadPool scheduler) {
+        public void setPinnedThreadId(final int threadId, final StealingQueueSchedulerThreadPool scheduler) {
             final int prev = (int) PINNED_THREAD_ID_HANDLE.getAndSet(this, threadId);
 
             // only update pin counts if actually changing
@@ -475,7 +473,7 @@ public final class CRSThreadPool extends Scheduler {
          *
          * @param threadId the ID of the thread to pin the task to. If the value is -1, the task will be unpinned.
          */
-        public void pin(final int threadId, final CRSThreadPool scheduler) {
+        public void pin(final int threadId, final StealingQueueSchedulerThreadPool scheduler) {
             if (threadId > scheduler.threadCount) {
                 // don't pin, this isn't a valid thread
                 return;
@@ -490,7 +488,7 @@ public final class CRSThreadPool extends Scheduler {
             this.setPinnedThreadId(threadId, scheduler);
         }
 
-        public void unpin(final CRSThreadPool scheduler) {
+        public void unpin(final StealingQueueSchedulerThreadPool scheduler) {
             this.setPinnedThreadId(PINNED_NOT_SET, scheduler);
         }
     }
@@ -524,13 +522,13 @@ public final class CRSThreadPool extends Scheduler {
         private static final VarHandle LINKED_TO_HANDLE = ConcurrentUtil.getVarHandle(TickThreadRunner.class, "linkedTo", ScheduledState.class);
         private static final VarHandle IS_PINNED_TO_HANDLE = ConcurrentUtil.getVarHandle(TickThreadRunner.class, "pinnedTasks", int.class);
         public final int id;
-        public final CRSThreadPool scheduler;
+        public final StealingQueueSchedulerThreadPool scheduler;
         public volatile Thread backingThread;
         private volatile TickThreadRunnerState state = new TickThreadRunnerState(null, STATE_IDLE);
         private volatile ScheduledState linkedTo = null;
         private int pinnedTasks = 0;
 
-        public TickThreadRunner(final int id, final CRSThreadPool scheduler) {
+        public TickThreadRunner(final int id, final StealingQueueSchedulerThreadPool scheduler) {
             this.id = id;
             this.scheduler = scheduler;
         }
@@ -733,7 +731,7 @@ public final class CRSThreadPool extends Scheduler {
 
         @Override
         public String toString() {
-            return "CRSThread-" + id;
+            return "StealingQueueThread-" + id;
         }
 
         private record TickThreadRunnerState(ScheduledState stateTarget, int state) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/StealingQueueSchedulerThreadPool.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/StealingQueueSchedulerThreadPool.java
@@ -15,6 +15,7 @@ import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.locks.LockSupport;
+import io.canvasmc.canvas.util.queue.FastHeapPriorityQueue;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
@@ -741,10 +742,10 @@ public final class StealingQueueSchedulerThreadPool extends Scheduler {
     @NullMarked
     private final class StealingQueue {
 
-        private final TickPriorityQueue<ScheduledState> queue;
+        private final FastHeapPriorityQueue<ScheduledState> queue;
 
         public StealingQueue(Comparator<ScheduledState> comparator) {
-            this.queue = new TickPriorityQueue<>(150, comparator, ScheduledState.class);
+            this.queue = new FastHeapPriorityQueue<>(150, comparator, ScheduledState.class);
         }
 
         public void add(ScheduledState state) {
@@ -757,7 +758,7 @@ public final class StealingQueueSchedulerThreadPool extends Scheduler {
         }
 
         public boolean isEmpty() {
-            return queue.size == 0;
+            return queue.size() == 0;
         }
 
         public boolean remove(ScheduledState state) {
@@ -766,7 +767,7 @@ public final class StealingQueueSchedulerThreadPool extends Scheduler {
 
         public @Nullable ScheduledState pollFor(final int partitionKey, final boolean runnerIsPinned) {
             long initialPollTimeNanos = System.nanoTime();
-            for (int i = 0; i < queue.size; i++) {
+            for (int i = 0; i < queue.size(); i++) {
                 ScheduledState element = queue.arr[i];
                 final Integer assoc = element.getPartitionKey();
                 final boolean canSteal = element.canSteal(initialPollTimeNanos);

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/TickPriorityQueue.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/TickPriorityQueue.java
@@ -1,29 +1,29 @@
 package io.canvasmc.canvas.tick;
 
+import it.unimi.dsi.fastutil.objects.ObjectArrays;
+import it.unimi.dsi.fastutil.objects.ObjectHeaps;
 import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Comparator;
-import it.unimi.dsi.fastutil.objects.ObjectArrays;
-import it.unimi.dsi.fastutil.objects.ObjectHeaps;
 
 public class TickPriorityQueue<K> {
-	protected transient K[] arr;
-	protected int size;
-	protected Comparator<? super K> c;
+    protected transient K[] arr;
+    protected int size;
+    protected Comparator<? super K> c;
 
-	@SuppressWarnings("unchecked")
-	public TickPriorityQueue(int capacity, Comparator<? super K> c, Class<K> classOf) {
+    @SuppressWarnings("unchecked")
+    public TickPriorityQueue(int capacity, Comparator<? super K> c, Class<K> classOf) {
         if (capacity <= 0) capacity = 1;
-		this.arr = (K[]) Array.newInstance(classOf, capacity);
-		this.c = c;
-	}
+        this.arr = (K[]) Array.newInstance(classOf, capacity);
+        this.c = c;
+    }
 
-	public void offer(K element) {
+    public void offer(K element) {
         if (element == null) throw new NullPointerException("Provided element cannot be null");
-		if (size == arr.length) arr = ObjectArrays.grow(arr, size + 1);
-		arr[size++] = element;
-		ObjectHeaps.upHeap(arr, size, size - 1, c);
-	}
+        if (size == arr.length) arr = ObjectArrays.grow(arr, size * 2);
+        arr[size++] = element;
+        ObjectHeaps.upHeap(arr, size, size - 1, c);
+    }
 
     public boolean remove(K element) {
         for (int i = 0; i < size; i++) {
@@ -40,34 +40,42 @@ public class TickPriorityQueue<K> {
         return false;
     }
 
-	public K poll() {
-		if (size == 0) return null;
-		final K result = arr[0];
-		arr[0] = arr[--size];
-		arr[size] = null;
-		if (size != 0) ObjectHeaps.downHeap(arr, size, 0, c);
-		return result;
-	}
+    public K poll() {
+        if (size == 0) return null;
+        final K result = arr[0];
+        arr[0] = arr[--size];
+        arr[size] = null;
+        if (size != 0) ObjectHeaps.downHeap(arr, size, 0, c);
+        return result;
+    }
 
     public K peek() {
         if (size == 0) return null;
         return arr[0];
     }
 
-	public int size() {
-		return size;
-	}
+    public int size() {
+        return size;
+    }
 
-	public void clear() {
-		Arrays.fill(arr, 0, size, null);
-		size = 0;
-	}
+    public void clear() {
+        Arrays.fill(arr, 0, size, null);
+        size = 0;
+    }
 
-	public void trim() {
-		arr = ObjectArrays.trim(arr, size);
-	}
+    public void trim() {
+        arr = ObjectArrays.trim(arr, size);
+    }
 
-	public Comparator<? super K> comparator() {
-		return c;
-	}
+    public Comparator<? super K> comparator() {
+        return c;
+    }
+
+    public boolean contains(final K element) {
+        for (int i = 0; i < size; i++) {
+            final K k = this.arr[i];
+            if (k == element) return true;
+        }
+        return false;
+    }
 }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/TickPriorityQueue.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/TickPriorityQueue.java
@@ -20,7 +20,7 @@ public class TickPriorityQueue<K> {
 
     public void offer(K element) {
         if (element == null) throw new NullPointerException("Provided element cannot be null");
-        if (size == arr.length) arr = ObjectArrays.grow(arr, size * 2);
+        if (size == arr.length) arr = ObjectArrays.grow(arr, Math.max(size * 2, 1));
         arr[size++] = element;
         ObjectHeaps.upHeap(arr, size, size - 1, c);
     }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/CpuTopology.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/CpuTopology.java
@@ -1,0 +1,88 @@
+package io.canvasmc.canvas.util;
+
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+import java.io.BufferedReader;
+import java.io.FileReader;
+import java.util.*;
+
+public class CpuTopology {
+
+    record CpuInfo(int cpu, int core, int socket, String l1d, String l1i, String l2, String l3) {}
+
+    public static boolean isLinux() {
+        return System.getProperty("os.name").toLowerCase().contains("linux");
+    }
+
+    // note: linux only
+    public static @NonNull String compileOutput() {
+        StringBuilder out = new StringBuilder();
+        List<CpuInfo> cpus = new ArrayList<>();
+        int cpuCount = Runtime.getRuntime().availableProcessors();
+
+        for (int cpu = 0; cpu < cpuCount; cpu++) {
+            int core   = readInt("/sys/devices/system/cpu/cpu" + cpu + "/topology/core_id", cpu);
+            int socket = readInt("/sys/devices/system/cpu/cpu" + cpu + "/topology/physical_package_id", 0);
+            String l1d = readCacheIndex(cpu, "Data");
+            String l1i = readCacheIndex(cpu, "Instruction");
+            String l2  = readCacheIndex(cpu, "Unified", 2);
+            String l3  = readCacheIndex(cpu, "Unified", 3);
+            cpus.add(new CpuInfo(cpu, core, socket, l1d, l1i, l2, l3));
+        }
+
+        out.append(String.format("%-5s %-6s %-7s %s%n", "CPU", "CORE", "SOCKET", "L1d:L1i:L2:L3"));
+
+        for (CpuInfo c : cpus) {
+            out.append(String.format("%-5d %-6d %-7d %s:%s:%s:%s%n",
+                c.cpu(), c.core(), c.socket(), c.l1d(), c.l1i(), c.l2(), c.l3()));
+        }
+
+        return out.toString();
+    }
+
+    private static int readInt(String path, int fallback) {
+        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
+            return Integer.parseInt(br.readLine().trim());
+        } catch (Exception e) {
+            return fallback;
+        }
+    }
+
+    private static @Nullable String readFile(String path) {
+        try (BufferedReader br = new BufferedReader(new FileReader(path))) {
+            return br.readLine().trim();
+        } catch (Exception e) {
+            return null;
+        }
+    }
+
+    private static @NonNull String readCacheIndex(int cpu, String type) {
+        String base = "/sys/devices/system/cpu/cpu" + cpu + "/cache/";
+        for (int i = 0; i < 8; i++) {
+            String typeFile = base + "index" + i + "/type";
+            String idFile   = base + "index" + i + "/id";
+            String t = readFile(typeFile);
+            if (type.equals(t)) {
+                String id = readFile(idFile);
+                return id != null ? id : String.valueOf(i);
+            }
+        }
+        return "?";
+    }
+
+    private static @NonNull String readCacheIndex(int cpu, String type, int level) {
+        String base = "/sys/devices/system/cpu/cpu" + cpu + "/cache/";
+        for (int i = 0; i < 8; i++) {
+            String typeFile  = base + "index" + i + "/type";
+            String levelFile = base + "index" + i + "/level";
+            String idFile    = base + "index" + i + "/id";
+            String t = readFile(typeFile);
+            String l = readFile(levelFile);
+            if (type.equals(t) && String.valueOf(level).equals(l)) {
+                String id = readFile(idFile);
+                return id != null ? id : String.valueOf(i);
+            }
+        }
+        return "?";
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/queue/FastHeapPriorityQueue.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/queue/FastHeapPriorityQueue.java
@@ -1,4 +1,4 @@
-package io.canvasmc.canvas.tick;
+package io.canvasmc.canvas.util.queue;
 
 import it.unimi.dsi.fastutil.objects.ObjectArrays;
 import it.unimi.dsi.fastutil.objects.ObjectHeaps;
@@ -6,13 +6,14 @@ import java.lang.reflect.Array;
 import java.util.Arrays;
 import java.util.Comparator;
 
-public class TickPriorityQueue<K> {
-    protected transient K[] arr;
+// based off object heap priority queue provided by fastutil
+public class FastHeapPriorityQueue<K> {
+    public transient K[] arr;
     protected int size;
     protected Comparator<? super K> c;
 
     @SuppressWarnings("unchecked")
-    public TickPriorityQueue(int capacity, Comparator<? super K> c, Class<K> classOf) {
+    public FastHeapPriorityQueue(int capacity, Comparator<? super K> c, Class<K> classOf) {
         if (capacity <= 0) capacity = 1;
         this.arr = (K[]) Array.newInstance(classOf, capacity);
         this.c = c;

--- a/canvas-server/src/main/java/me/lucko/spark/paper/common/command/modules/SamplerModule.java
+++ b/canvas-server/src/main/java/me/lucko/spark/paper/common/command/modules/SamplerModule.java
@@ -205,7 +205,7 @@ public class SamplerModule implements CommandModule {
         final double finalInterval = interval;
         Runnable pinCallback = () -> {
         ThreadDumper threadDumper;
-        boolean usingPinnedThreadDumper = io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.TRACKING_THREAD.get() != null;
+        boolean usingPinnedThreadDumper = io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.isProfiling();
         if (threads.isEmpty() || usingPinnedThreadDumper) {
             // use the server thread
             threadDumper = platform.getPlugin().getDefaultThreadDumper();
@@ -295,7 +295,7 @@ public class SamplerModule implements CommandModule {
                 platform.getPlugin().log(Level.SEVERE, "Profiler operation failed unexpectedly", throwable);
                     // Canvas start - rewrite scheduler
                 };
-                if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.TRACKING_THREAD.get() != null) {
+                if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.isProfiling()) {
                     // in ACTIVE profiling session, since that's atomic and doesn't have a cache
                     io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.endPinning(
                         (str) -> resp.broadcastPrefixed(text(str)),
@@ -320,7 +320,7 @@ public class SamplerModule implements CommandModule {
                 handleUpload(platform, resp, s, exportProps, saveToFile);
                 // Canvas start - rewrite scheduler
                 };
-                if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.TRACKING_THREAD.get() != null) {
+                if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.isProfiling()) {
                     // in ACTIVE profiling session, since that's atomic and doesn't have a cache
                     io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.endPinning(
                         (str) -> resp.broadcastPrefixed(text(str)),
@@ -493,7 +493,7 @@ public class SamplerModule implements CommandModule {
             resp.broadcastPrefixed(text("Profiler has been cancelled.", GOLD));
             // Canvas start - rewrite scheduler
             };
-            if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.TRACKING_THREAD.get() != null) {
+            if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.isProfiling()) {
                 // in ACTIVE profiling session, since that's atomic and doesn't have a cache
                 io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.endPinning(
                     (str) -> resp.replyPrefixed(text(str)),
@@ -535,7 +535,7 @@ public class SamplerModule implements CommandModule {
             }
             // Canvas start - rewrite scheduler
             };
-            if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.TRACKING_THREAD.get() != null) {
+            if (io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.isProfiling()) {
                 // in ACTIVE profiling session, since that's atomic and doesn't have a cache
                 io.canvasmc.canvas.spark.profiler.SparkRegionProfilerExtension.endPinning(
                     (str) -> resp.replyPrefixed(text(str)),


### PR DESCRIPTION
This adds the `AFFINITY` scheduler to Canvas, replacing the old `CRS`, now `StealingQueueSchedulerThreadPool`.

This scheduler adds per tick thread CPU affinity, which can be optionally disabled. It is based on the `EDF` scheduler, and also supports mid-tick-tasks like normal.

Work stealing works as:
  - peek global and local head
  - if local head is overdue, return that
  - if global head is overdue, return that
  - if still here, figure out the soonest deadline between the local and global head
    - if tied, it should be fine, since the comparator compares the IDs which are always unique per task, however we prefer the local task if it does happen
  - increment the next thread we will steal from. we try 1 steal per poll if we reach here, and for each poll we increment through the runners in order
  - if the thread we are trying to steal from isn't the current runner, we peek at the queue, and if it is stealable we return that, since it is past the steal thres
  - if we didn't return the potential stealable, we return the local head or global head depending on which has the soonest deadline, or if both are null, we return null

This also heavily cleans up the region profiler, which has been needed for quite a while