### PR TITLE
Add `canvas-supported` Flag

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -108,6 +108,10 @@ subprojects {
             authors = listOf("CanvasMC")
             foliaSupported = true
         }
+
+        tasks.processResources {
+            duplicatesStrategy = DuplicatesStrategy.EXCLUDE
+        }
     }
 }
 

--- a/canvas-api/paper-patches/base/0003-Add-canvas-supported-Flag.patch
+++ b/canvas-api/paper-patches/base/0003-Add-canvas-supported-Flag.patch
@@ -1,0 +1,31 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <duerismc@gmail.com>
+Date: Tue, 31 Mar 2026 00:33:14 -0700
+Subject: [PATCH] Add `canvas-supported` Flag
+
+This is for plugins that support Paper and it's forks, excluding Folia, but support Canvas. This acts identical to the folia-supported flag.
+
+diff --git a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+index 4a5ac5193bee2107ddc65f37a39046f92e875350..6edff8ad2c56765687bc82127f83497816a27dc7 100644
+--- a/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
++++ b/src/main/java/org/bukkit/plugin/PluginDescriptionFile.java
+@@ -270,6 +270,7 @@ public final class PluginDescriptionFile implements io.papermc.paper.plugin.conf
+     // Folia start - block plugins not marked as supported
+     private String foliaSupported;
+     private static final String FOLIA_SUPPORTED_KEY = "folia-supported";
++    private static final String CANVAS_SUPPORTED_KEY = "canvas-supported"; // Canvas - canvas supported flag
+ 
+     /**
+      * Returns whether the plugin has been marked to be compatible with regionised threading as provided
+@@ -1284,6 +1285,11 @@ public final class PluginDescriptionFile implements io.papermc.paper.plugin.conf
+         if (map.get(FOLIA_SUPPORTED_KEY) != null) {
+             foliaSupported = map.get(FOLIA_SUPPORTED_KEY).toString();
+         }
++        // Canvas start - canvas supported flag
++        if ((foliaSupported == null || foliaSupported.equalsIgnoreCase("false")) && map.containsKey(CANVAS_SUPPORTED_KEY)) {
++            foliaSupported = map.get(CANVAS_SUPPORTED_KEY).toString();
++        }
++        // Canvas end - canvas supported flag
+         // Folia end - block plugins not marked as supported
+     }
+ 

--- a/canvas-server/paper-patches/base/0008-Add-canvas-supported-Flag.patch
+++ b/canvas-server/paper-patches/base/0008-Add-canvas-supported-Flag.patch
@@ -1,0 +1,28 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <duerismc@gmail.com>
+Date: Tue, 31 Mar 2026 00:31:31 -0700
+Subject: [PATCH] Add `canvas-supported` Flag
+
+This is for plugins that support Paper and it's forks, excluding Folia, but support Canvas. This acts identical to the folia-supported flag.
+
+diff --git a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
+index fb7c6621e2805f4339c255f6c2e02c55ff4c502e..d43266c40ca6282ef8e4229d166353c983255983 100644
+--- a/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
++++ b/src/main/java/io/papermc/paper/plugin/provider/configuration/PaperPluginMeta.java
+@@ -65,6 +65,7 @@ public class PaperPluginMeta implements PluginMeta {
+     @Required
+     private ApiVersion apiVersion;
+     private boolean foliaSupported = false; // Folia
++    private boolean canvasSupported = false; // Canvas - canvas supported flag
+ 
+     private Map<PluginDependencyLifeCycle, Map<String, DependencyConfiguration>> dependencies = new EnumMap<>(PluginDependencyLifeCycle.class);
+ 
+@@ -255,7 +256,7 @@ public class PaperPluginMeta implements PluginMeta {
+     // Folia start
+     @Override
+     public boolean isFoliaSupported() {
+-        return this.foliaSupported;
++        return this.foliaSupported || this.canvasSupported; // Canvas - canvas supported flag
+     }
+     // Folia end
+ 


### PR DESCRIPTION
This is for plugins that support Paper and it's forks, excluding Folia, but support Canvas. This acts identical to the folia-supported flag.

This is primarily for plugins who have a setup where they don't support Folia, but support Canvas because of Canvas-only API

This is generally for plugins who can't support Folia, but can support Canvas because of the API Canvas fixes/provides for region threading. Plugins can use this flag or the `folia-supported` flag, as on Canvas, they both do the same thing, but in Folia if you only have `canvas-supported` then it won't load it because Folia needs `folia-supported`, but Canvas can load plugins without `canvas-supported`(requires `folia-supported` then)