### PR TITLE
Villager POI Search Range Configs

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -1,0 +1,33 @@
+--- a/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
++++ b/net/minecraft/world/entity/ai/behavior/AcquirePoi.java
+@@ -54,6 +_,21 @@
+         final Optional<Byte> onPoiAcquisitionEvent,
+         final BiPredicate<ServerLevel, BlockPos> validPoi
+     ) {
++    // Canvas start - configurable scan range and if poi should load
++        return create(poiType, memoryToValidate, memoryToAcquire, onlyIfAdult, onPoiAcquisitionEvent, validPoi, (_) -> SCAN_RANGE, ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.LOAD_FOR_SEARCHING);
++    }
++
++    public static BehaviorControl<PathfinderMob> create(
++        final Predicate<Holder<PoiType>> poiType,
++        final MemoryModuleType<GlobalPos> memoryToValidate,
++        final MemoryModuleType<GlobalPos> memoryToAcquire,
++        final boolean onlyIfAdult,
++        final Optional<Byte> onPoiAcquisitionEvent,
++        final BiPredicate<ServerLevel, BlockPos> validPoi,
++        final java.util.function.Function<Mob, Integer> scanRange,
++        final boolean shouldLoad
++    ) {
++    // Canvas end - configurable scan range and if poi should load
+         int batchSize = 5;
+         int rate = 20;
+         MutableLong nextScheduledStart = new MutableLong(0L);
+@@ -90,7 +_,7 @@
+                                 };
+                                 // Paper start - optimise POI searches
+                                 java.util.List<Pair<Holder<PoiType>, BlockPos>> poiPositionsRaw = new java.util.ArrayList<>();
+-                                ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.findNearestPoiPositions(poiManager, poiType, cacheTest, body.blockPosition(), SCAN_RANGE, Double.MAX_VALUE, PoiManager.Occupancy.HAS_SPACE, ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.LOAD_FOR_SEARCHING, 5, poiPositionsRaw);
++                                ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.findNearestPoiPositions(poiManager, poiType, cacheTest, body.blockPosition(), scanRange.apply(body), Double.MAX_VALUE, PoiManager.Occupancy.HAS_SPACE, shouldLoad, 5, poiPositionsRaw); // Canvas - configurable scan range and if poi should load
+                                 Set<Pair<Holder<PoiType>, BlockPos>> poiPositions = new java.util.HashSet<>(poiPositionsRaw.size());
+                                 for (Pair<Holder<PoiType>, BlockPos> pair : poiPositionsRaw) {
+                                     if (validPoi.test(level, pair.getSecond())) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/AcquirePoi.java.patch
@@ -5,7 +5,7 @@
          final BiPredicate<ServerLevel, BlockPos> validPoi
      ) {
 +    // Canvas start - configurable scan range and if poi should load
-+        return create(poiType, memoryToValidate, memoryToAcquire, onlyIfAdult, onPoiAcquisitionEvent, validPoi, (_) -> SCAN_RANGE, ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.LOAD_FOR_SEARCHING);
++        return create(poiType, memoryToValidate, memoryToAcquire, onlyIfAdult, onPoiAcquisitionEvent, validPoi, (_) -> SCAN_RANGE, (_) -> ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.LOAD_FOR_SEARCHING);
 +    }
 +
 +    public static BehaviorControl<PathfinderMob> create(
@@ -16,7 +16,7 @@
 +        final Optional<Byte> onPoiAcquisitionEvent,
 +        final BiPredicate<ServerLevel, BlockPos> validPoi,
 +        final java.util.function.Function<Mob, Integer> scanRange,
-+        final boolean shouldLoad
++        final java.util.function.Function<Mob, Boolean> shouldLoad
 +    ) {
 +    // Canvas end - configurable scan range and if poi should load
          int batchSize = 5;
@@ -27,7 +27,7 @@
                                  // Paper start - optimise POI searches
                                  java.util.List<Pair<Holder<PoiType>, BlockPos>> poiPositionsRaw = new java.util.ArrayList<>();
 -                                ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.findNearestPoiPositions(poiManager, poiType, cacheTest, body.blockPosition(), SCAN_RANGE, Double.MAX_VALUE, PoiManager.Occupancy.HAS_SPACE, ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.LOAD_FOR_SEARCHING, 5, poiPositionsRaw);
-+                                ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.findNearestPoiPositions(poiManager, poiType, cacheTest, body.blockPosition(), scanRange.apply(body), Double.MAX_VALUE, PoiManager.Occupancy.HAS_SPACE, shouldLoad, 5, poiPositionsRaw); // Canvas - configurable scan range and if poi should load
++                                ca.spottedleaf.moonrise.patches.poi_lookup.PoiAccess.findNearestPoiPositions(poiManager, poiType, cacheTest, body.blockPosition(), scanRange.apply(body), Double.MAX_VALUE, PoiManager.Occupancy.HAS_SPACE, shouldLoad.apply(body), 5, poiPositionsRaw); // Canvas - configurable scan range and if poi should load
                                  Set<Pair<Holder<PoiType>, BlockPos>> poiPositions = new java.util.HashSet<>(poiPositionsRaw.size());
                                  for (Pair<Holder<PoiType>, BlockPos> pair : poiPositionsRaw) {
                                      if (validPoi.test(level, pair.getSecond())) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java.patch
@@ -5,7 +5,7 @@
                      true,
                      Optional.empty(),
 -                    (l, p) -> true
-+                    (l, p) -> true, (body) -> body.level().canvasConfig().entities.villagers.reduceJobSitePoiSearchRange ? 16 : 48, false // Canvas - configurable scan range and if poi should load
++                    (l, p) -> true, (body) -> body.level().canvasConfig().entities.villagers.reduceJobSitePoiSearchRange ? 16 : 48, (body) -> body.level().canvasConfig().entities.villagers.villagerAcquirePoiTasksLoadChunks // Canvas - configurable scan range and if poi should load
                  )
              ),
              Pair.of(7, new GoToPotentialJobSite(speedModifier)),
@@ -13,8 +13,8 @@
 -            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.HOME), MemoryModuleType.HOME, false, Optional.of((byte)14), VillagerGoalPackages::validateBedPoi)),
 -            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.MEETING), MemoryModuleType.MEETING_POINT, true, Optional.of((byte)14))),
 +            // Canvas start - configurable scan range and if poi should load
-+            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.HOME), MemoryModuleType.HOME, MemoryModuleType.HOME, false, Optional.of((byte)14), VillagerGoalPackages::validateBedPoi, (body) -> body.level().canvasConfig().entities.villagers.reduceHomePoiSearchRange ? 16 : 48, false)),
-+            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.MEETING), MemoryModuleType.MEETING_POINT, MemoryModuleType.MEETING_POINT, true, Optional.of((byte)14), (_, _) -> true, (body) -> body.level().canvasConfig().entities.villagers.reduceMeetingPointPoiSearchRange ? 16 : 48, false)),
++            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.HOME), MemoryModuleType.HOME, MemoryModuleType.HOME, false, Optional.of((byte)14), VillagerGoalPackages::validateBedPoi, (body) -> body.level().canvasConfig().entities.villagers.reduceHomePoiSearchRange ? 16 : 48, (body) -> body.level().canvasConfig().entities.villagers.villagerAcquirePoiTasksLoadChunks)),
++            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.MEETING), MemoryModuleType.MEETING_POINT, MemoryModuleType.MEETING_POINT, true, Optional.of((byte)14), (_, _) -> true, (body) -> body.level().canvasConfig().entities.villagers.reduceMeetingPointPoiSearchRange ? 16 : 48, (body) -> body.level().canvasConfig().entities.villagers.villagerAcquirePoiTasksLoadChunks)),
 +            // Canvas end - configurable scan range and if poi should load
              Pair.of(10, AssignProfessionFromJobSite.create()),
              Pair.of(10, ResetProfession.create())

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java
++++ b/net/minecraft/world/entity/ai/behavior/VillagerGoalPackages.java
+@@ -54,13 +_,15 @@
+                     MemoryModuleType.POTENTIAL_JOB_SITE,
+                     true,
+                     Optional.empty(),
+-                    (l, p) -> true
++                    (l, p) -> true, (body) -> body.level().canvasConfig().entities.villagers.reduceJobSitePoiSearchRange ? 16 : 48, false // Canvas - configurable scan range and if poi should load
+                 )
+             ),
+             Pair.of(7, new GoToPotentialJobSite(speedModifier)),
+             Pair.of(8, YieldJobSite.create(speedModifier)),
+-            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.HOME), MemoryModuleType.HOME, false, Optional.of((byte)14), VillagerGoalPackages::validateBedPoi)),
+-            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.MEETING), MemoryModuleType.MEETING_POINT, true, Optional.of((byte)14))),
++            // Canvas start - configurable scan range and if poi should load
++            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.HOME), MemoryModuleType.HOME, MemoryModuleType.HOME, false, Optional.of((byte)14), VillagerGoalPackages::validateBedPoi, (body) -> body.level().canvasConfig().entities.villagers.reduceHomePoiSearchRange ? 16 : 48, false)),
++            Pair.of(10, AcquirePoi.create(p -> p.is(PoiTypes.MEETING), MemoryModuleType.MEETING_POINT, MemoryModuleType.MEETING_POINT, true, Optional.of((byte)14), (_, _) -> true, (body) -> body.level().canvasConfig().entities.villagers.reduceMeetingPointPoiSearchRange ? 16 : 48, false)),
++            // Canvas end - configurable scan range and if poi should load
+             Pair.of(10, AssignProfessionFromJobSite.create()),
+             Pair.of(10, ResetProfession.create())
+         );

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -380,9 +380,21 @@ public class WorldConfig extends Part {
 
         {
             option("skeletonAimAccuracy").docs("Defines the inaccuracy of skeleton bow shots. 14 is Vanilla, higher is more inaccurate and lower is more accurate");
+            option("villagers")
+                .docs(
+                    "Options regarding villagers. The options for reducing POI search ranges shrink the search radius(in blocks)",
+                    "from 48 to 16, which can help improve tick times with little to no noticeable Vanilla deviation"
+                );
         }
 
         public double skeletonAimAccuracy = 14.0D;
+
+        public Villagers villagers = new Villagers();
+        public static class Villagers {
+            public boolean reduceJobSitePoiSearchRange = false;
+            public boolean reduceHomePoiSearchRange = false;
+            public boolean reduceMeetingPointPoiSearchRange = false;
+        }
     }
 
     public Combat combat = new Combat();

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -383,14 +383,22 @@ public class WorldConfig extends Part {
             option("villagers")
                 .docs(
                     "Options regarding villagers. The options for reducing POI search ranges shrink the search radius(in blocks)",
-                    "from 48 to 16, which can help improve tick times with little to no noticeable Vanilla deviation"
+                    "from 48 to 16, which can help improve tick times with little Vanilla deviation, however this will prevent Villagers",
+                    "from acquiring POIs between 17-48 blocks away"
                 );
         }
 
         public double skeletonAimAccuracy = 14.0D;
 
         public Villagers villagers = new Villagers();
-        public static class Villagers {
+        public static class Villagers extends Part {
+
+            {
+                option("villagerAcquirePoiTasksLoadChunks")
+                    .docs("Whether the server should allow Villagers to load unloaded chunks for Villagers to locate POIs");
+            }
+
+            public boolean villagerAcquirePoiTasksLoadChunks = true;
             public boolean reduceJobSitePoiSearchRange = false;
             public boolean reduceHomePoiSearchRange = false;
             public boolean reduceMeetingPointPoiSearchRange = false;


### PR DESCRIPTION
AcquirePoi searches always run with a range of `48` blocks. Villagers have 4 POI types that are run through 3 different behavior controllers in the mob brain, specifically searching for `HOME`, `MEETING`, `JOB_SITE`, and `POTENTIAL_JOB_SITE`. Note that `JOB_SITE` is the memory to validate and `POTENTIAL_JOB_SITE` is the memory to acquire in their shared behavior controller. These POIs are later validated once present via the `ValidateNearbyPoi` class, which actually validates them in a radius of `16` blocks, unlike `48` which is what the initial search is for.

With this in mind, there are 3 configs added that shrink the search radius from `48` to `16`, to match the validator. These configs are as such:
- `reduceJobSitePoiSearchRange` - Reduces the `JOB_SITE`/`POTENTIAL_JOB_SITE` POI search range
- `reduceHomePoiSearchRange` - Reduces the `HOME` POI search range
- `reduceMeetingPointPoiSearchRange` - Reduces the `MEETING_POINT` POI search range

Note that these configs are in kebab-case for the actual YAML config

This PR also disables these 3 behavior controllers from loading POI chunks if the chunk isn't currently loaded. There were some noticeable MSPT improvements, being roughly `18.21ms` -> `13.57ms` of Villager ticking(inactive tick included), in a single region with ~585 villagers. While not the most impactful optimization, this does help optimize the current heaviest behavior controllers for Villagers in Canvas, which is at least *something*.

Note that these options do cause slight deviation from Vanilla, however probably not entirely noticeable to the average player.