### PR TITLE
Improve TPS Output

### DIFF
--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/commands/CommandServerHealth.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/commands/CommandServerHealth.java.patch
@@ -1,6 +1,23 @@
 --- a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 +++ b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
-@@ -274,6 +_,69 @@
+@@ -201,15 +_,7 @@
+             regionsBelowThreshold.add(new ObjectObjectImmutablePair<>(regions.get(i), report));
+         }
+ 
+-        regionsBelowThreshold.sort((p1, p2) -> {
+-            final TickData.TickReportData report1 = p1.right();
+-            final TickData.TickReportData report2 = p2.right();
+-            final double util1 = report1 == null ? 0.0 : report1.utilisation();
+-            final double util2 = report2 == null ? 0.0 : report2.utilisation();
+-
+-            // we want the largest first
+-            return Double.compare(util2, util1);
+-        });
++        regionsBelowThreshold.sort(CommandServerHealth::sortPair); // Canvas - expand TPS cmd
+ 
+         final TextComponent.Builder lowestRegionsBuilder = Component.text();
+ 
+@@ -274,6 +_,141 @@
                  .append(Component.text(" - ", LIST, TextDecoration.BOLD))
                  .append(Component.text("Online Players: ", PRIMARY))
                  .append(Component.text(Bukkit.getOnlinePlayers().size() + "\n", INFORMATION))
@@ -24,21 +41,24 @@
 +                        world2Regions.get(world).add(pair);
 +                    }
 +
-+                    final TextComponent.Builder builder = Component.text();
++                    final TextComponent.Builder mainBuilder = Component.text();
 +
-+                    builder.append(Component.text(world2Regions.size() + "\n", INFORMATION));
++                    mainBuilder.append(Component.text(world2Regions.size() + "\n", INFORMATION));
 +
 +                    for (final java.util.Map.Entry<ServerLevel, List<ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>>> entry : world2Regions.entrySet()) {
 +                        final List<ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>>
 +                            list = entry.getValue();
++                        list.sort(CommandServerHealth::sortPair);
 +                        final ServerLevel world = entry.getKey();
 +
-+                        builder.append(Component.text("   ", LIST));
-+                        builder.append(Component.text(" - ", LIST));
-+                        builder.append(Component.text(world.dimension().identifier().getPath(), INFORMATION));
-+                        builder.append(Component.text(": ", PRIMARY));
-+                        builder.append(Component.text(list.size() + " region" + (list.size() != 1 ? "s" : ""), SECONDARY));
-+                        builder.append(Component.text(", ", PRIMARY));
++                        final TextComponent.Builder worldBuilder = Component.text();
++
++                        worldBuilder.append(Component.text("   ", LIST));
++                        worldBuilder.append(Component.text(" - ", LIST));
++                        worldBuilder.append(Component.text(world.dimension().identifier().getPath(), INFORMATION));
++                        worldBuilder.append(Component.text(": ", PRIMARY));
++                        worldBuilder.append(Component.text(list.size() + " region" + (list.size() != 1 ? "s" : ""), SECONDARY));
++                        worldBuilder.append(Component.text(", ", PRIMARY));
 +
 +                        double worldUtil = 0.0;
 +                        double combinedTpsVals = 0.0D;
@@ -56,14 +76,83 @@
 +
 +                        double averagedTps = list.size() == 1 ? combinedTpsVals : combinedTpsVals / list.size();
 +
-+                        builder.append(Component.text(TWO_DECIMAL_PLACES.get().format(averagedTps), CommandUtil.getColourForTPS(averagedTps)));
-+                        builder.append(Component.text(" average TPS", SECONDARY));
-+                        builder.append(Component.text(", ", PRIMARY));
-+                        builder.append(Component.text(ONE_DECIMAL_PLACES.get().format(worldUtil * 100.0) + "/" + ONE_DECIMAL_PLACES.get().format(maxThreadCount * 100.0) + "%", CommandUtil.getUtilisationColourRegion(worldUtil)));
-+                        builder.append(Component.text(" util\n", SECONDARY));
++                        worldBuilder.append(Component.text(TWO_DECIMAL_PLACES.get().format(averagedTps), CommandUtil.getColourForTPS(averagedTps)));
++                        worldBuilder.append(Component.text(" average TPS", SECONDARY));
++                        worldBuilder.append(Component.text(", ", PRIMARY));
++                        worldBuilder.append(Component.text(ONE_DECIMAL_PLACES.get().format(worldUtil * 100.0) + "/" + ONE_DECIMAL_PLACES.get().format(maxThreadCount * 100.0) + "%", CommandUtil.getUtilisationColourRegion(worldUtil)));
++                        worldBuilder.append(Component.text(" util\n", SECONDARY));
++
++                        mainBuilder.append(worldBuilder.build()
++                            .hoverEvent(HoverEvent.showText(Component.text("Click to view highest utilizing regions for \"" + world.dimension().identifier().getPath() + "\"", SECONDARY)))
++                            .clickEvent(ClickEvent.callback((audience) -> {
++                                audience.sendMessage(Component.text()
++                                    .append(Component.text("Highest ", HEADER, TextDecoration.BOLD))
++                                    .append(Component.text(" utilisation regions in ", HEADER, TextDecoration.BOLD))
++                                    .append(Component.text(world.dimension().identifier().getPath() + "\n", INFORMATION, TextDecoration.BOLD))
++
++                                    .append(((java.util.function.Supplier<Component>) () -> {
++
++                                        // copied from above
++                                        final TextComponent.Builder worldRegionsBuilder = Component.text();
++
++                                        for (int i = 0, len = Math.min(lowestRegionsCount, list.size()); i < len; ++i) {
++                                            final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>
++                                                pair = list.get(i);
++
++                                            final TickData.TickReportData report = pair.right();
++                                            final ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region =
++                                                pair.left();
++
++                                            if (report == null) {
++                                                // skip regions with no data
++                                                continue;
++                                            }
++
++                                            final ChunkPos chunkCenter = region.getCenterChunk();
++                                            if (chunkCenter == null) {
++                                                // region does not exist anymore
++                                                continue;
++                                            }
++                                            final int centerBlockX = ((chunkCenter.x() << 4) | 7);
++                                            final int centerBlockZ = ((chunkCenter.z() << 4) | 7);
++                                            final double util = report.utilisation();
++                                            final double tps = report.tpsData().segmentAll().average();
++                                            final double mspt = report.timePerTickData().segmentAll().average() / 1.0E6;
++
++                                            final int yLoc = 80;
++                                            final String location = "[w:'" + world.getWorld().getName() + "'," + centerBlockX + "," + yLoc + "," + centerBlockZ + "]";
++                                            final Component line = Component.text()
++                                                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
++                                                .append(Component.text("Region around block ", PRIMARY))
++                                                .append(Component.text(location, INFORMATION))
++                                                .append(Component.text(":\n", PRIMARY))
++
++                                                .append(Component.text("    ", PRIMARY))
++                                                .append(Component.text(ONE_DECIMAL_PLACES.get().format(util * 100.0), region.getData().getRegionSchedulingHandle().getTickManager().isSprinting() ? CommandUtil.SPRINTING_COLOR : CommandUtil.getUtilisationColourRegion(util))) // Canvas - region threading
++                                                .append(Component.text("% util at ", PRIMARY))
++                                                .append(Component.text(TWO_DECIMAL_PLACES.get().format(mspt), region.getData().getRegionSchedulingHandle().getTickManager().isSprinting() ? CommandUtil.SPRINTING_COLOR : CommandUtil.getColourForMSPT(mspt))) // Canvas - region threading
++                                                .append(Component.text(" MSPT at ", PRIMARY))
++                                                .append(Component.text(TWO_DECIMAL_PLACES.get().format(tps), region.getData().getRegionSchedulingHandle().getTickManager().isSprinting() ? CommandUtil.SPRINTING_COLOR : CommandUtil.getColourForTPS(tps))) // Canvas - region threading
++                                                .append(Component.text(" TPS\n", PRIMARY))
++
++                                                .append(Component.text("    ", PRIMARY))
++                                                .append(formatRegionStats(region.getData().getRegionStats(), (i + 1) != len))
++                                                .build()
++
++                                                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey().toString() + " run tp " + centerBlockX + ".5 " + yLoc + " " + centerBlockZ + ".5"))
++                                                .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, Component.text("Click to teleport to " + location, SECONDARY)));
++
++                                            worldRegionsBuilder.append(line);
++                                        }
++
++                                        return worldRegionsBuilder.build();
++                                    }).get())
++                                );
++                            }))
++                        );
 +                    }
 +
-+                    return builder.build();
++                    return mainBuilder.build();
 +                }).get())
 +
 +                // Canvas end - expand TPS cmd
@@ -94,3 +183,25 @@
                  .append(Component.text(TWO_DECIMAL_PLACES.get().format(maxTps) + "\n", CommandUtil.getColourForTPS(maxTps)))
  
                  .append(Component.text("Highest ", HEADER, TextDecoration.BOLD))
+@@ -315,6 +_,21 @@
+ 
+         return true;
+     }
++    // Canvas start - expand TPS cmd
++
++    private static int sortPair(
++        final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData> p1,
++        final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData> p2
++    ) {
++        final TickData.TickReportData report1 = p1.right();
++        final TickData.TickReportData report2 = p2.right();
++        final double util1 = report1 == null ? 0.0 : report1.utilisation();
++        final double util2 = report2 == null ? 0.0 : report2.utilisation();
++
++        // we want the largest first
++        return Double.compare(util2, util1);
++    }
++    // Canas end - expand TPS cmd
+ 
+     @Override
+     public boolean execute(final CommandSender sender, final String commandLabel, final String[] args) {

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/commands/CommandServerHealth.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/commands/CommandServerHealth.java.patch
@@ -1,29 +1,98 @@
 --- a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 +++ b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
-@@ -274,6 +_,26 @@
+@@ -274,6 +_,71 @@
                  .append(Component.text(" - ", LIST, TextDecoration.BOLD))
                  .append(Component.text("Online Players: ", PRIMARY))
                  .append(Component.text(Bukkit.getOnlinePlayers().size() + "\n", INFORMATION))
-+                // Canvas start - add build channel and scheduler
++                // Canvas start - expand TPS cmd
 +
 +                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
-+                .append(Component.text("Build Channel: ", PRIMARY))
-+                .append(
-+                    Component.text(io.canvasmc.canvas.GlobalConfiguration.getBuildStatus().name() + "\n", TextColor.color(io.canvasmc.canvas.GlobalConfiguration.getBuildStatus().color()))
-+                        .hoverEvent(HoverEvent.showText(
-+                            Component.text("Running ", HEADER).append(Component.text(io.papermc.paper.ServerBuildInfo.buildInfo().brandName(), PRIMARY))
-+                                .appendNewline()
-+                                .append(Component.text(io.canvasmc.canvas.GlobalConfiguration.getBuildStatus() == io.canvasmc.canvas.util.version.ApiClient.BuildStatus.LOCAL
-+                                    ? "Local-Build" : String.valueOf(io.papermc.paper.ServerBuildInfo.buildInfo().buildNumber().orElse(-1)), SECONDARY))
-+                                .append(Component.text("-", LIST))
-+                                .append(Component.text(io.papermc.paper.ServerBuildInfo.buildInfo().gitBranch().orElse("Unknown Branch"), SECONDARY))
-+                        ))
-+                )
-+
-+                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
-+                .append(Component.text("Scheduler: ", PRIMARY))
++                .append(Component.text("Scheduler Type: ", PRIMARY))
 +                .append(Component.text(io.papermc.paper.configuration.GlobalConfiguration.get().threadedRegions.scheduler + "\n", INFORMATION))
-+                // Canvas end - add build channel and scheduler
++
++                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
++                .append(Component.text("Worlds: ", PRIMARY))
++                .append(((java.util.function.Supplier<Component>) () -> {
++                    // region count, util, average tps
++
++                    final java.util.Map<ServerLevel, List<ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>>>
++                        world2Regions = new java.util.HashMap<>();
++
++                    for (int i = 0, len = regionsBelowThreshold.size(); i < len; ++i) {
++                        final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>
++                            pair = regionsBelowThreshold.get(i);
++                        final ServerLevel world = pair.left().regioniser.world;
++                        world2Regions.putIfAbsent(world, new ArrayList<>());
++                        world2Regions.get(world).add(pair);
++                    }
++
++                    final TextComponent.Builder builder = Component.text();
++
++                    builder.append(Component.text(world2Regions.size() + "\n", INFORMATION));
++
++                    for (final java.util.Map.Entry<ServerLevel, List<ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>>> entry : world2Regions.entrySet()) {
++                        final List<ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>>
++                            list = entry.getValue();
++                        final ServerLevel world = entry.getKey();
++
++                        builder.append(Component.text("   ", LIST));
++                        builder.append(Component.text(" - ", LIST));
++                        builder.append(Component.text(world.dimension().identifier().getPath(), INFORMATION));
++                        builder.append(Component.text(": ", PRIMARY));
++                        builder.append(Component.text(list.size() + " region" + (list.size() != 1 ? "s" : ""), SECONDARY));
++                        builder.append(Component.text(", ", PRIMARY));
++
++                        double worldUtil = 0.0;
++                        double combinedTpsVals = 0.0D;
++
++                        for (final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData> pair : list) {
++
++                            final TickData.TickReportData report = pair.right();
++
++                            final double util = report == null ? 0.0D : report.utilisation();
++                            final double tps = report == null ? TickRegionScheduler.getTickRate() : report.tpsData().segmentAll().average();
++
++                            worldUtil += util;
++                            combinedTpsVals += tps;
++                        }
++
++                        double averagedTps = list.size() == 1 ? combinedTpsVals : combinedTpsVals / list.size();
++
++                        builder.append(Component.text(TWO_DECIMAL_PLACES.get().format(averagedTps), CommandUtil.getColourForTPS(averagedTps)));
++                        builder.append(Component.text(" average TPS", SECONDARY));
++                        builder.append(Component.text(", ", PRIMARY));
++                        builder.append(Component.text(ONE_DECIMAL_PLACES.get().format(worldUtil * 100.0) + "/" + ONE_DECIMAL_PLACES.get().format(maxThreadCount * 100.0) + "%", CommandUtil.getUtilisationColourRegion(worldUtil)));
++                        builder.append(Component.text(" util\n", SECONDARY));
++                    }
++
++                    return builder.build();
++                }).get())
++
++                // Canvas end - expand TPS cmd
  
                  .append(Component.text(" - ", LIST, TextDecoration.BOLD))
                  .append(Component.text("Total regions: ", PRIMARY))
+@@ -293,16 +_,13 @@
+                 .append(Component.text(TWO_DECIMAL_PLACES.get().format(genRate) + "\n", INFORMATION))
+ 
+                 .append(Component.text(" - ", LIST, TextDecoration.BOLD))
+-                .append(Component.text("Lowest Region TPS: ", PRIMARY))
+-                .append(Component.text(TWO_DECIMAL_PLACES.get().format(minTps) + "\n", CommandUtil.getColourForTPS(minTps)))
+-
+-
+-                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
+-                .append(Component.text("Median Region TPS: ", PRIMARY))
+-                .append(Component.text(TWO_DECIMAL_PLACES.get().format(medianTps) + "\n", CommandUtil.getColourForTPS(medianTps)))
+-
+-                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
+-                .append(Component.text("Highest Region TPS: ", PRIMARY))
++                // Canvas start - compact min/med/max tps
++                .append(Component.text("Min/Median/Max TPS: ", PRIMARY))
++                .append(Component.text(TWO_DECIMAL_PLACES.get().format(minTps), CommandUtil.getColourForTPS(minTps)))
++                .append(Component.text("/", LIST))
++                .append(Component.text(TWO_DECIMAL_PLACES.get().format(medianTps), CommandUtil.getColourForTPS(medianTps)))
++                .append(Component.text("/", LIST))
++                // Canvas end - compact min/med/max tps
+                 .append(Component.text(TWO_DECIMAL_PLACES.get().format(maxTps) + "\n", CommandUtil.getColourForTPS(maxTps)))
+ 
+                 .append(Component.text("Highest ", HEADER, TextDecoration.BOLD))

--- a/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/commands/CommandServerHealth.java.patch
+++ b/canvas-server/minecraft-patches/sources/io/papermc/paper/threadedregions/commands/CommandServerHealth.java.patch
@@ -1,6 +1,6 @@
 --- a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 +++ b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
-@@ -274,6 +_,71 @@
+@@ -274,6 +_,69 @@
                  .append(Component.text(" - ", LIST, TextDecoration.BOLD))
                  .append(Component.text("Online Players: ", PRIMARY))
                  .append(Component.text(Bukkit.getOnlinePlayers().size() + "\n", INFORMATION))
@@ -13,8 +13,6 @@
 +                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
 +                .append(Component.text("Worlds: ", PRIMARY))
 +                .append(((java.util.function.Supplier<Component>) () -> {
-+                    // region count, util, average tps
-+
 +                    final java.util.Map<ServerLevel, List<ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>>>
 +                        world2Regions = new java.util.HashMap<>();
 +

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -434,6 +434,7 @@ public class WorldConfig extends Part {
         public boolean eggCanKnockbackPlayers = false;
     }
 
+    // TODO - move this to "blocks" config
     public Spawner spawner = new Spawner();
     public static class Spawner extends Part {
 


### PR DESCRIPTION
As requested by `capypucu_` on discord, this PR introduces a visual change and improvement to the `tps` command output, now showing per-world TPS data alongside the server-wide data, and compacting the Low/Median/Highest TPS lines to 1 line.

Below is an image of the new TPS command

<img width="684" height="323" alt="image" src="https://github.com/user-attachments/assets/4df69831-ff2d-46d1-a34b-b8c870400ffe" />
