### PR TITLE
Fix filtered ender pearl motion sync

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
@@ -58,7 +58,7 @@
                      Vec3 deltaMovement = this.entity.getDeltaMovement();
                      double d = deltaMovement.distanceToSqr(this.lastSentMovement);
                      if (d > 1.0E-7 || d > 0.0 && deltaMovement.lengthSqr() == 0.0) {
-@@ -210,9 +_,41 @@
+@@ -210,9 +_,42 @@
                                          )
                                      )
                                  );
@@ -85,14 +85,14 @@
 +                               3. Ender Eyes, they depend on their velocity being set bc the packet sets the velocity on the client, but the client doesn't handle the
 +                                    ender eye velocity on its own bc the ender eye velocity is in relation to the stronghold structure which the client doesn't have access to
 +                               4. Shulker bullets use random to determine where they are going, so we need to send velocity packets to ensure it remains smooth on the client
-+
 +                               This filter helps keep unneeded packets reduced, but also ensures that we keep smooth visual gameplay
 +                            */
 +                            if (
 +                                (this.entity instanceof net.minecraft.world.entity.item.ItemEntity && flag1) ||
 +                                this.entity instanceof net.minecraft.world.entity.projectile.EyeOfEnder ||
 +                                this.entity instanceof net.minecraft.world.entity.animal.squid.Squid ||
-+                                this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet
++                                this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet ||
++                                this.entity instanceof net.minecraft.world.entity.projectile.throwableitemprojectile.ThrownEnderpearl
 +                            ) {
 +                                this.synchronizer.sendToTrackingPlayers(new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement));
 +                            }


### PR DESCRIPTION
Fixes ender pearls being affected by `filterClientboundSetEntityMotionPacket`.

Ender pearls inherit shooter movement as part of their velocity. When motion packets are filtered, the client can miss velocity corrections and visually desync pearl movement, especially when throwing while sprinting.

This adds `ThrownEnderpearl` to the existing entity motion packet allow-list, matching other entities that require velocity sync for smooth client-side rendering.
