### PR TITLE
Cache Level#getEntities results by bounding box

### DIFF
--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedWorldData.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/RegionizedWorldData.java.patch
@@ -15,6 +15,26 @@
                  if (tileEntity != null) {
                      tileEntity.updateTicks(fromTickOffset, fromRedstoneTimeOffset);
                  }
+@@ -158,6 +_,9 @@
+             for (final ChunkHolder chunkHolder : from.chunkHoldersToBroadcast) {
+                 into.chunkHoldersToBroadcast.add(chunkHolder);
+             }
++            // Canvas start - cache getEntities lookups by bounding box for the current tick
++            into.canvas$getEntitiesBoxCache.clear();
++            // Canvas end - cache getEntities lookups by bounding box for the current tick
+         }
+ 
+         @Override
+@@ -234,6 +_,9 @@
+ 
+                 levelTicksBlockRegionData.put(key, worldData.blockLevelTicks);
+                 levelTicksFluidRegionData.put(key, worldData.fluidLevelTicks);
++                // Canvas start - cache getEntities lookups by bounding box for the current tick
++                worldData.canvas$getEntitiesBoxCache.clear();
++                // Canvas end - cache getEntities lookups by bounding box for the current tick
+             }
+ 
+             from.blockLevelTicks.split(chunkToRegionShift, levelTicksBlockRegionData);
 @@ -252,7 +_,18 @@
                    //       marked as removed. So if there is no section, it's probably removed!
              }
@@ -35,7 +55,12 @@
                  final int chunkX = pos.getX() >> 4;
                  final int chunkZ = pos.getZ() >> 4;
  
-@@ -334,7 +_,7 @@
+@@ -330,11 +_,12 @@
+     };
+ 
+     public final ServerLevel world;
++    public final CanvasGetEntitiesBoxCache canvas$getEntitiesBoxCache = new CanvasGetEntitiesBoxCache(); // Canvas - cache getEntities lookups by bounding box for the current tick
+ 
      private RegionizedServer.WorldLevelData tickData;
  
      // connections
@@ -104,7 +129,7 @@
  
      public final TickRegions.TickRegionData regionData;
  
-@@ -459,6 +_,7 @@
+@@ -459,11 +_,32 @@
          this.wireHandler = new alternate.current.wire.WireHandler(world);
          this.turbo = new io.papermc.paper.redstone.RedstoneWireTurbo((RedStoneWireBlock)Blocks.REDSTONE_WIRE);
          this.regionData = regionData;
@@ -112,6 +137,31 @@
  
          // tasks may be drained before the region ticks, so we must set up the tick data early just in case
          this.updateTickData();
+     }
+ 
++    // Canvas start - cache getEntities lookups by bounding box for the current tick
++    public static final class CanvasGetEntitiesBoxCache {
++        public final it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<List<Entity>> entitiesByBoundingBox = new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>();
++        private long tick = Long.MIN_VALUE;
++
++        public void clearIfStale() {
++            final long currentTick = RegionizedServer.getCurrentTick();
++            if (this.tick != currentTick) {
++                this.tick = currentTick;
++                this.entitiesByBoundingBox.clear();
++            }
++        }
++
++        public void clear() {
++            this.tick = Long.MIN_VALUE;
++            this.entitiesByBoundingBox.clear();
++        }
++    }
++    // Canvas end - cache getEntities lookups by bounding box for the current tick
++
+     public void checkWorld(final Level against) {
+         if (this.world != against) {
+             throw new IllegalStateException("World mismatch: expected " + this.world.getWorld().getName() + " but got " + (against == null ? "null" : against.getWorld().getName()));
 @@ -487,6 +_,7 @@
          this.skipHopperEvents = this.world.paperConfig().hopper.disableMoveEvent || org.bukkit.event.inventory.InventoryMoveItemEvent.getHandlerList().getRegisteredListeners().length == 0; // Paper - Perf: Optimize Hoppers
          // always subtract from server init so that the tick starts at zero, allowing us to cast to int without much worry

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -1,5 +1,30 @@
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
+@@ -107,6 +_,24 @@
+     public static final int MAX_BRIGHTNESS = 15;
+     public static final int MAX_ENTITY_SPAWN_Y = 20000000;
+     public static final int MIN_ENTITY_SPAWN_Y = -20000000;
++    // Canvas start - cache getEntities lookups by bounding box for the current tick
++    private static final io.papermc.paper.threadedregions.RegionizedData<Level.CanvasGetEntitiesBoxCache> canvas$regionizedGetEntitiesBoxCache =
++        new io.papermc.paper.threadedregions.RegionizedData<>(null, regionData -> new Level.CanvasGetEntitiesBoxCache(), new io.papermc.paper.threadedregions.RegionizedData.RegioniserCallback<>() {
++            @Override
++            public void merge(final Level.CanvasGetEntitiesBoxCache from, final Level.CanvasGetEntitiesBoxCache into, final long fromTickOffset) {
++                into.clear();
++            }
++
++            @Override
++            public void split(final Level.CanvasGetEntitiesBoxCache from, final int chunkToRegionShift,
++                              final it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap<Level.CanvasGetEntitiesBoxCache> regionToData,
++                              final it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<Level.CanvasGetEntitiesBoxCache> dataSet) {
++                for (final Level.CanvasGetEntitiesBoxCache cache : dataSet) {
++                    cache.clear();
++                }
++            }
++        });
++    // Canvas end - cache getEntities lookups by bounding box for the current tick
+     public static final WeightedList<ExplosionParticleInfo> DEFAULT_EXPLOSION_BLOCK_PARTICLES = WeightedList.<ExplosionParticleInfo>builder()
+         .add(new ExplosionParticleInfo(ParticleTypes.POOF, 0.5F, 1.0F))
+         .add(new ExplosionParticleInfo(ParticleTypes.SMOKE, 1.0F, 1.0F))
 @@ -203,7 +_,7 @@
  
      @Override
@@ -95,6 +120,75 @@
          } catch (Throwable var6) {
              // Paper start - Prevent block entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
+@@ -1719,16 +_,66 @@
+         List<Entity> list = Lists.newArrayList();
+ 
+         // Paper start - rewrite chunk system
++        // Canvas start - cache getEntities lookups by bounding box for the current tick
++        if (io.canvasmc.canvas.Config.INSTANCE.useBoxCacheForGetEntities) {
++            final Level.CanvasGetEntitiesBoxCache cache = Level.canvas$regionizedGetEntitiesBoxCache.get();
++            cache.clearIfStale();
++
++            final List<Entity> cached = cache.entitiesByBoundingBox.get(Level.canvas$getEntitiesBoxCacheKey(boundingBox));
++            if (cached != null) {
++                return cached;
++            }
++        }
++
+         final List<Entity> ret = new java.util.ArrayList<>();
+-
+         ((ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemLevel)this).moonrise$getEntityLookup().getEntities(entity, boundingBox, ret, predicate);
+-
+         ca.spottedleaf.moonrise.common.PlatformHooks.get().addToGetEntities((Level)(Object)this, entity, boundingBox, predicate, ret);
+ 
++        if (io.canvasmc.canvas.Config.INSTANCE.useBoxCacheForGetEntities) {
++            Level.canvas$regionizedGetEntitiesBoxCache.get().entitiesByBoundingBox.put(Level.canvas$getEntitiesBoxCacheKey(boundingBox), ret);
++        }
++        // Canvas end - cache getEntities lookups by bounding box for the current tick
++
+         return ret;
+         // Paper end - rewrite chunk system
+     }
+ 
++    // Canvas start - cache getEntities lookups by bounding box for the current tick
++    private static long canvas$getEntitiesBoxCacheKey(final AABB boundingBox) {
++        long result = 1L;
++        long bits = Double.doubleToLongBits(boundingBox.minX);
++        result = 31L * result + (bits ^ bits >>> 32);
++        bits = Double.doubleToLongBits(boundingBox.minY);
++        result = 31L * result + (bits ^ bits >>> 32);
++        bits = Double.doubleToLongBits(boundingBox.minZ);
++        result = 31L * result + (bits ^ bits >>> 32);
++        bits = Double.doubleToLongBits(boundingBox.maxX);
++        result = 31L * result + (bits ^ bits >>> 32);
++        bits = Double.doubleToLongBits(boundingBox.maxY);
++        result = 31L * result + (bits ^ bits >>> 32);
++        bits = Double.doubleToLongBits(boundingBox.maxZ);
++        return 31L * result + (bits ^ bits >>> 32);
++    }
++
++    private static final class CanvasGetEntitiesBoxCache {
++        private final it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<List<Entity>> entitiesByBoundingBox = new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>();
++        private long tick = Long.MIN_VALUE;
++
++        private void clearIfStale() {
++            final long currentTick = io.papermc.paper.threadedregions.RegionizedServer.getCurrentTick();
++            if (this.tick != currentTick) {
++                this.tick = currentTick;
++                this.entitiesByBoundingBox.clear();
++            }
++        }
++
++        private void clear() {
++            this.tick = Long.MIN_VALUE;
++            this.entitiesByBoundingBox.clear();
++        }
++    }
++    // Canvas end - cache getEntities lookups by bounding box for the current tick
++
+     @Override
+     public <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> entityTypeTest, AABB bounds, Predicate<? super T> predicate) {
+         List<T> list = Lists.newArrayList();
 @@ -1855,6 +_,35 @@
      public List<Entity> getPushableEntities(Entity entity, AABB boundingBox) {
          return this.getEntities(entity, boundingBox, EntitySelector.pushableBy(entity));

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -1,30 +1,5 @@
 --- a/net/minecraft/world/level/Level.java
 +++ b/net/minecraft/world/level/Level.java
-@@ -107,6 +_,24 @@
-     public static final int MAX_BRIGHTNESS = 15;
-     public static final int MAX_ENTITY_SPAWN_Y = 20000000;
-     public static final int MIN_ENTITY_SPAWN_Y = -20000000;
-+    // Canvas start - cache getEntities lookups by bounding box for the current tick
-+    private static final io.papermc.paper.threadedregions.RegionizedData<Level.CanvasGetEntitiesBoxCache> canvas$regionizedGetEntitiesBoxCache =
-+        new io.papermc.paper.threadedregions.RegionizedData<>(null, regionData -> new Level.CanvasGetEntitiesBoxCache(), new io.papermc.paper.threadedregions.RegionizedData.RegioniserCallback<>() {
-+            @Override
-+            public void merge(final Level.CanvasGetEntitiesBoxCache from, final Level.CanvasGetEntitiesBoxCache into, final long fromTickOffset) {
-+                into.clear();
-+            }
-+
-+            @Override
-+            public void split(final Level.CanvasGetEntitiesBoxCache from, final int chunkToRegionShift,
-+                              final it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap<Level.CanvasGetEntitiesBoxCache> regionToData,
-+                              final it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet<Level.CanvasGetEntitiesBoxCache> dataSet) {
-+                for (final Level.CanvasGetEntitiesBoxCache cache : dataSet) {
-+                    cache.clear();
-+                }
-+            }
-+        });
-+    // Canvas end - cache getEntities lookups by bounding box for the current tick
-     public static final WeightedList<ExplosionParticleInfo> DEFAULT_EXPLOSION_BLOCK_PARTICLES = WeightedList.<ExplosionParticleInfo>builder()
-         .add(new ExplosionParticleInfo(ParticleTypes.POOF, 0.5F, 1.0F))
-         .add(new ExplosionParticleInfo(ParticleTypes.SMOKE, 1.0F, 1.0F))
 @@ -203,7 +_,7 @@
  
      @Override
@@ -120,32 +95,29 @@
          } catch (Throwable var6) {
              // Paper start - Prevent block entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
-@@ -1719,16 +_,68 @@
+@@ -1719,16 +_,45 @@
          List<Entity> list = Lists.newArrayList();
  
          // Paper start - rewrite chunk system
 +        // Canvas start - cache getEntities lookups by bounding box for the current tick
 +        if (io.canvasmc.canvas.Config.INSTANCE.useBoxCacheForGetEntities) {
-+            final Level.CanvasGetEntitiesBoxCache cache = Level.canvas$regionizedGetEntitiesBoxCache.get();
++            final io.papermc.paper.threadedregions.RegionizedWorldData.CanvasGetEntitiesBoxCache cache = this.getCurrentWorldData().canvas$getEntitiesBoxCache;
 +            cache.clearIfStale();
-+
 +            final List<Entity> cached = cache.entitiesByBoundingBox.get(Level.canvas$getEntitiesBoxCacheKey(entity, boundingBox, predicate));
 +            if (cached != null) {
 +                return cached;
 +            }
 +        }
-+
          final List<Entity> ret = new java.util.ArrayList<>();
 -
          ((ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemLevel)this).moonrise$getEntityLookup().getEntities(entity, boundingBox, ret, predicate);
 -
          ca.spottedleaf.moonrise.common.PlatformHooks.get().addToGetEntities((Level)(Object)this, entity, boundingBox, predicate, ret);
- 
+-
 +        if (io.canvasmc.canvas.Config.INSTANCE.useBoxCacheForGetEntities) {
-+            Level.canvas$regionizedGetEntitiesBoxCache.get().entitiesByBoundingBox.put(Level.canvas$getEntitiesBoxCacheKey(entity, boundingBox, predicate), ret);
++            this.getCurrentWorldData().canvas$getEntitiesBoxCache.entitiesByBoundingBox.put(Level.canvas$getEntitiesBoxCacheKey(entity, boundingBox, predicate), ret);
 +        }
 +        // Canvas end - cache getEntities lookups by bounding box for the current tick
-+
          return ret;
          // Paper end - rewrite chunk system
      }
@@ -168,26 +140,7 @@
 +        bits = Double.doubleToLongBits(boundingBox.maxZ);
 +        return 31L * result + (bits ^ bits >>> 32);
 +    }
-+
-+    private static final class CanvasGetEntitiesBoxCache {
-+        private final it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<List<Entity>> entitiesByBoundingBox = new it.unimi.dsi.fastutil.longs.Long2ObjectOpenHashMap<>();
-+        private long tick = Long.MIN_VALUE;
-+
-+        private void clearIfStale() {
-+            final long currentTick = io.papermc.paper.threadedregions.RegionizedServer.getCurrentTick();
-+            if (this.tick != currentTick) {
-+                this.tick = currentTick;
-+                this.entitiesByBoundingBox.clear();
-+            }
-+        }
-+
-+        private void clear() {
-+            this.tick = Long.MIN_VALUE;
-+            this.entitiesByBoundingBox.clear();
-+        }
-+    }
 +    // Canvas end - cache getEntities lookups by bounding box for the current tick
-+
      @Override
      public <T extends Entity> List<T> getEntities(EntityTypeTest<Entity, T> entityTypeTest, AABB bounds, Predicate<? super T> predicate) {
          List<T> list = Lists.newArrayList();

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -95,7 +95,7 @@
          } catch (Throwable var6) {
              // Paper start - Prevent block entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
-@@ -1719,16 +_,45 @@
+@@ -1719,16 +_,48 @@
          List<Entity> list = Lists.newArrayList();
  
          // Paper start - rewrite chunk system
@@ -109,11 +109,11 @@
 +            }
 +        }
          final List<Entity> ret = new java.util.ArrayList<>();
--
+ 
          ((ca.spottedleaf.moonrise.patches.chunk_system.level.ChunkSystemLevel)this).moonrise$getEntityLookup().getEntities(entity, boundingBox, ret, predicate);
--
+ 
          ca.spottedleaf.moonrise.common.PlatformHooks.get().addToGetEntities((Level)(Object)this, entity, boundingBox, predicate, ret);
--
+ 
 +        if (io.canvasmc.canvas.Config.INSTANCE.useBoxCacheForGetEntities) {
 +            this.getCurrentWorldData().canvas$getEntitiesBoxCache.entitiesByBoundingBox.put(Level.canvas$getEntitiesBoxCacheKey(entity, boundingBox, predicate), ret);
 +        }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -120,7 +120,7 @@
          } catch (Throwable var6) {
              // Paper start - Prevent block entity and entity crashes
              final String msg = String.format("Entity threw exception at %s:%s,%s,%s", entity.level().getWorld().getName(), entity.getX(), entity.getY(), entity.getZ());
-@@ -1719,16 +_,66 @@
+@@ -1719,16 +_,68 @@
          List<Entity> list = Lists.newArrayList();
  
          // Paper start - rewrite chunk system
@@ -129,7 +129,7 @@
 +            final Level.CanvasGetEntitiesBoxCache cache = Level.canvas$regionizedGetEntitiesBoxCache.get();
 +            cache.clearIfStale();
 +
-+            final List<Entity> cached = cache.entitiesByBoundingBox.get(Level.canvas$getEntitiesBoxCacheKey(boundingBox));
++            final List<Entity> cached = cache.entitiesByBoundingBox.get(Level.canvas$getEntitiesBoxCacheKey(entity, boundingBox, predicate));
 +            if (cached != null) {
 +                return cached;
 +            }
@@ -142,7 +142,7 @@
          ca.spottedleaf.moonrise.common.PlatformHooks.get().addToGetEntities((Level)(Object)this, entity, boundingBox, predicate, ret);
  
 +        if (io.canvasmc.canvas.Config.INSTANCE.useBoxCacheForGetEntities) {
-+            Level.canvas$regionizedGetEntitiesBoxCache.get().entitiesByBoundingBox.put(Level.canvas$getEntitiesBoxCacheKey(boundingBox), ret);
++            Level.canvas$regionizedGetEntitiesBoxCache.get().entitiesByBoundingBox.put(Level.canvas$getEntitiesBoxCacheKey(entity, boundingBox, predicate), ret);
 +        }
 +        // Canvas end - cache getEntities lookups by bounding box for the current tick
 +
@@ -151,8 +151,10 @@
      }
  
 +    // Canvas start - cache getEntities lookups by bounding box for the current tick
-+    private static long canvas$getEntitiesBoxCacheKey(final AABB boundingBox) {
++    private static long canvas$getEntitiesBoxCacheKey(final @Nullable Entity entity, final AABB boundingBox, final Predicate<? super Entity> predicate) {
 +        long result = 1L;
++        result = 31L * result + System.identityHashCode(entity);
++        result = 31L * result + System.identityHashCode(predicate);
 +        long bits = Double.doubleToLongBits(boundingBox.minX);
 +        result = 31L * result + (bits ^ bits >>> 32);
 +        bits = Double.doubleToLongBits(boundingBox.minY);

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -305,8 +305,7 @@ public class Config {
     public boolean enableCachedMTBEntityTypeConvert = false;
 
     @Comment({
-        "Caches Level#getEntities results by bounding box for the current tick to reduce repeated lookups.",
-        "Note that plugins which query the same box multiple times in one tick with different predicates may get incorrect results.",
+        "Caches Level#getEntities results for the current tick to reduce repeated lookups."
     })
     public boolean useBoxCacheForGetEntities = false;
 

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -304,6 +304,12 @@ public class Config {
     @Comment("Whether to cache expensive CraftEntityType#minecraftToBukkit call")
     public boolean enableCachedMTBEntityTypeConvert = false;
 
+    @Comment({
+        "Caches Level#getEntities results by bounding box for the current tick to reduce repeated lookups.",
+        "Note that plugins which query the same box multiple times in one tick with different predicates may get incorrect results.",
+    })
+    public boolean useBoxCacheForGetEntities = false;
+
     @Comment("Enables creation of tile entity snapshots on retrieving blockstates")
     public boolean tileEntitySnapshotCreation = false;
 


### PR DESCRIPTION
Adds an optional per-tick cache for Level#getEntities, keyed by bounding box, to reduce repeated lookups.
Stores results in a regionised cache, cleared each tick.

In testing with ~1000 cows cramming in a small 6x6 space it was around 5x faster than vanilla. 