### PR TITLE
Restore chunk ticking guard for block entity ticks

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/Level.java.patch
@@ -42,7 +42,7 @@
 +                continue;
 +            }
 +
-+            if (runsNormally && tickingBlockEntity.getPos() != null) { // block entity sleeping
++            if (runsNormally && tickingBlockEntity.getPos() != null && this.shouldTickBlocksAt(tickingBlockEntity.getPos())) { // Canvas - only tick block entities in ticking chunks
                  tickingBlockEntity.tick();
 -                // Paper start - rewrite chunk system
                  if ((++tickedEntities & 7) == 0) {


### PR DESCRIPTION
Restore the chunk ownership check before ticking block entities to prevent cross-region or non-ticking chunk block entity ticks introduced by the block entity iteration optimization, from commit 649047d7.