### PR TITLE
Fix save task player data

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/players/PlayerList.java.patch
@@ -35,10 +35,11 @@
              )
          );
          player.getBukkitEntity().sendSupportedChannels(); // CraftBukkit
-@@ -292,6 +_,7 @@
+@@ -292,6 +_,8 @@
  
          // player.connection.send(ClientboundPlayerInfoUpdatePacket.createPlayerInitializing(this.players)); // CraftBukkit - replaced with loop below
          this.players.add(player);
++        player.lastSave = System.nanoTime(); // Canvas - init lastSave on join
 +        this.canvas$pushToBuckets(player); // Canvas - optimize playerlist tick
          this.playersByName.put(player.getScoreboardName().toLowerCase(java.util.Locale.ROOT), player); // Spigot
          this.playersByUUID.put(player.getUUID(), player);
@@ -175,7 +176,7 @@
                      player.connection.send(packet);
                  }
              }
-@@ -1053,9 +_,9 @@
+@@ -1053,13 +_,13 @@
              int numSaved = 0;
              final long now = System.nanoTime(); // Folia - region threading
              final long timeInterval = (long)interval * io.papermc.paper.threadedregions.TickRegionScheduler.getTimeBetweenTicks(); // Folia - region threading // Canvas - region threading
@@ -187,6 +188,11 @@
                  continue;
              }
              // Folia end - region threading
+-            if (interval == -1 || now - player.lastSave >= timeInterval) { // Folia - region threading
++                if (interval == -1 || player.lastSave == ServerPlayer.LAST_SAVE_ABSENT || now - player.lastSave >= timeInterval) { // Folia - region threading // Canvas - fix overflow on LAST_SAVE_ABSENT
+                 this.save(player);
+                 if (interval != -1 && ++numSaved >= io.papermc.paper.configuration.GlobalConfiguration.get().playerAutoSave.maxPerTick()) {
+                     break;
 @@ -1270,6 +_,7 @@
      }
  


### PR DESCRIPTION
I noticed on a server I was working on that players were being rolled back if they didn’t disconnect properly (e.g., machine crash or similar). After investigating, I found that PlayerList#saveAll was never triggered because Player#lastSave was set to Long.MIN_VALUE when the player connected. Since this is a negative value, the condition required to perform the save was never met.