### PR TITLE
Preserve hidden ender chest rows when permissions change

### DIFF
--- a/canvas-server/minecraft-patches/base/0004-Purpur-Ender-Chest-6-Rows-Config.patch
+++ b/canvas-server/minecraft-patches/base/0004-Purpur-Ender-Chest-6-Rows-Config.patch
@@ -84,7 +84,7 @@ index 1fb3a34ea872dec73658fac59743e46ef8db5151..6c3fb411f31ffbe9775fd7c43b7c79c8
          return new ChestMenu(MenuType.GENERIC_9x6, containerId, playerInventory, container, 6);
      }
 diff --git a/net/minecraft/world/inventory/PlayerEnderChestContainer.java b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
-index 9749909b8253b432bb2f7fba2cd8ff17a8579b30..9fef1faf4e6eb148d1b49426373de9614078d481 100644
+index 9749909b8253b432bb2f7fba2cd8ff17a8579b30..dd9b7702a445faca539d795a9efecd035402bc4e 100644
 --- a/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 +++ b/net/minecraft/world/inventory/PlayerEnderChestContainer.java
 @@ -26,11 +26,18 @@ public class PlayerEnderChestContainer extends SimpleContainer {
@@ -107,6 +107,31 @@ index 9749909b8253b432bb2f7fba2cd8ff17a8579b30..9fef1faf4e6eb148d1b49426373de961
      public void setActiveChest(EnderChestBlockEntity enderChestBlockEntity) {
          this.activeChest = enderChestBlockEntity;
      }
+@@ -40,19 +47,21 @@ public class PlayerEnderChestContainer extends SimpleContainer {
+     }
+ 
+     public void fromSlots(ValueInput.TypedInputList<ItemStackWithSlot> input) {
+-        for (int i = 0; i < this.getContainerSize(); i++) {
++        int storageSlotCount = super.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        for (int i = 0; i < storageSlotCount; i++) {
+             this.setItem(i, ItemStack.EMPTY);
+         }
+ 
+         for (ItemStackWithSlot itemStackWithSlot : input) {
+-            if (itemStackWithSlot.isValidInContainer(this.getContainerSize())) {
++            if (itemStackWithSlot.isValidInContainer(storageSlotCount)) {
+                 this.setItem(itemStackWithSlot.slot(), itemStackWithSlot.stack());
+             }
+         }
+     }
+ 
+     public void storeAsSlots(ValueOutput.TypedOutputList<ItemStackWithSlot> output) {
+-        for (int i = 0; i < this.getContainerSize(); i++) {
++        int storageSlotCount = super.getContainerSize(); // Purpur - preserve hidden ender chest rows
++        for (int i = 0; i < storageSlotCount; i++) {
+             ItemStack item = this.getItem(i);
+             if (!item.isEmpty()) {
+                 output.add(new ItemStackWithSlot(i, item));
 diff --git a/net/minecraft/world/level/block/EnderChestBlock.java b/net/minecraft/world/level/block/EnderChestBlock.java
 index 383e8285d366c7f594b0b4ff55b367970c9b69e4..9c61abf2092afe1d39ee41033c4452c4db95e25e 100644
 --- a/net/minecraft/world/level/block/EnderChestBlock.java


### PR DESCRIPTION
- Fixes item loss when ender chest row permissions are reduced. (Closes #200)

~~Previously, the permission-limited ender chest size was also used when loading and saving the player’s ender chest contents. If a player had 6 rows, placed items in rows 4-6, then later logged in without `purpur.enderchest.rows.six` the container reported a smaller size and those hidden slots were not saved back to player data.~~

~~This change keeps the permission-based row limit for access/UI behavior, but uses the full backing ender chest storage size when loading and saving contents. Hidden rows remain inaccessible without permission, but their items stay persisted and become available again if the player regains the required row permission.~~

EDIT: This adds support for preserving ender chest contents in rows hidden by permission-based row limits.

Currently, when permission-based ender chest rows are enabled, reducing a player’s allowed row count also reduces the size used by ender chest load/save logic. As a result, slots outside the player’s current permission range are not retained. This change keeps the existing permission-based access behavior intact: players can only view and interact with rows they currently have permission for. The new behavior is that hidden rows remain part of the backing storage during persistence, so their contents can be retained and become available again if the player regains the required row permission.

[@/BillyGalbreath (Purpur creator) says this is not a bug and is working as intended](https://github.com/PurpurMC/Purpur/issues/1773#issuecomment-4286755404), asked if it instead it could be intended to work this way. Hence the strike-through and rename. 

At the very least it would be nice if this can be added to Canvas so ender chests aren't screwed for people.