### PR TITLE
Optimize Netty flushing in region threading

### DIFF
--- a/build-data/canvas.at
+++ b/build-data/canvas.at
@@ -28,6 +28,10 @@ public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle
 public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle tickTimes1m
 public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle tickTimes5m
 public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle tickTimes5s
+public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner
+public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner currentTickingRegion
+public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner currentTickingTask
+public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner currentTickingWorldRegionizedData
 public io.papermc.paper.threadedregions.TickRegions$TickRegionData getRegionizedData(Lio/papermc/paper/threadedregions/RegionizedData;)Ljava/lang/Object;
 public io.papermc.paper.threadedregions.TickRegions$TickRegionData tickHandle
 public net.minecraft.core.Direction VALUES
@@ -38,6 +42,7 @@ public net.minecraft.server.level.ServerChunkCache ticketStorage
 public net.minecraft.server.level.ServerEntity sendDirtyEntityData()V
 public net.minecraft.server.level.ServerPlayer checkRidingStatistics(DDD)V
 public net.minecraft.server.network.ServerCommonPacketListenerImpl keepConnectionAlive()V
+public net.minecraft.server.network.ServerCommonPacketListenerImpl suspendFlushingOnServerThread
 public net.minecraft.server.players.PlayerList SEND_PLAYER_INFO_INTERVAL
 public net.minecraft.server.players.PlayerList save(Lnet/minecraft/server/level/ServerPlayer;)V
 public net.minecraft.util.Mth SIN

--- a/build-data/canvas.at
+++ b/build-data/canvas.at
@@ -28,10 +28,10 @@ public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle
 public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle tickTimes1m
 public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle tickTimes5m
 public io.papermc.paper.threadedregions.TickRegionScheduler$RegionScheduleHandle tickTimes5s
-public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner
-public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner currentTickingRegion
-public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner currentTickingTask
-public io.papermc.paper.threadedregions.TickRegionScheduler.TickThreadRunner currentTickingWorldRegionizedData
+public io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner
+public io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner currentTickingRegion
+public io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner currentTickingTask
+public io.papermc.paper.threadedregions.TickRegionScheduler$TickThreadRunner currentTickingWorldRegionizedData
 public io.papermc.paper.threadedregions.TickRegions$TickRegionData getRegionizedData(Lio/papermc/paper/threadedregions/RegionizedData;)Ljava/lang/Object;
 public io.papermc.paper.threadedregions.TickRegions$TickRegionData tickHandle
 public net.minecraft.core.Direction VALUES

--- a/canvas-server/minecraft-patches/base/0002-Remove-Folia-Profiler.patch
+++ b/canvas-server/minecraft-patches/base/0002-Remove-Folia-Profiler.patch
@@ -987,7 +987,7 @@ index 24c8581b2fa9c3ef6f6aad64bd4454d64fe233ae..fdb0bcdca1cd38f55f191d42e422c354
  
      private boolean saveChunk(final ChunkAccess chunk, final boolean unloading, final Completable<CompoundTag>[] chunkSave) {
 diff --git a/io/papermc/paper/threadedregions/TickRegionScheduler.java b/io/papermc/paper/threadedregions/TickRegionScheduler.java
-index 690db9aa75f4850e3fff6b5d55b13fb0ad280dc5..71260702b8ba260001a5f1c1e935dd5b8717f3d7 100644
+index 8bab5c5ee347316b579c00d1c82d1e05f1f7f5da..3c646d9d594cbead75a30150b7e03124e2beaaf8 100644
 --- a/io/papermc/paper/threadedregions/TickRegionScheduler.java
 +++ b/io/papermc/paper/threadedregions/TickRegionScheduler.java
 @@ -142,13 +142,8 @@ public final class TickRegionScheduler {
@@ -1023,9 +1023,9 @@ index 690db9aa75f4850e3fff6b5d55b13fb0ad280dc5..71260702b8ba260001a5f1c1e935dd5b
       * Schedules the given region
       * @throws IllegalStateException If the region is already scheduled or is ticking
 @@ -286,9 +270,6 @@ public final class TickRegionScheduler {
-         private ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> currentTickingRegion;
-         private RegionizedWorldData currentTickingWorldRegionizedData;
-         private SchedulableTick currentTickingTask;
+         public ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> currentTickingRegion;
+         public RegionizedWorldData currentTickingWorldRegionizedData;
+         public SchedulableTick currentTickingTask;
 -        // Folia start - profiler
 -        private ca.spottedleaf.leafprofiler.RegionizedProfiler.Handle profiler = ca.spottedleaf.leafprofiler.RegionizedProfiler.Handle.NO_OP_HANDLE;
 -        // Folia end - profiler

--- a/canvas-server/minecraft-patches/base/0003-Remove-Vanilla-Profiler.patch
+++ b/canvas-server/minecraft-patches/base/0003-Remove-Vanilla-Profiler.patch
@@ -1135,7 +1135,7 @@ index 8218fffbed10a3951045ad21a008dfe995ae8880..aca88b9ec53debc85387fcd5920eef1d
                  this.stopUsingItem();
                  this.connection.send(new ClientboundPlayerAbilitiesPacket(this.getAbilities()));
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index d691302945b86290536120dfb0d04be88f40ed23..e74a53de5d3ef1156b0643d13d49754ca1393e13 100644
+index b7ff2ba1c9fa270dae5f5b436e2d5b4124dfb9c3..017044915b943edabf8865eda8d7bd8c415520b3 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -26,7 +26,6 @@ import net.minecraft.server.level.ClientInformation;

--- a/canvas-server/minecraft-patches/base/0013-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0013-Fixup-Region-Threading.patch
@@ -156,7 +156,7 @@ index 1f49d787ecee4ba9dce087036a4e3cbce2228c17..3e3c10df71c7269ab063e80d30584b34
  
      public NearbyPlayers getNearbyPlayers() {
 diff --git a/io/papermc/paper/threadedregions/TickRegionScheduler.java b/io/papermc/paper/threadedregions/TickRegionScheduler.java
-index 71260702b8ba260001a5f1c1e935dd5b8717f3d7..af8fd1a55c23a4f33a206384838aaf9465ec5df3 100644
+index 3c646d9d594cbead75a30150b7e03124e2beaaf8..6a39eba0237c378ef612b10539746ee4fe4efe0a 100644
 --- a/io/papermc/paper/threadedregions/TickRegionScheduler.java
 +++ b/io/papermc/paper/threadedregions/TickRegionScheduler.java
 @@ -28,7 +28,7 @@ import java.util.function.BooleanSupplier;

--- a/canvas-server/minecraft-patches/base/0013-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0013-Fixup-Region-Threading.patch
@@ -633,7 +633,7 @@ index 8d4f092ec65d285508be81cbfadd6e747e1d067e..2db474ced22d5867b0f6315185af31d3
  
      public static ServerPlayer getPlayer(final String name) {
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 8ef9f0a9a018fb7e86d5bbd5860c9ebdef7dc022..3ef5fca023aeb70cd83a7200b0ccf20ef8ef6b18 100644
+index 8ef9f0a9a018fb7e86d5bbd5860c9ebdef7dc022..c0291ae3509ba54ed5691d92ee457126a6061628 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -365,7 +365,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -698,7 +698,7 @@ index 8ef9f0a9a018fb7e86d5bbd5860c9ebdef7dc022..3ef5fca023aeb70cd83a7200b0ccf20e
          //this.tickCount++; // Folia - region threading
          //this.tickRateManager.tick(); // Folia - region threading
 -        this.tickChildren(hasTimeLeft, region); // Folia - region threading
-+        // Canvas start - region threading
++        // Canvas start - optimize flush calls with region threading
 +        try {
 +            List<ServerPlayer> flushing = new java.util.ArrayList<>(region.world.getCurrentWorldData().getLocalPlayers());
 +            for (final net.minecraft.server.level.ServerPlayer localPlayer : flushing) {
@@ -722,7 +722,7 @@ index 8ef9f0a9a018fb7e86d5bbd5860c9ebdef7dc022..3ef5fca023aeb70cd83a7200b0ccf20e
 +            region.world.fillReportDetails(crashReport);
 +            throw new ReportedException(crashReport);
 +        }
-+        // Canvas end - region threading
++        // Canvas end - optimize flush calls with region threading
          if (false && nanos - this.lastServerStatus >= STATUS_EXPIRE_TIME_NANOS) { // Folia - region threading
              this.lastServerStatus = nanos;
              this.status = this.buildServerStatus();
@@ -858,7 +858,7 @@ index 544df762687f1762a01bd34441f7e7feedcb5e57..e993d717d965cda4b007366b9be56d55
                                  if (entity.isRemoved()) return; // Folia - region threading - if we despawned, DON'T TICK IT!
                                  if (true) { // Paper - rewrite chunk system
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index aca88b9ec53debc85387fcd5920eef1d0292b769..1fd0df462ae28d58789aba5e1f60df8615e339bc 100644
+index aca88b9ec53debc85387fcd5920eef1d0292b769..fd8ec07dac4f0612c96d5006d398c54ad0b56254 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -1817,7 +1817,18 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -867,7 +867,7 @@ index aca88b9ec53debc85387fcd5920eef1d0292b769..1fd0df462ae28d58789aba5e1f60df86
          this.stopUsingItem();
 +        // if not suspending, we resume flushing. we check this on pre dimension change
 +        // since this is called for portaling *and* cross-region teleports
-+        if (!this.connection.suspendFlushingOnServerThread) this.connection.resumeFlushing(); // Canvas - region threading
++        if (!this.connection.suspendFlushingOnServerThread) this.connection.resumeFlushing(); // Canvas - optimize flush calls with region threading
      }
 +    // Canvas start - region threading
 +
@@ -902,22 +902,42 @@ index ded991859a6a94693cce183b3bf380a9241a2976..33ee081848da6d245019ae594f5b117b
      private static TicketType register(String name, long timeout, @TicketType.Flags int flags) {
          return Registry.register(BuiltInRegistries.TICKET_TYPE, name, new TicketType(timeout, flags));
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index 017044915b943edabf8865eda8d7bd8c415520b3..8e0aa227cd77ae308582ecc1f9bcc62967a86cde 100644
+index 017044915b943edabf8865eda8d7bd8c415520b3..bbe4a3cf736f911e87f83681769b9a70c27cddf8 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-@@ -330,10 +330,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+@@ -309,10 +309,17 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+         this.suspendFlushingOnServerThread = true;
+     }
+ 
++    // Canvas start - optimize flush calls with region threading
++    private int lastSentNonFlushPacketCount = 0;
++    private int sentNonFlushPacketCount = 0;
+     public void resumeFlushing() {
+         this.suspendFlushingOnServerThread = false;
+-        this.connection.flushChannel();
++        if (lastSentNonFlushPacketCount != sentNonFlushPacketCount) {
++            connection.flushChannel();
++            lastSentNonFlushPacketCount = sentNonFlushPacketCount;
++        }
+     }
++    // Canvas end - optimize flush calls with region threading
+ 
+     public void send(Packet<?> packet) {
+         this.send(packet, null);
+@@ -330,10 +337,13 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
              this.close();
          }
  
 -        boolean flag = !this.suspendFlushingOnServerThread || !this.server.isSameThread();
 -
-+        // Canvas start - region threading
++        // Canvas start - optimize flush calls with region threading
 +        boolean flush = !this.suspendFlushingOnServerThread ||
 +            !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(connection.getPlayer());
++        if (!flush) sentNonFlushPacketCount++;
          try {
 -            this.connection.send(packet, sendListener, flag);
 +            this.connection.send(packet, sendListener, flush);
-+        // Canvas end - region threading
++        // Canvas end - optimize flush calls with region threading
          } catch (Throwable var7) {
              CrashReport crashReport = CrashReport.forThrowable(var7, "Sending packet");
              CrashReportCategory crashReportCategory = crashReport.addCategory("Packet being sent");

--- a/canvas-server/minecraft-patches/base/0013-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0013-Fixup-Region-Threading.patch
@@ -633,7 +633,7 @@ index 8d4f092ec65d285508be81cbfadd6e747e1d067e..2db474ced22d5867b0f6315185af31d3
  
      public static ServerPlayer getPlayer(final String name) {
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 8ef9f0a9a018fb7e86d5bbd5860c9ebdef7dc022..b24997f5f11aaffa8b002831d196936218890eec 100644
+index 8ef9f0a9a018fb7e86d5bbd5860c9ebdef7dc022..3ef5fca023aeb70cd83a7200b0ccf20ef8ef6b18 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -365,7 +365,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -693,7 +693,40 @@ index 8ef9f0a9a018fb7e86d5bbd5860c9ebdef7dc022..b24997f5f11aaffa8b002831d1969362
              try {
                  this.stopped = true;
                  this.stopServer();
-@@ -1851,7 +1837,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+@@ -1674,7 +1660,31 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         // Folia end - region threading
+         //this.tickCount++; // Folia - region threading
+         //this.tickRateManager.tick(); // Folia - region threading
+-        this.tickChildren(hasTimeLeft, region); // Folia - region threading
++        // Canvas start - region threading
++        try {
++            List<ServerPlayer> flushing = new java.util.ArrayList<>(region.world.getCurrentWorldData().getLocalPlayers());
++            for (final net.minecraft.server.level.ServerPlayer localPlayer : flushing) {
++                // by suspending flushing, this will suspend flushing on the owning thread of the player
++                // however, if a diff thread sends a packet, it automatically flushes
++                localPlayer.connection.suspendFlushing();
++            }
++            this.tickChildren(hasTimeLeft, region);
++            for (final net.minecraft.server.level.ServerPlayer localPlayer : flushing) {
++                // if this thread doesn't own the player for some reason, or they were marked to
++                // continue flushing, we don't even try and touch it
++                if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(localPlayer)
++                    || !localPlayer.connection.suspendFlushingOnServerThread) {
++                    continue;
++                }
++                // note, this also flushes the channel
++                localPlayer.connection.resumeFlushing();
++            }
++        } catch (Throwable thrown) {
++            CrashReport crashReport = CrashReport.forThrowable(thrown, "Exception ticking region");
++            region.world.fillReportDetails(crashReport);
++            throw new ReportedException(crashReport);
++        }
++        // Canvas end - region threading
+         if (false && nanos - this.lastServerStatus >= STATUS_EXPIRE_TIME_NANOS) { // Folia - region threading
+             this.lastServerStatus = nanos;
+             this.status = this.buildServerStatus();
+@@ -1851,7 +1861,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
          regionizedWorldData.tickConnections(); // Folia - region threading
          //this.playerList.tick(); // Folia - region threading
          this.debugSubscribers.tick();
@@ -825,12 +858,16 @@ index 544df762687f1762a01bd34441f7e7feedcb5e57..e993d717d965cda4b007366b9be56d55
                                  if (entity.isRemoved()) return; // Folia - region threading - if we despawned, DON'T TICK IT!
                                  if (true) { // Paper - rewrite chunk system
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index aca88b9ec53debc85387fcd5920eef1d0292b769..79360e5c65d45ab8f619bc789d0e4322ce95ffbc 100644
+index aca88b9ec53debc85387fcd5920eef1d0292b769..1fd0df462ae28d58789aba5e1f60df8615e339bc 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
-@@ -1818,6 +1818,14 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+@@ -1817,7 +1817,18 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+     public void preChangeDimension() {
          super.preChangeDimension();
          this.stopUsingItem();
++        // if not suspending, we resume flushing. we check this on pre dimension change
++        // since this is called for portaling *and* cross-region teleports
++        if (!this.connection.suspendFlushingOnServerThread) this.connection.resumeFlushing(); // Canvas - region threading
      }
 +    // Canvas start - region threading
 +
@@ -843,7 +880,7 @@ index aca88b9ec53debc85387fcd5920eef1d0292b769..79360e5c65d45ab8f619bc789d0e4322
  
      @Override
      protected void placeSingleSync(ServerLevel originWorld, ServerLevel destination, EntityTreeNode treeNode, long teleportFlags) {
-@@ -2254,7 +2262,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+@@ -2254,7 +2265,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
  
      @Override
      protected void pushEntities() {
@@ -864,6 +901,26 @@ index ded991859a6a94693cce183b3bf380a9241a2976..33ee081848da6d245019ae594f5b117b
  
      private static TicketType register(String name, long timeout, @TicketType.Flags int flags) {
          return Registry.register(BuiltInRegistries.TICKET_TYPE, name, new TicketType(timeout, flags));
+diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
+index 017044915b943edabf8865eda8d7bd8c415520b3..8e0aa227cd77ae308582ecc1f9bcc62967a86cde 100644
+--- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
++++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
+@@ -330,10 +330,12 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack
+             this.close();
+         }
+ 
+-        boolean flag = !this.suspendFlushingOnServerThread || !this.server.isSameThread();
+-
++        // Canvas start - region threading
++        boolean flush = !this.suspendFlushingOnServerThread ||
++            !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(connection.getPlayer());
+         try {
+-            this.connection.send(packet, sendListener, flag);
++            this.connection.send(packet, sendListener, flush);
++        // Canvas end - region threading
+         } catch (Throwable var7) {
+             CrashReport crashReport = CrashReport.forThrowable(var7, "Sending packet");
+             CrashReportCategory crashReportCategory = crashReport.addCategory("Packet being sent");
 diff --git a/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java b/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java
 index 2cc3dd1f267ae78d3aacb84509d4bf668235688f..dacf6f0ccaea50dbb0d5f0f0173d5b0d51aaceea 100644
 --- a/net/minecraft/server/network/ServerConfigurationPacketListenerImpl.java

--- a/canvas-server/minecraft-patches/base/0014-Fix-world-load-and-unload-API.patch
+++ b/canvas-server/minecraft-patches/base/0014-Fix-world-load-and-unload-API.patch
@@ -52,7 +52,7 @@ index 09566c1a0505d112d7a03200789243d7c82f6466..f2cef3ee3300a58af2d34c65341ab2b6
          // worldborder tick
          // advancing the weather cycle
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 3ef5fca023aeb70cd83a7200b0ccf20ef8ef6b18..f221b9bc7074236a30cceac5b7a386ba9acb306b 100644
+index c0291ae3509ba54ed5691d92ee457126a6061628..c35522077cca5d20d3845d74c17924091876eb9e 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1657,6 +1657,69 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/canvas-server/minecraft-patches/base/0014-Fix-world-load-and-unload-API.patch
+++ b/canvas-server/minecraft-patches/base/0014-Fix-world-load-and-unload-API.patch
@@ -52,7 +52,7 @@ index 09566c1a0505d112d7a03200789243d7c82f6466..f2cef3ee3300a58af2d34c65341ab2b6
          // worldborder tick
          // advancing the weather cycle
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index b24997f5f11aaffa8b002831d196936218890eec..e37752d6020db52107c90d82d17347c430f111ef 100644
+index 3ef5fca023aeb70cd83a7200b0ccf20ef8ef6b18..f221b9bc7074236a30cceac5b7a386ba9acb306b 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -1657,6 +1657,69 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa

--- a/canvas-server/minecraft-patches/base/0015-Rewrite-Waypoints.patch
+++ b/canvas-server/minecraft-patches/base/0015-Rewrite-Waypoints.patch
@@ -31,7 +31,7 @@ index bff5d52536f1202f916e8b93e2592ab512f4e850..689a2b5ca3eac55d19b1ea50a315c525
          //this.updateSkyBrightness(); // Folia - region threading - delay until first tick
          // Paper start - rewrite chunk system
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 79360e5c65d45ab8f619bc789d0e4322ce95ffbc..bf985623c7a6b35d266f48fc98f68b4a571bd154 100644
+index 1fd0df462ae28d58789aba5e1f60df8615e339bc..07a3b57dc63095c8a5f818725b58cd551d6d2a77 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -266,6 +266,10 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/base/0015-Rewrite-Waypoints.patch
+++ b/canvas-server/minecraft-patches/base/0015-Rewrite-Waypoints.patch
@@ -31,7 +31,7 @@ index bff5d52536f1202f916e8b93e2592ab512f4e850..689a2b5ca3eac55d19b1ea50a315c525
          //this.updateSkyBrightness(); // Folia - region threading - delay until first tick
          // Paper start - rewrite chunk system
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 1fd0df462ae28d58789aba5e1f60df8615e339bc..07a3b57dc63095c8a5f818725b58cd551d6d2a77 100644
+index fd8ec07dac4f0612c96d5006d398c54ad0b56254..ed3f719c956e5d2233c9a14f76bdeda08753111b 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -266,6 +266,10 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/base/0016-Fix-respawn-anchor-charges-not-being-processed.patch
+++ b/canvas-server/minecraft-patches/base/0016-Fix-respawn-anchor-charges-not-being-processed.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix respawn anchor charges not being processed
 
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index bf985623c7a6b35d266f48fc98f68b4a571bd154..52ce14982505a9e2fa9987b6e1c303c2dda52f3c 100644
+index 07a3b57dc63095c8a5f818725b58cd551d6d2a77..187eae2106b8c91c4b165be5ab46df42f18daa8c 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -1611,7 +1611,11 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/base/0016-Fix-respawn-anchor-charges-not-being-processed.patch
+++ b/canvas-server/minecraft-patches/base/0016-Fix-respawn-anchor-charges-not-being-processed.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Fix respawn anchor charges not being processed
 
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 07a3b57dc63095c8a5f818725b58cd551d6d2a77..187eae2106b8c91c4b165be5ab46df42f18daa8c 100644
+index ed3f719c956e5d2233c9a14f76bdeda08753111b..ec8b437add9bc462d0c0258e9ff55a0c32df5bbc 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -1611,7 +1611,11 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/base/0017-Rewrite-Ender-Pearl-Saving.patch
+++ b/canvas-server/minecraft-patches/base/0017-Rewrite-Ender-Pearl-Saving.patch
@@ -66,7 +66,7 @@ index f2cef3ee3300a58af2d34c65341ab2b6feee641d..22784873f951e228da76d99dab1e6592
  
      private void tickPlayerSample() {
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index f221b9bc7074236a30cceac5b7a386ba9acb306b..f3a28aac5f3bb8cf12af73a0abc725bf5997303f 100644
+index c35522077cca5d20d3845d74c17924091876eb9e..3bce1f96bc98c5a313e26fc7642e61f5619e5e51 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -288,6 +288,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -78,7 +78,7 @@ index f221b9bc7074236a30cceac5b7a386ba9acb306b..f3a28aac5f3bb8cf12af73a0abc725bf
      public final ca.spottedleaf.moonrise.common.time.TickData tickTimes1s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(1L));
      public final ca.spottedleaf.moonrise.common.time.TickData tickTimes5s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(5L));
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 187eae2106b8c91c4b165be5ab46df42f18daa8c..0da35e4158da2c7c8cdee5726f03278574c15e55 100644
+index ec8b437add9bc462d0c0258e9ff55a0c32df5bbc..8b013e8dc92ddb0d8f42a5cfe3c9b9e92e4c1722 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -270,7 +270,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/base/0017-Rewrite-Ender-Pearl-Saving.patch
+++ b/canvas-server/minecraft-patches/base/0017-Rewrite-Ender-Pearl-Saving.patch
@@ -66,7 +66,7 @@ index f2cef3ee3300a58af2d34c65341ab2b6feee641d..22784873f951e228da76d99dab1e6592
  
      private void tickPlayerSample() {
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index e37752d6020db52107c90d82d17347c430f111ef..e3baeb9275f4cae94f10b25484a1444f6ebe455d 100644
+index f221b9bc7074236a30cceac5b7a386ba9acb306b..f3a28aac5f3bb8cf12af73a0abc725bf5997303f 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -288,6 +288,7 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -78,7 +78,7 @@ index e37752d6020db52107c90d82d17347c430f111ef..e3baeb9275f4cae94f10b25484a1444f
      public final ca.spottedleaf.moonrise.common.time.TickData tickTimes1s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(1L));
      public final ca.spottedleaf.moonrise.common.time.TickData tickTimes5s  = new ca.spottedleaf.moonrise.common.time.TickData(java.util.concurrent.TimeUnit.SECONDS.toNanos(5L));
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 52ce14982505a9e2fa9987b6e1c303c2dda52f3c..716452f1588ceffa45e9bac664ce0da8ddb31943 100644
+index 187eae2106b8c91c4b165be5ab46df42f18daa8c..0da35e4158da2c7c8cdee5726f03278574c15e55 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -270,7 +270,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -129,7 +129,7 @@ index 52ce14982505a9e2fa9987b6e1c303c2dda52f3c..716452f1588ceffa45e9bac664ce0da8
      }
  
      private void loadAndSpawnEnderPearl(ValueInput input) {
-@@ -3422,11 +3444,13 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+@@ -3425,11 +3447,13 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
      }
  
      public void registerEnderPearl(ThrownEnderpearl enderPearl) {

--- a/canvas-server/minecraft-patches/base/0019-Implement-Teleport-Portal-and-Respawn-Events.patch
+++ b/canvas-server/minecraft-patches/base/0019-Implement-Teleport-Portal-and-Respawn-Events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Teleport Portal and Respawn Events
 
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 0da35e4158da2c7c8cdee5726f03278574c15e55..564f23aae54335c62278c8a5bba140f2b82b4e6d 100644
+index 8b013e8dc92ddb0d8f42a5cfe3c9b9e92e4c1722..24f134768bfa1dcbc3f6b19006b32761ebcf9c19 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -1728,14 +1728,29 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/base/0019-Implement-Teleport-Portal-and-Respawn-Events.patch
+++ b/canvas-server/minecraft-patches/base/0019-Implement-Teleport-Portal-and-Respawn-Events.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Implement Teleport Portal and Respawn Events
 
 
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 716452f1588ceffa45e9bac664ce0da8ddb31943..2ff6e8279cf5f959032d3ccf31f4b91527bd2a2f 100644
+index 0da35e4158da2c7c8cdee5726f03278574c15e55..564f23aae54335c62278c8a5bba140f2b82b4e6d 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -1728,14 +1728,29 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/base/0020-Fix-End-Credits.patch
+++ b/canvas-server/minecraft-patches/base/0020-Fix-End-Credits.patch
@@ -27,7 +27,7 @@ index 22784873f951e228da76d99dab1e65925fd3697a..b95f76adf2d37badc4d2dcacf340e569
  
              if (!conn.isConnected()) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 2ff6e8279cf5f959032d3ccf31f4b91527bd2a2f..90a65f39997ac147247a5055b7d8d070c509dfbf 100644
+index 564f23aae54335c62278c8a5bba140f2b82b4e6d..94762c889db6f9a2643795b784087a44a500b6fb 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -269,6 +269,8 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -83,7 +83,7 @@ index 2ff6e8279cf5f959032d3ccf31f4b91527bd2a2f..90a65f39997ac147247a5055b7d8d070
      }
  
      @Override
-@@ -1998,12 +2020,22 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+@@ -2001,12 +2023,22 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
                  return false;
              }
              this.wonGame = true;

--- a/canvas-server/minecraft-patches/base/0020-Fix-End-Credits.patch
+++ b/canvas-server/minecraft-patches/base/0020-Fix-End-Credits.patch
@@ -27,7 +27,7 @@ index 22784873f951e228da76d99dab1e65925fd3697a..b95f76adf2d37badc4d2dcacf340e569
  
              if (!conn.isConnected()) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 564f23aae54335c62278c8a5bba140f2b82b4e6d..94762c889db6f9a2643795b784087a44a500b6fb 100644
+index 24f134768bfa1dcbc3f6b19006b32761ebcf9c19..66f6467534a213d921451a49e5833820489a04d6 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -269,6 +269,8 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -21,15 +21,7 @@
  
              while (this.running) {
                  final long tickStart = System.nanoTime(); // Paper - improve tick loop
-@@ -1724,6 +_,7 @@
-         // Folia end - region threading
-         //this.tickCount++; // Folia - region threading
-         //this.tickRateManager.tick(); // Folia - region threading
-+        region.world.getCurrentWorldData().tpsbar.tick(); // Canvas - tpsbar
-         this.tickChildren(hasTimeLeft, region); // Folia - region threading
-         if (false && nanos - this.lastServerStatus >= STATUS_EXPIRE_TIME_NANOS) { // Folia - region threading
-             this.lastServerStatus = nanos;
-@@ -1849,6 +_,21 @@
+@@ -1873,12 +_,28 @@
          //io.papermc.paper.adventure.providers.ClickCallbackProviderImpl.DIALOG_CLICK_MANAGER.handleQueue(this.tickCount); // Paper // Folia - region threading - moved to global tick
          //this.getFunctions().tick(); // Folia - region threading - TODO Purge functions
          this.updateEffectiveRespawnData();
@@ -51,7 +43,14 @@
  
          // CraftBukkit start
          // Run tasks that are waiting on processing
-@@ -2007,7 +_,7 @@
+         if (false) while (!this.processQueue.isEmpty()) { // Folia - region threading
+             this.processQueue.remove().run();
+         }
++        region.world.getCurrentWorldData().tpsbar.tick(); // Canvas - tpsbar
+ 
+         // Send time updates to everyone, it will get the right time from the world the player is in.
+         // Paper start - Perf: Optimize time updates
+@@ -2031,7 +_,7 @@
  
      @DontObfuscate
      public String getServerModName() {
@@ -60,7 +59,7 @@
      }
  
      public SystemReport fillSystemReport(SystemReport systemReport) {
-@@ -2307,6 +_,13 @@
+@@ -2331,6 +_,13 @@
          return 256;
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -102,7 +102,7 @@
                          return;
                      }
  
-@@ -2179,7 +_,7 @@
+@@ -2182,7 +_,7 @@
              CriteriaTriggers.CHANGED_DIMENSION.trigger(this, resourceKey, resourceKey1);
          }
  
@@ -111,7 +111,7 @@
              // CraftBukkit end
              CriteriaTriggers.NETHER_TRAVEL.trigger(this, this.enteredNetherPosition);
          }
-@@ -2342,7 +_,7 @@
+@@ -2345,7 +_,7 @@
          if (this.spawnExtraParticlesOnFall && onGround && this.fallDistance > 0.0) {
              Vec3 vec3 = pos.getCenter().add(0.0, 0.5, 0.0);
              int i = (int)Mth.clamp(50.0 * this.fallDistance, 0.0, 200.0);
@@ -120,7 +120,7 @@
              this.spawnExtraParticlesOnFall = false;
          }
  
-@@ -2557,7 +_,7 @@
+@@ -2560,7 +_,7 @@
                      this.awardStat(Stats.SWIM_ONE_CM, rounded);
                      this.causeFoodExhaustion(this.level().spigotConfig.swimMultiplier * (float) rounded * 0.01F, org.bukkit.event.entity.EntityExhaustionEvent.ExhaustionReason.SWIM); // CraftBukkit - EntityExhaustionEvent // Spigot
                  }
@@ -129,7 +129,7 @@
                  int rounded = Math.round((float)Math.sqrt(dx * dx + dy * dy + dz * dz) * 100.0F);
                  if (rounded > 0) {
                      this.awardStat(Stats.WALK_UNDER_WATER_ONE_CM, rounded);
-@@ -2681,6 +_,7 @@
+@@ -2684,6 +_,7 @@
  
      public void disconnect() {
          this.disconnected = true;
@@ -137,7 +137,7 @@
          this.ejectPassengers();
  
          // Paper start - Workaround vehicle not tracking the passenger disconnection dismount
-@@ -3560,7 +_,7 @@
+@@ -3563,7 +_,7 @@
      }
  
      public Set<DebugSubscription<?>> debugSubscriptions() {
@@ -146,7 +146,7 @@
      }
  
      public record RespawnConfig(LevelData.RespawnData respawnData, boolean forced) {
-@@ -3573,7 +_,7 @@
+@@ -3576,7 +_,7 @@
          );
  
          static ResourceKey<Level> getDimensionOrDefault(ServerPlayer.@Nullable RespawnConfig respawnConfig) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
@@ -1,7 +1,7 @@
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-@@ -315,10 +_,47 @@
-     }
+@@ -322,10 +_,47 @@
+     // Canvas end - optimize flush calls with region threading
  
      public void send(Packet<?> packet) {
 +        // Canvas start - no chat reports

--- a/canvas-server/paper-patches/files/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java.patch
+++ b/canvas-server/paper-patches/files/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java.patch
@@ -1,0 +1,46 @@
+--- a/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
++++ b/src/main/java/ca/spottedleaf/moonrise/common/util/TickThread.java
+@@ -243,10 +_,21 @@
+         if (entity == null) {
+             return true;
+         }
++        // Canvas start - optimize thread check
++        final Thread thread = Thread.currentThread();
++        // not on tick thread, can't possibly own the entity
++        if (!(thread instanceof TickThread tickThread)) return false;
++        // not on tick runner, meaning not part of the region scheduler, nope
++        if (!(tickThread instanceof TickRegionScheduler.TickThreadRunner threadRunner)) {
++            // if is shutdown thread, it owns the entity
++            // note, shutdown thread is instanceof TickThread, so this works
++            return tickThread instanceof RegionShutdownThread;
++        }
++        // Canvas end - optimize thread check
+         final ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region =
+-            TickRegionScheduler.getCurrentRegion();
++            threadRunner.currentTickingRegion;// Canvas - optimize thread check
+         if (region == null) {
+-            if (RegionizedServer.isGlobalTickThread()) {
++            if (RegionizedServer.getGlobalTickData() == threadRunner.currentTickingTask) {// Canvas - optimize thread check
+                 if (entity instanceof net.minecraft.server.level.ServerPlayer serverPlayer) {
+                     final net.minecraft.server.network.ServerGamePacketListenerImpl possibleBad = serverPlayer.connection;
+                     if (possibleBad == null) {
+@@ -265,9 +_,7 @@
+                     return false;
+                 }
+             }
+-            if (isShutdownThread()) {
+-                return true;
+-            }
++            // Canvas - optimize thread check
+             if (entity instanceof net.minecraft.server.level.ServerPlayer serverPlayer) {
+                 // off-main access to server player is never ok, server player is owned by one of global context or region context always
+                 return false;
+@@ -286,7 +_,7 @@
+             return false;
+         }
+ 
+-        final RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        final RegionizedWorldData worldData = threadRunner.currentTickingWorldRegionizedData; // Canvas - optimize thread check
+ 
+         // pass through the check if the entity is removed and we own its chunk
+         if (worldData.hasEntity(entity)) {


### PR DESCRIPTION
In Vanilla, it suspends/resumes flushing of packets unless the packet being sent is async. This helps have fewer flush calls meaning less syscalls and such, and is much better for TCP connections and Netty

Folia is always in a constant state of flush, meaning every single packet makes the server flush the channel. This is ungodly stupid and is actually horrendous for performance of Netty.

This patch fixes this and makes it restore the suspend/resume flushing during the main region tick, and optimizes the entity thread check to call `Thread.currentThread()` fewer times.

This is moved to the region threading fixes patch, since technically this is a fix to the region threading model, however it can be moved outside of this into its own patch.