### PR TITLE
Packet overflow config options

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/network/Connection.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/network/Connection.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/network/Connection.java
 +++ b/net/minecraft/network/Connection.java
+@@ -213,7 +_,7 @@
+                     if (player != null) player.quitReason = org.bukkit.event.player.PlayerQuitEvent.QuitReason.TIMED_OUT; // Paper - Add API for quit reason
+                     this.disconnect(Component.translatable("disconnect.timeout"));
+                 } else {
+-                    Component component = Component.translatable("disconnect.genericReason", "Internal Exception: " + exception);
++                    Component component = Component.translatable("disconnect.genericReason", "Internal Exception: " + (exception instanceof PacketEncoder.PacketTooLargeException ? io.canvasmc.canvas.Config.INSTANCE.networking.packetTooLargeDisconnectReason : exception)); // Canvas - configurable packet too large disconnect reason
+                     PacketListener packetListener = this.packetListener;
+                     DisconnectionDetails disconnectionDetails;
+                     if (packetListener != null) {
 @@ -354,6 +_,8 @@
          if (protocolInfo.flow() != this.getReceiving()) {
              throw new IllegalStateException("Invalid inbound protocol: " + protocolInfo.id());

--- a/canvas-server/minecraft-patches/sources/net/minecraft/network/PacketEncoder.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/network/PacketEncoder.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/network/PacketEncoder.java
++++ b/net/minecraft/network/PacketEncoder.java
+@@ -55,7 +_,7 @@
+     // packet size is encoded into 3-byte varint
+     private static final int MAX_FINAL_PACKET_SIZE = (1 << 21) - 1;
+     // Vanilla Max size for the encoder (before compression)
+-    private static final int MAX_PACKET_SIZE = 8388608;
++    private static final int MAX_PACKET_SIZE = io.canvasmc.canvas.Config.INSTANCE.networking.maximumPacketBytes; // Canvas - configurable max packet bytes
+ 
+     public static class PacketTooLargeException extends RuntimeException {
+         private final Packet<?> packet;

--- a/canvas-server/minecraft-patches/sources/net/minecraft/network/PacketEncoder.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/network/PacketEncoder.java.patch
@@ -5,7 +5,7 @@
      private static final int MAX_FINAL_PACKET_SIZE = (1 << 21) - 1;
      // Vanilla Max size for the encoder (before compression)
 -    private static final int MAX_PACKET_SIZE = 8388608;
-+    private static final int MAX_PACKET_SIZE = io.canvasmc.canvas.Config.INSTANCE.networking.maximumPacketBytes; // Canvas - configurable max packet bytes
++    private static int MAX_PACKET_SIZE = io.canvasmc.canvas.Config.INSTANCE.networking.maximumPacketBytes; // Canvas - configurable max packet bytes
  
      public static class PacketTooLargeException extends RuntimeException {
          private final Packet<?> packet;

--- a/canvas-server/minecraft-patches/sources/net/minecraft/network/protocol/game/ClientboundContainerSetContentPacket.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/network/protocol/game/ClientboundContainerSetContentPacket.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/network/protocol/game/ClientboundContainerSetContentPacket.java
++++ b/net/minecraft/network/protocol/game/ClientboundContainerSetContentPacket.java
+@@ -30,6 +_,7 @@
+ 
+     @Override
+     public boolean packetTooLarge(net.minecraft.network.Connection manager) {
++        if (io.canvasmc.canvas.Config.INSTANCE.networking.disablePaperPacketOverflowContainerFix) return false; // Canvas - container overflow config
+         for (int i = 0 ; i < this.items.size() ; i++) {
+             manager.send(new ClientboundContainerSetSlotPacket(this.containerId, this.stateId, i, this.items.get(i)));
+         }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/Config.java
@@ -296,6 +296,19 @@ public class Config {
 
         @Comment("This option makes protocol switching asynchronous, reducing global region blocking and improving login and configuration performance.")
         public boolean asyncProtocolSwitch = false;
+
+        @Comment("The maximum bytes that can be sent by the server in a single packet to a player before kicking them")
+        public int maximumPacketBytes = 8388608;
+
+        @Comment({
+        	"Paper implements an overflow fallback for container contents packets to the client, splitting the load into individual packets",
+        	"for each individual slot to prevent kicking the player for large containers. By enabling this, the server wont split the packet, and will",
+        	"kick the player if they attempt to open a container with the set contents packet larger than the max packet byte size"
+        })
+        public boolean disablePaperPacketOverflowContainerFix = false;
+
+        @Comment("The disconnet reason sent to the client when the server attempted to send a packet that was too large")
+        public String packetTooLargeDisconnectReason = "Clientbound packet exceeded max packet bytes";
     }
 
     @Comment("Check if a cactus can survive before growing. Heavily optimizes cacti farms")


### PR DESCRIPTION
The changes present in this PR are intended to patch an exploit in regards to excessive opening/closing of containers with lots of NBT data in them causing CPU usage spikes and ping spikes.

This has been realized to be caused by Papers patch for excessive packet sizes for containers. This allows configuring the max packet size for all packets, disabling the excessive packet size fix, and customizing the disconnect reason sent to the client.

The config options are:
- `maximumPacketBytes`- Default to match Vanilla
- `disablePaperPacketOverflowContainerFix` - Keeps the overflow enabled by default
- `packetTooLargeDisconnectReason`