### PR TITLE
Only filter the actual useless packet

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
@@ -109,23 +109,17 @@ index ff49ffb122bb46b261b8d16f3f253746a2e4e8be..0b8e63684c46d130fca2c753a0030a43
                      }
                  }
  
-@@ -268,6 +315,21 @@ public class ServerEntity {
+@@ -268,6 +315,15 @@ public class ServerEntity {
              this.synchronizer.sendToTrackingPlayersAndSelf(new ClientboundSetEntityMotionPacket(this.entity));
          }
      }
-+    // Canvas start - reduce useless move packets
 +
++    // Canvas start - reduce useless move packets
 +    private boolean canvas$isUselessMoveEntityPacket(@Nullable Packet<?> packet) {
-+        if (!(packet instanceof ClientboundMoveEntityPacket moveEntityPacket)) return false;
-+        return switch (packet) {
-+            case ClientboundMoveEntityPacket.Pos ignored ->
-+                moveEntityPacket.getXa() == 0 && moveEntityPacket.getYa() == 0 && moveEntityPacket.getZa() == 0;
-+            case ClientboundMoveEntityPacket.PosRot ignored ->
-+                moveEntityPacket.getXa() == 0 && moveEntityPacket.getYa() == 0 && moveEntityPacket.getZa() == 0 && moveEntityPacket.getYRot() == 0 && moveEntityPacket.getXRot() == 0;
-+            case ClientboundMoveEntityPacket.Rot ignored ->
-+                moveEntityPacket.getYRot() == 0 && moveEntityPacket.getXRot() == 0;
-+            default -> false;
-+        };
++        if (packet instanceof ClientboundMoveEntityPacket.Pos posPacket) {
++            return posPacket.getXa() == 0 && posPacket.getYa() == 0 && posPacket.getZa() == 0;
++        }
++        return false;
 +    }
 +    // Canvas end - reduce useless move packets
  


### PR DESCRIPTION
Out of `Pos`, `PosRot` and `Rot`, only the Pos packet represents a delta, making it the only possible packet to be actually useless if the movement is 0.
`PosRot` and `Rot` are floating points, meaning comparing it directly is not appropriate and are very unlikely to match, and even when they do match, the rotation is _not_ a delta but a **new angle** (See [Java Protocol](https://minecraft.wiki/w/Java_Edition_protocol/Packets#Update_Entity_Position)), it will trigger whenever an entity decides to face south rather than just not moving their heads.