### PR TITLE
Region Guards

### DIFF
--- a/build-data/paperServer.at
+++ b/build-data/paperServer.at
@@ -1,5 +1,6 @@
 # This file is auto generated, any changes may be overridden!
 # See CONTRIBUTING.md on how to add access transformers.
+public ca.spottedleaf.moonrise.common.util.TickThread getThreadContext()Ljava/lang/String;
 public io.papermc.paper.world.migration.WorldMigrationContext
 public io.papermc.paper.world.migration.WorldMigrationContext <init>(Lnet/minecraft/world/level/storage/LevelStorageSource$LevelStorageAccess;Lnet/minecraft/core/HolderLookup$Provider;Ljava/lang/String;Lnet/minecraft/resources/ResourceKey;Lnet/minecraft/resources/ResourceKey;)V
 public io.papermc.paper.world.migration.WorldMigrationContext baseRoot()Ljava/nio/file/Path;

--- a/canvas-server/minecraft-patches/base/0022-Region-Tick-Guards.patch
+++ b/canvas-server/minecraft-patches/base/0022-Region-Tick-Guards.patch
@@ -1,0 +1,82 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <duerismc@gmail.com>
+Date: Mon, 4 May 2026 18:45:25 -0700
+Subject: [PATCH] Region Tick Guards
+
+
+diff --git a/net/minecraft/server/level/ChunkMap.java b/net/minecraft/server/level/ChunkMap.java
+index 6fcf0ee02caf94164c1d9a6e0fe2f813a8cc73a7..97c1f739253f986688178dbabc13bc114c6962bb 100644
+--- a/net/minecraft/server/level/ChunkMap.java
++++ b/net/minecraft/server/level/ChunkMap.java
+@@ -956,7 +956,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+     }
+ 
+     public void addEntity(final Entity entity) {
+-        org.spigotmc.AsyncCatcher.catchOp("entity track"); // Spigot
++        io.canvasmc.canvas.util.TickGuard.guard(entity, "Cannot add entity to tracking async"); // Canvas - region guards
+         // Paper start - ignore and warn about illegal addEntity calls instead of crashing server
+         if (!entity.valid || entity.level() != this.level || entity.moonrise$getTrackedEntity() != null) { // Folia - region threading
+             LOGGER.error("Illegal ChunkMap::addEntity for world " + io.papermc.paper.util.MCUtil.getLevelName(this.level)
+@@ -1004,7 +1004,7 @@ public class ChunkMap extends SimpleRegionStorage implements ChunkHolder.PlayerP
+     }
+ 
+     protected void removeEntity(final Entity entity) {
+-        org.spigotmc.AsyncCatcher.catchOp("entity untrack"); // Spigot
++        io.canvasmc.canvas.util.TickGuard.guard(entity, "Cannot remove entity from tracking async"); // Canvas - region guards
+         if (entity instanceof ServerPlayer player) {
+             this.updatePlayerStatus(player, false);
+ 
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index ae4c386eba2407bedb25861870bb3f55019321bc..c4cb32e8dfe18b41570fdd4c84a85d338bc8b68b 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -1773,7 +1773,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+ 
+     // CraftBukkit start
+     private boolean addEntity(final Entity entity, final org.bukkit.event.entity.CreatureSpawnEvent.@Nullable SpawnReason spawnReason) {
+-        org.spigotmc.AsyncCatcher.catchOp("entity add"); // Spigot
++        io.canvasmc.canvas.util.TickGuard.guard(entity, "Cannot add entity async"); // Canvas - region guards
+         entity.generation = false; // Paper - Don't fire sync event during generation; Reset flag if it was added during a ServerLevel generation process
+         // Paper start - extra debug info
+         if (entity.valid) {
+diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
+index 0b936e53ea6ce50ccd9f8fe23b875d35a814a1ad..8d9ebacb10f2c1510a50d0eced89eb0c642f7710 100644
+--- a/net/minecraft/server/level/ServerPlayer.java
++++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -891,6 +891,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+     }
+ 
+     public void initMenu(final AbstractContainerMenu container) {
++        io.canvasmc.canvas.util.TickGuard.guard(this, "Cannot init menu async"); // Canvas - region guards
+         container.addSlotListener(this.containerListener);
+         container.setSynchronizer(this.containerSynchronizer);
+     }
+@@ -2445,6 +2446,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+ 
+     @Override
+     public OptionalInt openMenu(final @Nullable MenuProvider provider) {
++        io.canvasmc.canvas.util.TickGuard.guard(this, "Cannot open menu async"); // Canvas - region guards
+         if (provider == null) {
+             return OptionalInt.empty();
+         } else {
+@@ -2583,6 +2585,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+     }
+     @Override
+     public void closeContainer(org.bukkit.event.inventory.InventoryCloseEvent.Reason reason) {
++        io.canvasmc.canvas.util.TickGuard.guard(this, "Cannot close container async"); // Canvas - region guards
+         org.bukkit.craftbukkit.event.CraftEventFactory.handleInventoryCloseEvent(this, reason); // CraftBukkit
+         // Paper end - Inventory close reason
+         this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
+diff --git a/net/minecraft/world/level/block/state/BlockBehaviour.java b/net/minecraft/world/level/block/state/BlockBehaviour.java
+index 42918460ae0fffdde1e7fab5baec6a3662b10be7..6c17f84e69a2a60d8a7170a9e16c27f356288ee9 100644
+--- a/net/minecraft/world/level/block/state/BlockBehaviour.java
++++ b/net/minecraft/world/level/block/state/BlockBehaviour.java
+@@ -170,7 +170,7 @@ public abstract class BlockBehaviour implements FeatureElement {
+     }
+ 
+     protected void onPlace(final BlockState state, final Level level, final BlockPos pos, final BlockState oldState, final boolean movedByPiston) {
+-        org.spigotmc.AsyncCatcher.catchOp("block onPlace"); // Spigot
++        io.canvasmc.canvas.util.TickGuard.guard(pos, level, "Cannot place block async"); // Canvas - region guards
+     }
+ 
+     protected void affectNeighborsAfterRemoval(final BlockState state, final ServerLevel level, final BlockPos pos, final boolean movedByPiston) {

--- a/canvas-server/minecraft-patches/base/0022-Region-Tick-Guards.patch
+++ b/canvas-server/minecraft-patches/base/0022-Region-Tick-Guards.patch
@@ -67,6 +67,18 @@ index 0b936e53ea6ce50ccd9f8fe23b875d35a814a1ad..8d9ebacb10f2c1510a50d0eced89eb0c
          org.bukkit.craftbukkit.event.CraftEventFactory.handleInventoryCloseEvent(this, reason); // CraftBukkit
          // Paper end - Inventory close reason
          this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
+diff --git a/net/minecraft/world/entity/LivingEntity.java b/net/minecraft/world/entity/LivingEntity.java
+index ba8f83d1f74fb17d15f732a5282b89e3452dc270..27bbe51f490d4248fda5347ba21b1ecdaca8265f 100644
+--- a/net/minecraft/world/entity/LivingEntity.java
++++ b/net/minecraft/world/entity/LivingEntity.java
+@@ -1831,6 +1831,7 @@ public abstract class LivingEntity extends Entity implements Attackable, Waypoin
+     }
+ 
+     public void die(final DamageSource source) {
++        io.canvasmc.canvas.util.TickGuard.guard(this, "Cannot die async"); // Canvas - region guards
+         if (!this.isRemoved() && !this.dead) {
+             Entity sourceEntity = source.getEntity();
+             LivingEntity killer = this.getKillCredit();
 diff --git a/net/minecraft/world/level/block/state/BlockBehaviour.java b/net/minecraft/world/level/block/state/BlockBehaviour.java
 index 42918460ae0fffdde1e7fab5baec6a3662b10be7..6c17f84e69a2a60d8a7170a9e16c27f356288ee9 100644
 --- a/net/minecraft/world/level/block/state/BlockBehaviour.java

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -67,7 +67,7 @@
      }
  
      private void saveParentVehicle(final ValueOutput playerOutput) {
-@@ -1447,6 +_,7 @@
+@@ -1448,6 +_,7 @@
          if (killer != null) {
              this.awardStat(Stats.ENTITY_KILLED_BY.get(killer.getType()));
              killer.awardKillScore(this, source);
@@ -75,7 +75,7 @@
              this.createWitherRose(killer);
          }
  
-@@ -1719,7 +_,7 @@
+@@ -1720,7 +_,7 @@
          }
          // Canvas end - region threading
          this.respawn((player) -> {
@@ -84,7 +84,7 @@
          }, org.bukkit.event.player.PlayerRespawnEvent.RespawnReason.END_PORTAL, true);
      }
  
-@@ -1852,7 +_,7 @@
+@@ -1853,7 +_,7 @@
          // find and modify respawn block state
          if (respawnWorld == null || respawnConfig == null) {
              // default to regular spawn
@@ -93,7 +93,7 @@
          } else {
              // load chunk for block
              // give at least 1 radius of loaded chunks so that we do not sync load anything
-@@ -1873,7 +_,7 @@
+@@ -1874,7 +_,7 @@
                              null, false, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.PLAYER_RESPAWN
                          );
                          // default to regular spawn
@@ -102,7 +102,7 @@
                          return;
                      }
  
-@@ -2225,7 +_,7 @@
+@@ -2226,7 +_,7 @@
              CriteriaTriggers.CHANGED_DIMENSION.trigger(this, oldKey, newKey);
          }
  
@@ -111,7 +111,7 @@
              // CraftBukkit end
              if (!respawning) CriteriaTriggers.NETHER_TRAVEL.trigger(this, this.enteredNetherPosition); // Canvas - region threading
          }
-@@ -2405,7 +_,7 @@
+@@ -2406,7 +_,7 @@
          if (this.spawnExtraParticlesOnFall && onGround && this.fallDistance > 0.0) {
              Vec3 centered = pos.getCenter().add(0.0, 0.5, 0.0);
              int particles = (int)Mth.clamp(50.0 * this.fallDistance, 0.0, 200.0);
@@ -120,7 +120,7 @@
                  .sendParticles(new BlockParticleOption(ParticleTypes.BLOCK, onState), centered.x, centered.y, centered.z, particles, 0.3F, 0.3F, 0.3F, 0.15F);
              this.spawnExtraParticlesOnFall = false;
          }
-@@ -2750,6 +_,7 @@
+@@ -2753,6 +_,7 @@
  
      public void disconnect() {
          this.disconnected = true;
@@ -128,7 +128,7 @@
          this.ejectPassengers();
  
          // Paper start - Workaround vehicle not tracking the passenger disconnection dismount
-@@ -3639,7 +_,7 @@
+@@ -3642,7 +_,7 @@
      }
  
      public Set<DebugSubscription<?>> debugSubscriptions() {
@@ -137,7 +137,7 @@
      }
  
      public record RespawnConfig(LevelData.RespawnData respawnData, boolean forced) {
-@@ -3652,7 +_,7 @@
+@@ -3655,7 +_,7 @@
          );
  
          private static ResourceKey<Level> getDimensionOrDefault(final ServerPlayer.@Nullable RespawnConfig respawnConfig) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -140,7 +140,7 @@
      }
  
      private void updateGlowingStatus() {
-@@ -1892,6 +_,7 @@
+@@ -1893,6 +_,7 @@
                      }
                  }
                  // Paper end
@@ -148,7 +148,7 @@
                  this.createWitherRose(killer);
                  }
  
-@@ -1908,7 +_,7 @@
+@@ -1909,7 +_,7 @@
      protected void createWitherRose(final @Nullable LivingEntity killer) {
          if (this.level() instanceof ServerLevel serverLevel) {
              boolean var6 = false;
@@ -157,7 +157,7 @@
                  if (serverLevel.getGameRules().get(GameRules.MOB_GRIEFING)) {
                      BlockPos pos = this.blockPosition();
                      BlockState state = Blocks.WITHER_ROSE.defaultBlockState();
-@@ -2219,7 +_,7 @@
+@@ -2220,7 +_,7 @@
  
      @Override
      public boolean isAlive() {
@@ -166,7 +166,7 @@
      }
  
      public boolean isLookingAtMe(
-@@ -2761,7 +_,7 @@
+@@ -2762,7 +_,7 @@
                  this.swapHandItems();
                  break;
              case 60:
@@ -175,7 +175,7 @@
                  break;
              case 65:
                  this.breakItem(this.getItemBySlot(EquipmentSlot.BODY));
-@@ -2826,6 +_,7 @@
+@@ -2827,6 +_,7 @@
      }
  
      protected void updateSwingTime() {
@@ -183,7 +183,7 @@
          int currentSwingDuration = this.getCurrentSwingDuration();
          if (this.swinging) {
              this.swingTime++;
-@@ -3165,7 +_,7 @@
+@@ -3166,7 +_,7 @@
              waterWalker *= 0.5F;
          }
  
@@ -192,7 +192,7 @@
              slowDown += (0.54600006F - slowDown) * waterWalker;
              speed += (this.getSpeed() - speed) * waterWalker;
          }
-@@ -3795,7 +_,7 @@
+@@ -3796,7 +_,7 @@
              this.checkAutoSpinAttack(beforeTravelBox, this.getBoundingBox());
          }
  
@@ -201,7 +201,7 @@
          // Paper start - Add EntityMoveEvent
          if (((ServerLevel) this.level()).getCurrentWorldData().hasEntityMoveEvent && !(this instanceof Player)) { // Folia - region threading
              if (this.xo != this.getX() || this.yo != this.getY() || this.zo != this.getZ() || this.yRotO != this.getYRot() || this.xRotO != this.getXRot()) {
-@@ -3831,6 +_,7 @@
+@@ -3832,6 +_,7 @@
      protected void updateFallFlying() {
          this.checkFallDistanceAccumulation();
          if (!this.level().isClientSide()) {
@@ -209,7 +209,7 @@
              if (!this.canGlide()) {
                  if (this.getSharedFlag(Entity.FLAG_FALL_FLYING) && !CraftEventFactory.callToggleGlideEvent(this, false).isCancelled()) // CraftBukkit
                  this.setSharedFlag(Entity.FLAG_FALL_FLYING, false);
-@@ -3869,6 +_,12 @@
+@@ -3870,6 +_,12 @@
      }
  
      protected void pushEntities() {
@@ -222,7 +222,7 @@
          // Paper start - don't run getEntities if we're not going to use its result
          if (!this.isPushable()) {
              return;
-@@ -3884,7 +_,11 @@
+@@ -3885,7 +_,11 @@
              return;
          }
          // Paper end - don't run getEntities if we're not going to use its result
@@ -235,7 +235,7 @@
          if (!pushableEntities.isEmpty()) {
              if (this.level() instanceof ServerLevel serverLevel) {
                  // Paper - don't run getEntities if we're not going to use its result; moved up
-@@ -4060,6 +_,7 @@
+@@ -4061,6 +_,7 @@
  
      @Override
      public boolean isCollidable(boolean ignoreClimbing) {
@@ -243,7 +243,7 @@
          return this.isAlive() && !this.isSpectator() && (ignoreClimbing || !this.onClimbable()) && this.collides; // CraftBukkit
          // Paper end - Climbing should not bypass cramming gamerule
      }
-@@ -4177,6 +_,18 @@
+@@ -4178,6 +_,18 @@
                  );
              }
  

--- a/canvas-server/paper-patches/base/0013-Region-Tick-Guards.patch
+++ b/canvas-server/paper-patches/base/0013-Region-Tick-Guards.patch
@@ -1,0 +1,53 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <duerismc@gmail.com>
+Date: Mon, 4 May 2026 18:45:25 -0700
+Subject: [PATCH] Region Tick Guards
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+index 0299c282682f623eab358d97604c6b62464a7bac..3489a4e14caec93651544146e00592ac52628311 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftHumanEntity.java
+@@ -502,6 +502,8 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     @Override
+     public InventoryView openMerchant(Merchant merchant, boolean force) {
+         Preconditions.checkNotNull(merchant, "merchant cannot be null");
++        io.canvasmc.canvas.util.TickGuard.guard(((org.bukkit.craftbukkit.entity.CraftEntity) merchant).entity, "Cannot open merchant screen of merchant not in same region"); // Canvas - region guards
++        io.canvasmc.canvas.util.TickGuard.guard(this.entity, "Cannot open merchant screen async from target player"); // Canvas - region guards
+ 
+         if (!force && merchant.isTrading()) {
+             return null;
+@@ -563,7 +565,7 @@ public class CraftHumanEntity extends CraftLivingEntity implements HumanEntity {
+     }
+ 
+     private InventoryView openInventory(Location location, boolean force, Material material) {
+-        org.spigotmc.AsyncCatcher.catchOp("open" + material);
++        io.canvasmc.canvas.util.TickGuard.guard(this.entity, "Cannot open inventory async"); // Canvas - region guards
+         if (location == null) {
+             location = this.getLocation();
+         }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+index db26642e0da92d81a9ae6bc5d6ea4febadab7080..38ae2cb6ec29a62bc07885b2855348515a777610 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
+@@ -509,7 +509,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
+ 
+     @Override
+     public boolean addPotionEffect(PotionEffect effect, boolean force) {
+-        org.spigotmc.AsyncCatcher.catchOp("effect add"); // Paper
++        io.canvasmc.canvas.util.TickGuard.guard(this.entity, "Cannot add potion effect async"); // Canvas - region guards
+         this.getHandle().addEffect(org.bukkit.craftbukkit.potion.CraftPotionUtil.fromBukkit(effect), EntityPotionEffectEvent.Cause.PLUGIN); // Paper - Don't ignore icon
+         return true;
+     }
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 961e2751d244b488a9db873260049b802d498f1f..5be9cd4d853031da3b5e80769beb79cb0ced02ca 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -1703,6 +1703,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+     @Override
+     public void setGameMode(GameMode mode) {
+         Preconditions.checkArgument(mode != null, "GameMode cannot be null");
++        io.canvasmc.canvas.util.TickGuard.guard(this.entity, "Cannot set gamemode async"); // Canvas - region guards
+         if (this.getHandle().connection == null) return;
+ 
+         this.getHandle().setGameMode(GameType.byId(mode.getValue()), org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.PLUGIN, null); // Paper - Expand PlayerGameModeChangeEvent

--- a/canvas-server/paper-patches/base/0013-Region-Tick-Guards.patch
+++ b/canvas-server/paper-patches/base/0013-Region-Tick-Guards.patch
@@ -27,7 +27,7 @@ index 0299c282682f623eab358d97604c6b62464a7bac..3489a4e14caec93651544146e00592ac
              location = this.getLocation();
          }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
-index db26642e0da92d81a9ae6bc5d6ea4febadab7080..38ae2cb6ec29a62bc07885b2855348515a777610 100644
+index 03fea774f874b21e87a1281eb07a6b52ed2c31cd..40b822fcb11965e74a68139f638b51995885779d 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftLivingEntity.java
 @@ -509,7 +509,7 @@ public class CraftLivingEntity extends CraftEntity implements LivingEntity {
@@ -40,10 +40,26 @@ index db26642e0da92d81a9ae6bc5d6ea4febadab7080..38ae2cb6ec29a62bc07885b285534851
          return true;
      }
 diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-index 961e2751d244b488a9db873260049b802d498f1f..5be9cd4d853031da3b5e80769beb79cb0ced02ca 100644
+index ffaeb706b4288fce82a8d7468dc00036e42eca27..c6416254d9426c5e68d2c0c968a09ba7a8c377a8 100644
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -1703,6 +1703,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+@@ -1381,6 +1381,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+ 
+     @Override
+     public void loadData() {
++        ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(this.entity, "Cannot load data async"); // Canvas - region guards
+         this.server.getHandle().playerIo.load(this.getHandle().nameAndId())
+             .map(tag -> TagValueInput.create(ProblemReporter.DISCARDING, this.server.getServer().registryAccess(), tag))
+             .ifPresent(this.getHandle()::load);
+@@ -1388,6 +1389,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+ 
+     @Override
+     public void saveData() {
++        ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(this.entity, "Cannot save data async"); // Canvas - region guards
+         this.server.getHandle().playerIo.save(this.getHandle());
+     }
+ 
+@@ -1703,6 +1705,7 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
      @Override
      public void setGameMode(GameMode mode) {
          Preconditions.checkArgument(mode != null, "GameMode cannot be null");

--- a/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java.patch
+++ b/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2122,8 +_,14 @@
+@@ -2123,8 +_,14 @@
  
      @Override
      public boolean canSee(org.bukkit.entity.Entity entity) {

--- a/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java.patch
+++ b/canvas-server/paper-patches/files/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java.patch
@@ -1,6 +1,6 @@
 --- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
 +++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
-@@ -2123,8 +_,14 @@
+@@ -2125,8 +_,14 @@
  
      @Override
      public boolean canSee(org.bukkit.entity.Entity entity) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -229,19 +229,6 @@ public class GlobalConfiguration extends Part {
                     "Configurations for the AFFINITY scheduler provided by Canvas. For these options to take effect,",
                     "change the 'threaded-regions.scheduler' option in 'paper-global.yml' to 'AFFINITY'"
                 );
-
-            option("overloadedLogMillis")
-                .docs(
-                    "Amount of time between the end and next start of a region tick where the server will log a",
-                    "warning that the scheduler is overloaded. Can help catch if you need to allocate more threads",
-                    "or help identify deadline missing issues"
-                ).greaterThan(0.0F);
-
-            option("defaultTickRate")
-                .docs(
-                    "The default tick rate for the scheduler. Vanilla is 20, the game will run faster or slower depending on how you adjust this value.",
-                    "Note this should really only be used for debugging purposes and for custom environments that require this change"
-                ).greaterThan(0.0F);
         }
 
         public AffinityScheduler affinityScheduler = new AffinityScheduler();
@@ -291,8 +278,43 @@ public class GlobalConfiguration extends Part {
             public boolean enableAffinitySchedulerCpuAffinity = false;
         }
 
+        {
+            option("overloadedLogMillis")
+                .docs(
+                    "Amount of time between the end and next start of a region tick where the server will log a",
+                    "warning that the scheduler is overloaded. Can help catch if you need to allocate more threads",
+                    "or help identify deadline missing issues"
+                ).greaterThan(0.0F);
+
+            option("defaultTickRate")
+                .docs(
+                    "The default tick rate for the scheduler. Vanilla is 20, the game will run faster or slower depending on how you adjust this value.",
+                    "Note this should really only be used for debugging purposes and for custom environments that require this change"
+                ).greaterThan(0.0F);
+
+            option("guardSeverity")
+                .docs(
+                    Style.wrap(
+                        "Canvas introduces extra tick thread checks to help catch plugin issues. This determines how aggressive the new guards are"
+                    ).defineEnum(GuardSeverity.class, (severity) -> {
+                        return switch (severity) {
+                            case LOG -> "Just logs a warning in console, but continues the operation";
+                            case THROW -> "Throws an exception, can crash the server. Good for ensuring correctness";
+                            case SILENT -> "Doesn't say anything or do anything";
+                        };
+                    })
+                );
+        }
+
         public long overloadedLogMillis = 5_000L;
         public float defaultTickRate = 20.0F;
+        public GuardSeverity guardSeverity = GuardSeverity.LOG;
+
+        public enum GuardSeverity {
+            SILENT,
+            LOG,
+            THROW
+        }
     }
 
     public ChunkSystem chunkSystem = new ChunkSystem();

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -308,7 +308,7 @@ public class GlobalConfiguration extends Part {
 
         public long overloadedLogMillis = 5_000L;
         public float defaultTickRate = 20.0F;
-        public GuardSeverity guardSeverity = GuardSeverity.LOG;
+        public GuardSeverity guardSeverity = GuardSeverity.THROW;
 
         public enum GuardSeverity {
             SILENT,

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/TickGuard.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/TickGuard.java
@@ -1,0 +1,51 @@
+package io.canvasmc.canvas.util;
+
+import ca.spottedleaf.moonrise.common.util.EntityUtil;
+import ca.spottedleaf.moonrise.common.util.TickThread;
+import ca.spottedleaf.moonrise.common.util.WorldUtil;
+import io.canvasmc.canvas.GlobalConfiguration;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+
+import static ca.spottedleaf.moonrise.common.util.TickThread.getThreadContext;
+import static io.canvasmc.canvas.GlobalConfiguration.LOGGER;
+
+public class TickGuard {
+
+    public static void guard(final BlockPos pos, final Level world, String reason) {
+        switch (GlobalConfiguration.getInstance().regionScheduler.guardSeverity) {
+            case SILENT -> ensureIsTickThread(reason);
+            case LOG -> {
+                // ensure tick thread first, since that is required, then we check and log
+                ensureIsTickThread(reason);
+                if (!TickThread.isTickThreadFor(world, pos)) {
+                    LOGGER.warn("Thread failed main thread check: {}, context={}, world={}, block_pos={}", reason, getThreadContext(), WorldUtil.getWorldName(world), pos, new Throwable());
+                }
+            }
+            case THROW -> TickThread.ensureTickThread(world, pos, reason);
+        }
+    }
+
+    public static void guard(final Entity entity, String reason) {
+        switch (GlobalConfiguration.getInstance().regionScheduler.guardSeverity) {
+            case SILENT -> ensureIsTickThread(reason);
+            case LOG -> {
+                // ensure tick thread first, since that is required, then we check and log
+                ensureIsTickThread(reason);
+                if (!TickThread.isTickThreadFor(entity)) {
+                    LOGGER.warn("Thread failed main thread check: {}, context={}, entity={}", reason, getThreadContext(), EntityUtil.dumpEntity(entity), new Throwable());
+                }
+            }
+            case THROW -> TickThread.ensureTickThread(entity, reason);
+        }
+    }
+
+    private static void ensureIsTickThread(String reason) {
+        if (!TickThread.isTickThread()) {
+            LOGGER.error("Thread failed main thread check: {}, context={}", reason, getThreadContext(), new Throwable());
+            throw new IllegalStateException(reason);
+        }
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/TickGuard.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/TickGuard.java
@@ -5,26 +5,31 @@ import ca.spottedleaf.moonrise.common.util.TickThread;
 import ca.spottedleaf.moonrise.common.util.WorldUtil;
 import io.canvasmc.canvas.GlobalConfiguration;
 import net.minecraft.core.BlockPos;
-import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.ChunkPos;
 import net.minecraft.world.level.Level;
+import org.jspecify.annotations.NonNull;
 
 import static ca.spottedleaf.moonrise.common.util.TickThread.getThreadContext;
 import static io.canvasmc.canvas.GlobalConfiguration.LOGGER;
 
 public class TickGuard {
 
-    public static void guard(final BlockPos pos, final Level world, String reason) {
+    public static void guard(final @NonNull BlockPos pos, final Level world, String reason) {
+        guard(pos.getX() >> 4, pos.getZ() >> 4, world, reason);
+    }
+
+    public static void guard(final int chunkX, final int chunkZ, final Level world, String reason) {
         switch (GlobalConfiguration.getInstance().regionScheduler.guardSeverity) {
             case SILENT -> ensureIsTickThread(reason);
             case LOG -> {
                 // ensure tick thread first, since that is required, then we check and log
                 ensureIsTickThread(reason);
-                if (!TickThread.isTickThreadFor(world, pos)) {
-                    LOGGER.warn("Thread failed main thread check: {}, context={}, world={}, block_pos={}", reason, getThreadContext(), WorldUtil.getWorldName(world), pos, new Throwable());
+                if (!TickThread.isTickThreadFor(world, chunkX, chunkZ)) {
+                    LOGGER.warn("Thread failed main thread check: {}, context={}, world={}, chunk_pos={}", reason, getThreadContext(), WorldUtil.getWorldName(world), new ChunkPos(chunkX, chunkZ), new Throwable());
                 }
             }
-            case THROW -> TickThread.ensureTickThread(world, pos, reason);
+            case THROW -> TickThread.ensureTickThread(world, chunkX, chunkZ, reason);
         }
     }
 


### PR DESCRIPTION
It is seen time and time again that plugins are doing blatantly unsafe practices off the owning context of certain entities and players. With players, this sort of abuse is easy, since they are not thread-checked like non-player-entities are. There ofc is no real way to introduce this, since this logic is intentional, and by thread checking practically everything in the Player Bukkit API, plugins will not be compatible in the slightest with Canvas.

The proposal here is to implement "guards", which implement thread checks with optional severity of the check, on places that are commonly seen in stacktraces and crashes of issues caused by plugins, like inventory opening/closing for example.

There are 3 options for this, `SILENT`, `LOG`, `THROW`. `SILENT` means nothing is logged or checked, `LOG` means the server logs a warning, and `THROW` acts as a throwing thread check.

In this PR there are also a few hard-thread-checks, since there are methods that simply should never be allowed to just be called async and the server owner turns off the warning. Those 2 are just save/load player data on the `Player` object.

The hope with this is to narrow down plugin issues, and reduce crashes induced by said plugins unsafely scheduling operations. If there are more things that should be guarded, or suggestions, or questions, comment here.