### PR TITLE
Restore spawner configs, implement 2 new configs

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/LivingEntity.java.patch
@@ -239,7 +239,7 @@
  
      @Override
      public boolean isCollidable(boolean ignoreClimbing) {
-+        if (this.canvas$fromSpawner && level().canvasConfig().spawner.spawnedEntitiesHaveNoCollision) return false; // Canvas - spawner configs
++        if (this.canvas$fromSpawner && level().canvasConfig().blocks.spawner.spawnedEntitiesHaveNoCollision) return false; // Canvas - spawner configs
          return this.isAlive() && !this.isSpectator() && (ignoreClimbing || !this.onClimbable()) && this.collides; // CraftBukkit
          // Paper end - Climbing should not bypass cramming gamerule
      }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/BaseSpawner.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/BaseSpawner.java.patch
@@ -1,5 +1,89 @@
 --- a/net/minecraft/world/level/BaseSpawner.java
 +++ b/net/minecraft/world/level/BaseSpawner.java
+@@ -45,14 +_,77 @@
+     public @Nullable SpawnData nextSpawnData;
+     private double spin;
+     private double oSpin;
+-    public int minSpawnDelay = 200;
+-    public int maxSpawnDelay = 800;
+-    public int spawnCount = 4;
++    // Canvas start - spawner configs
++    public int minSpawnDelay = getMinSpawnDelayDefault();
++    public int maxSpawnDelay = getMaxSpawnDelayDefault();
++    public int spawnCount = getSpawnCountDefault();
++    // Canvas end - spawner configs
+     private @Nullable Entity displayEntity;
+-    public int maxNearbyEntities = 6;
+-    public int requiredPlayerRange = 16;
+-    public int spawnRange = 4;
++    // Canvas start - spawner configs
++    public int maxNearbyEntities = getMaxNearbyEntitiesDefault();
++    public int requiredPlayerRange = getRequiredPlayerRangeDefault();
++    public int spawnRange = getSpawnRangeDefault();
++    // Canvas end - spawner configs
+     private int tickDelay = 0; // Paper - Configurable mob spawner tick rate
++    // Canvas start - spawner configs
++
++    // this is instantiated on the region that we are being placed at, so we are technically
++    // able to fetch the current region and pull the Canvas config from there
++
++    private int getMinSpawnDelayDefault() {
++        final io.papermc.paper.threadedregions.RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        if (worldData == null) {
++            // return vanilla default
++            return 200;
++        }
++        return worldData.world.canvasConfig().blocks.spawner.minSpawnDelay;
++    }
++
++    private int getMaxSpawnDelayDefault() {
++        final io.papermc.paper.threadedregions.RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        if (worldData == null) {
++            // return vanilla default
++            return 800;
++        }
++        return worldData.world.canvasConfig().blocks.spawner.maxSpawnDelay;
++    }
++
++    private int getSpawnCountDefault() {
++        final io.papermc.paper.threadedregions.RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        if (worldData == null) {
++            // return vanilla default
++            return 4;
++        }
++        return worldData.world.canvasConfig().blocks.spawner.spawnCount;
++    }
++
++    private int getMaxNearbyEntitiesDefault() {
++        final io.papermc.paper.threadedregions.RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        if (worldData == null) {
++            // return vanilla default
++            return 6;
++        }
++        return worldData.world.canvasConfig().blocks.spawner.maxNearbyEntities;
++    }
++
++    private int getRequiredPlayerRangeDefault() {
++        final io.papermc.paper.threadedregions.RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        if (worldData == null) {
++            // return vanilla default
++            return 16;
++        }
++        return worldData.world.canvasConfig().blocks.spawner.requiredPlayerRange;
++    }
++
++    private int getSpawnRangeDefault() {
++        final io.papermc.paper.threadedregions.RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        if (worldData == null) {
++            // return vanilla default
++            return 4;
++        }
++        return worldData.world.canvasConfig().blocks.spawner.spawnRange;
++    }
++    // Canvas end - spawner configs
+ 
+     public void setEntityId(final EntityType<?> type, final @Nullable Level level, final RandomSource random, final BlockPos pos) {
+         this.getOrCreateNextSpawnData(level, random, pos).getEntityToSpawn().putString("id", BuiltInRegistries.ENTITY_TYPE.getKey(type).toString());
 @@ -60,7 +_,7 @@
      }
  
@@ -14,7 +98,7 @@
                              }
  
 -                            int nearBy = level.getEntities(
-+                            int nearBy = level.canvasConfig().spawner.disableMaxNearbyEntitiesCheck ? Integer.MIN_VALUE : level.getEntities( // Canvas - spawner configs
++                            int nearBy = level.canvasConfig().blocks.spawner.disableMaxNearbyEntitiesCheck ? Integer.MIN_VALUE : level.getEntities( // Canvas - spawner configs
                                      EntityTypeTest.forExactClass(entity.getClass()),
                                      new AABB(pos.getX(), pos.getY(), pos.getZ(), pos.getX() + 1, pos.getY() + 1, pos.getZ() + 1).inflate(this.spawnRange),
                                      EntitySelector.NO_SPECTATORS
@@ -26,3 +110,25 @@
                              }
  
                              // Paper start
+@@ -240,13 +_,15 @@
+         this.spawnPotentials = input.read("SpawnPotentials", SpawnData.LIST_CODEC)
+             .orElseGet(() -> WeightedList.of(this.nextSpawnData != null ? this.nextSpawnData : new SpawnData()));
+         // Paper start - use int if set
+-        this.minSpawnDelay = input.getIntOr("Paper.MinSpawnDelay", input.getIntOr("MinSpawnDelay", 200));
+-        this.maxSpawnDelay = input.getIntOr("Paper.MaxSpawnDelay", input.getIntOr("MaxSpawnDelay", 800));
++        this.minSpawnDelay = input.getIntOr("Paper.MinSpawnDelay", input.getIntOr("MinSpawnDelay", getMinSpawnDelayDefault())); // Canvas - spawner configs
++        this.maxSpawnDelay = input.getIntOr("Paper.MaxSpawnDelay", input.getIntOr("MaxSpawnDelay", getMaxSpawnDelayDefault())); // Canvas - spawner configs
+         // Paper end - use int if set
+-        this.spawnCount = input.getIntOr("SpawnCount", 4);
+-        this.maxNearbyEntities = input.getIntOr("MaxNearbyEntities", 6);
+-        this.requiredPlayerRange = input.getIntOr("RequiredPlayerRange", 16);
+-        this.spawnRange = input.getIntOr("SpawnRange", 4);
++        // Canvas start - spawner configs
++        this.spawnCount = input.getIntOr("SpawnCount", getSpawnCountDefault());
++        this.maxNearbyEntities = input.getIntOr("MaxNearbyEntities", getMaxNearbyEntitiesDefault());
++        this.requiredPlayerRange = input.getIntOr("RequiredPlayerRange", getRequiredPlayerRangeDefault());
++        this.spawnRange = input.getIntOr("SpawnRange", getSpawnRangeDefault());
++        // Canvas end - spawner configs
+         this.displayEntity = null;
+     }
+ 

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/ChestBlock.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/ChestBlock.java.patch
@@ -29,11 +29,10 @@
      public static DoubleBlockCombiner.Combiner<ChestBlockEntity, Optional<MenuProvider>> MENU_PROVIDER_COMBINER = new DoubleBlockCombiner.Combiner<ChestBlockEntity, Optional<MenuProvider>>() {
          @Override
          public Optional<MenuProvider> acceptDouble(final ChestBlockEntity first, final ChestBlockEntity second) {
-@@ -284,6 +_,16 @@
-     public BlockEntityType<? extends ChestBlockEntity> blockEntityType() {
+@@ -285,6 +_,16 @@
          return this.blockEntityType.get();
      }
-+
+ 
 +    // Canvas start - optimize hoppers
 +    public static @Nullable Container canvas$getContainerForHoppers(
 +        final ChestBlock block, final BlockState state, final Level level, final BlockPos pos, final boolean ignoreBeingBlocked, final Container container
@@ -42,7 +41,17 @@
 +        // to tick the hoppers in our testing environment. ~20.14ms was from this method
 +        return block.combine(state, level, pos, ignoreBeingBlocked).apply(NULLABLE_DIRECT_CONTAINER);
 +    }
++
 +    // Canvas end - optimize hoppers
- 
      public static @Nullable Container getContainer(
          final ChestBlock block, final BlockState state, final Level level, final BlockPos pos, final boolean ignoreBeingBlocked
+     ) {
+@@ -353,7 +_,7 @@
+ 
+     public static boolean isBlockedChestByBlock(final BlockGetter level, final BlockPos pos) {
+         BlockPos above = pos.above();
+-        return level.getBlockState(above).isRedstoneConductor(level, above);
++        return (!(level instanceof net.minecraft.server.level.ServerLevel serverLevel) || !serverLevel.canvasConfig().blocks.chestsCanOpenWithFullBlockAbove) && level.getBlockState(above).isRedstoneConductor(level, above); // Canvas - block configs
+     }
+ 
+     private static boolean isCatSittingOnChest(final LevelAccessor level, final BlockPos pos) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/EnchantingTableBlock.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/EnchantingTableBlock.java.patch
@@ -1,0 +1,37 @@
+--- a/net/minecraft/world/level/block/EnchantingTableBlock.java
++++ b/net/minecraft/world/level/block/EnchantingTableBlock.java
+@@ -45,8 +_,32 @@
+     }
+ 
+     public static boolean isValidBookShelf(final Level level, final BlockPos pos, final BlockPos offset) {
+-        return level.getBlockState(pos.offset(offset)).is(BlockTags.ENCHANTMENT_POWER_PROVIDER)
+-            && level.getBlockState(pos.offset(offset.getX() / 2, offset.getY(), offset.getZ() / 2)).is(BlockTags.ENCHANTMENT_POWER_TRANSMITTER);
++        // Canvas start - block configs
++        final BlockState offsetState = level.getBlockState(pos.offset(offset));
++
++        // must be a power provider
++        if (!offsetState.is(BlockTags.ENCHANTMENT_POWER_PROVIDER)) {
++            if (level.canvasConfig().blocks.fullChiseledBookShelvesCountAsValidEnchantPowerSources
++                && offsetState.is(Blocks.CHISELED_BOOKSHELF)) {
++
++                // all slots have to be filled for it to be a valid bookshelf
++                for (final net.minecraft.world.level.block.state.properties.BooleanProperty slotOccupiedProperty : ChiseledBookShelfBlock.SLOT_OCCUPIED_PROPERTIES) {
++                    if (!offsetState.getValue(slotOccupiedProperty)) {
++                        return false;
++                    }
++                }
++
++            }
++            else return false;
++        }
++
++        // check if something is blocking the shelf
++        if (!level.getBlockState(pos.offset(offset.getX() / 2, offset.getY(), offset.getZ() / 2)).is(BlockTags.ENCHANTMENT_POWER_TRANSMITTER)) {
++            return false;
++        }
++
++        return true;
++        // Canvas end - block configs
+     }
+ 
+     @Override

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -490,6 +490,22 @@ public class WorldConfig extends Part {
     public Blocks blocks = new Blocks();
     public static class Blocks extends Part {
 
+        {
+            option("spawner")
+                .docs(
+                    Style.create().wordWrap(
+                        "All integer options in this section of the configuration are only applied on creation of the spawner",
+                        "instances in question. This is due to plugins being able to modify these values too at runtime via Paper",
+                        "API. Any already generated spawners will not get this configuration applied, it will only apply to new ones"
+                    ).blank()
+                    .literal("The options in question are:")
+                    .wordWrap(
+                        "\"min-spawn-delay\", \"max-spawn-delay\", \"spawn-count\", \"max-nearby-entities\",",
+                        "\"required-player-range\", \"spawn-range\""
+                    )
+                );
+        }
+
         public boolean chestsCanOpenWithFullBlockAbove = false;
         public boolean fullChiseledBookShelvesCountAsValidEnchantPowerSources = false;
 
@@ -497,17 +513,17 @@ public class WorldConfig extends Part {
         public static class Spawner extends Part {
 
             {
-                option("minSpawnDelay").docs("The minimum delay between spawner spawns. This is only applied at spawner creation")
+                option("minSpawnDelay").docs("The minimum delay between spawner spawns")
                     .greaterThanOrEqualTo(0.0F);
-                option("maxSpawnDelay").docs("The maximum delay between spawner spawns. This is only applied at spawner creation")
+                option("maxSpawnDelay").docs("The maximum delay between spawner spawns")
                     .greaterThanOrEqualTo(0.0F);
-                option("spawnCount").docs("The amount of entities a spawner spawns per cycle. This is only applied at spawner creation")
+                option("spawnCount").docs("The amount of entities a spawner spawns per cycle")
                     .greaterThanOrEqualTo(0.0F);
-                option("maxNearbyEntities").docs("The maximum amount of nearby entities before the spawner stops ticking. This is only applied at spawner creation")
+                option("maxNearbyEntities").docs("The maximum amount of nearby entities before the spawner stops ticking")
                     .greaterThanOrEqualTo(0.0F);
-                option("requiredPlayerRange").docs("The required player range for spawners to activate. This is only applied at spawner creation")
+                option("requiredPlayerRange").docs("The required player range for spawners to activate")
                     .greaterThanOrEqualTo(0.0F);
-                option("spawnRange").docs("The maximum position range for spawned entities. This is only applied at spawner creation")
+                option("spawnRange").docs("The maximum position range for spawned entities")
                     .greaterThanOrEqualTo(0.0F);
                 option("disableMaxNearbyEntitiesCheck").docs("Disables the spawner max nearby entities check");
                 option("spawnedEntitiesHaveNoCollision").docs("Disables collisions for entities spawned by spawners");

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -187,6 +187,10 @@ public class WorldConfig extends Part {
             // if nothing matched, it doesn't have an override
             return false;
         });
+
+        if (blocks.spawner.minSpawnDelay > blocks.spawner.maxSpawnDelay) {
+            throw new IllegalArgumentException("min-spawn-delay must be less than or equal to max spawn delay");
+        }
     }
 
     {
@@ -493,12 +497,18 @@ public class WorldConfig extends Part {
         public static class Spawner extends Part {
 
             {
-                option("minSpawnDelay").docs("The minimum delay between spawner spawns");
-                option("maxSpawnDelay").docs("The maximum delay between spawner spawns");
-                option("spawnCount").docs("The amount of entities a spawner spawns per cycle");
-                option("maxNearbyEntities").docs("The maximum amount of nearby entities before the spawner stops ticking");
-                option("requiredPlayerRange").docs("The required player range for spawners to activate");
-                option("spawnRange").docs("The maximum position range for spawned entities");
+                option("minSpawnDelay").docs("The minimum delay between spawner spawns. This is only applied at spawner creation")
+                    .greaterThanOrEqualTo(0.0F);
+                option("maxSpawnDelay").docs("The maximum delay between spawner spawns. This is only applied at spawner creation")
+                    .greaterThanOrEqualTo(0.0F);
+                option("spawnCount").docs("The amount of entities a spawner spawns per cycle. This is only applied at spawner creation")
+                    .greaterThanOrEqualTo(0.0F);
+                option("maxNearbyEntities").docs("The maximum amount of nearby entities before the spawner stops ticking. This is only applied at spawner creation")
+                    .greaterThanOrEqualTo(0.0F);
+                option("requiredPlayerRange").docs("The required player range for spawners to activate. This is only applied at spawner creation")
+                    .greaterThanOrEqualTo(0.0F);
+                option("spawnRange").docs("The maximum position range for spawned entities. This is only applied at spawner creation")
+                    .greaterThanOrEqualTo(0.0F);
                 option("disableMaxNearbyEntitiesCheck").docs("Disables the spawner max nearby entities check");
                 option("spawnedEntitiesHaveNoCollision").docs("Disables collisions for entities spawned by spawners");
             }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -473,7 +473,6 @@ public class WorldConfig extends Part {
         }
 
         public boolean disableSweepingEdge = false;
-        public boolean disableNetheriteKnockbackResistance = false;
         public boolean disableCritsWhileSprinting = false;
         // public int invulnerabilityTicks = 10;
         public boolean allowFishingRodsToPullEntities = true;
@@ -484,30 +483,35 @@ public class WorldConfig extends Part {
         public boolean eggCanKnockbackPlayers = false;
     }
 
-    // TODO - move this to "blocks" config
-    public Spawner spawner = new Spawner();
-    public static class Spawner extends Part {
+    public Blocks blocks = new Blocks();
+    public static class Blocks extends Part {
 
-        {
-            // option("minSpawnDelay").docs("The minimum delay between spawner spawns");
-            // option("maxSpawnDelay").docs("The maximum delay between spawner spawns");
-            // option("spawnCount").docs("The amount of entities a spawner spawns per cycle");
-            // option("maxNearbyEntities").docs("The maximum amount of nearby entities before the spawner stops ticking");
-            // option("requiredPlayerRange").docs("The required player range for spawners to activate");
-            // option("spawnRange").docs("The maximum position range for spawned entities");
-            option("disableMaxNearbyEntitiesCheck").docs("Disables the spawner max nearby entities check");
-            option("spawnedEntitiesHaveNoCollision").docs("Disables collisions for entities spawned by spawners");
+        public boolean chestsCanOpenWithFullBlockAbove = false;
+        public boolean fullChiseledBookShelvesCountAsValidEnchantPowerSources = false;
+
+        public Spawner spawner = new Spawner();
+        public static class Spawner extends Part {
+
+            {
+                option("minSpawnDelay").docs("The minimum delay between spawner spawns");
+                option("maxSpawnDelay").docs("The maximum delay between spawner spawns");
+                option("spawnCount").docs("The amount of entities a spawner spawns per cycle");
+                option("maxNearbyEntities").docs("The maximum amount of nearby entities before the spawner stops ticking");
+                option("requiredPlayerRange").docs("The required player range for spawners to activate");
+                option("spawnRange").docs("The maximum position range for spawned entities");
+                option("disableMaxNearbyEntitiesCheck").docs("Disables the spawner max nearby entities check");
+                option("spawnedEntitiesHaveNoCollision").docs("Disables collisions for entities spawned by spawners");
+            }
+
+            public int minSpawnDelay = 200;
+            public int maxSpawnDelay = 800;
+            public int spawnCount = 4;
+            public int maxNearbyEntities = 6;
+            public int requiredPlayerRange = 16;
+            public int spawnRange = 4;
+            public boolean disableMaxNearbyEntitiesCheck = false;
+            public boolean spawnedEntitiesHaveNoCollision = false;
         }
-
-        // TODO - can we bring these back or find suitable replacements?
-        // public int minSpawnDelay = 200;
-        // public int maxSpawnDelay = 800;
-        // public int spawnCount = 4;
-        // public int maxNearbyEntities = 6;
-        // public int requiredPlayerRange = 16;
-        // public int spawnRange = 4;
-        public boolean disableMaxNearbyEntitiesCheck = false;
-        public boolean spawnedEntitiesHaveNoCollision = false;
     }
 
     {


### PR DESCRIPTION
This restores the 1.21.11 spawner configs that were dropped in 26.1.2's update, now placing it in the `blocks` section, alongside 2 new configs:

- `chests-can-open-with-full-block-above`
- `full-chiseled-book-shelves-count-as-valid-enchant-power-sources`

These 2 add the capability to open chest blocks while they have a block above, and also use filled chiseled bookshelves as a valid power source for enchantment tables