### PR TITLE
Improve projectile tracking smoothness

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ChunkMap.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ChunkMap.java.patch
@@ -1,5 +1,13 @@
 --- a/net/minecraft/server/level/ChunkMap.java
 +++ b/net/minecraft/server/level/ChunkMap.java
+@@ -72,6 +_,7 @@
+ import net.minecraft.world.entity.EntityType;
+ import net.minecraft.world.entity.ai.village.poi.PoiManager;
+ import net.minecraft.world.entity.boss.enderdragon.EnderDragonPart;
++import net.minecraft.world.entity.projectile.Projectile;
+ import net.minecraft.world.level.ChunkPos;
+ import net.minecraft.world.level.Level;
+ import net.minecraft.world.level.TicketStorage;
 @@ -253,7 +_,7 @@
  
          final int index = entity.getType().getCategory().ordinal();
@@ -9,6 +17,16 @@
          if (inRange == null) {
              return;
          }
+@@ -979,6 +_,9 @@
+             i = org.spigotmc.TrackingRange.getEntityTrackingRange(entity, i); // Spigot
+             if (i != 0) {
+                 int updateInterval = type.updateInterval();
++                if (entity instanceof Projectile) {
++                    updateInterval = 1; // Canvas - smooth projectile tracking under load
++                }
+                 if (entity.moonrise$getTrackedEntity() != null) { // Folia - region threading
+                     throw (IllegalStateException)Util.pauseInIde(new IllegalStateException("Entity is already tracked!"));
+                 } else {
 @@ -661,7 +_,7 @@
                  printFuture(chunkHolder.getEntityTickingChunkFuture()),
                  this.ticketStorage.getTicketDebugString(longKey, false),

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerEntity.java.patch
@@ -58,7 +58,14 @@
                      Vec3 deltaMovement = this.entity.getDeltaMovement();
                      double d = deltaMovement.distanceToSqr(this.lastSentMovement);
                      if (d > 1.0E-7 || d > 0.0 && deltaMovement.lengthSqr() == 0.0) {
-@@ -210,9 +_,41 @@
+@@ -202,7 +_,7 @@
+-                        this.lastSentMovement = deltaMovement;
+                         if (this.entity instanceof AbstractHurtingProjectile abstractHurtingProjectile) {
++                            this.lastSentMovement = deltaMovement;
+                             this.synchronizer
+                                 .sendToTrackingPlayers(
+                                     new ClientboundBundlePacket(
+@@ -210,9 +_,44 @@
                                          )
                                      )
                                  );
@@ -66,6 +73,7 @@
 +                        // Canvas start - filter ClientboundSetEntityMotionPacket
 +                        } else if (!io.canvasmc.canvas.Config.INSTANCE.networking.filterClientboundSetEntityMotionPacket) {
 +                            // sends all of them if not filtering
++                            this.lastSentMovement = deltaMovement;
                              this.synchronizer.sendToTrackingPlayers(new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement));
 +                        } else {
 +                            /*
@@ -92,8 +100,10 @@
 +                                (this.entity instanceof net.minecraft.world.entity.item.ItemEntity && flag1) ||
 +                                this.entity instanceof net.minecraft.world.entity.projectile.EyeOfEnder ||
 +                                this.entity instanceof net.minecraft.world.entity.animal.squid.Squid ||
-+                                this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet
++                                this.entity instanceof net.minecraft.world.entity.projectile.ShulkerBullet ||
++                                this.entity instanceof net.minecraft.world.entity.projectile.throwableitemprojectile.ThrownEnderpearl
 +                            ) {
++                                this.lastSentMovement = deltaMovement;
 +                                this.synchronizer.sendToTrackingPlayers(new ClientboundSetEntityMotionPacket(this.entity.getId(), this.lastSentMovement));
 +                            }
                          }
@@ -123,3 +133,12 @@
  
      private void handleMinecartPosRot(NewMinecartBehavior behavior, byte yRot, byte xRot, boolean dirty) {
          this.sendDirtyEntityData();
+@@ -323,6 +_,9 @@
+         Packet<ClientGamePacketListener> addEntityPacket = this.entity.getAddEntityPacket(this);
+         consumer.accept(addEntityPacket);
++        if (this.entity instanceof net.minecraft.world.entity.projectile.throwableitemprojectile.ThrownEnderpearl) {
++            consumer.accept(new ClientboundSetEntityMotionPacket(this.entity.getId(), this.entity.getDeltaMovement()));
++        }
+         if (this.trackedDataValues != null) {
+             consumer.accept(new ClientboundSetEntityDataPacket(this.entity.getId(), this.trackedDataValues));
+         }


### PR DESCRIPTION
## Summary
- update projectile entity tracking to tick every server tick for smoother client movement under load
- keep ender pearl motion packets synchronized when motion packet filtering is enabled

## Testing
- ./gradlew :canvas-server:compileJava
- ./gradlew createMojmapPublisherJar
- tested on DE-1 under live conditions