### PR TITLE
simd-support for chunk-gen

### DIFF
--- a/canvas-api/src/main/java/io/canvasmc/canvas/simd/VectorizedChunkGeneration.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/simd/VectorizedChunkGeneration.java
@@ -1,0 +1,122 @@
+package io.canvasmc.canvas.simd;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+public final class VectorizedChunkGeneration {
+
+    private static final VectorSpecies<Integer> I_SPEC = IntVector.SPECIES_PREFERRED;
+    private static final VectorSpecies<Integer> PAIR_SPEC = IntVector.SPECIES_64;
+
+    private static final ThreadLocal<int[]> PAIR_X = ThreadLocal.withInitial(() -> new int[PAIR_SPEC.length()]);
+    private static final ThreadLocal<int[]> PAIR_Y = ThreadLocal.withInitial(() -> new int[PAIR_SPEC.length()]);
+    private static final ThreadLocal<int[]> PAIR_Z = ThreadLocal.withInitial(() -> new int[PAIR_SPEC.length()]);
+    private static final ThreadLocal<int[]> PAIR_OUT = ThreadLocal.withInitial(() -> new int[PAIR_SPEC.length()]);
+
+    private static volatile boolean startupConfigured;
+    private static volatile boolean enabled;
+
+    private VectorizedChunkGeneration() {
+    }
+
+    public static void configureStartup(final boolean enabledInConfig, final boolean simdEnabled) {
+        if (startupConfigured) {
+            return;
+        }
+        enabled = enabledInConfig && simdEnabled;
+        startupConfigured = true;
+    }
+
+    public static boolean isEnabled() {
+        return enabled;
+    }
+
+    public static int preferredVectorBitSize() {
+        return I_SPEC.vectorBitSize();
+    }
+
+    public static boolean hasAvx3fCompatibleWidth() {
+        return I_SPEC.vectorBitSize() >= 512;
+    }
+
+    public static long squaredDistancePair(
+        final int dx0, final int dy0, final int dz0,
+        final int dx1, final int dy1, final int dz1
+    ) {
+        if (!enabled) {
+            final int dist0 = dx0 * dx0 + dy0 * dy0 + dz0 * dz0;
+            final int dist1 = dx1 * dx1 + dy1 * dy1 + dz1 * dz1;
+            return ((long) dist0 << 32) | (dist1 & 0xffffffffL);
+        }
+
+        final int[] x = PAIR_X.get();
+        final int[] y = PAIR_Y.get();
+        final int[] z = PAIR_Z.get();
+        x[0] = dx0;
+        x[1] = dx1;
+        y[0] = dy0;
+        y[1] = dy1;
+        z[0] = dz0;
+        z[1] = dz1;
+
+        final IntVector dx = IntVector.fromArray(PAIR_SPEC, x, 0);
+        final IntVector dy = IntVector.fromArray(PAIR_SPEC, y, 0);
+        final IntVector dz = IntVector.fromArray(PAIR_SPEC, z, 0);
+        final IntVector dist = dx.mul(dx).add(dy.mul(dy)).add(dz.mul(dz));
+
+        final int[] out = PAIR_OUT.get();
+        dist.intoArray(out, 0);
+        return ((long) out[0] << 32) | (out[1] & 0xffffffffL);
+    }
+
+    public static void squaredDistances3d(
+        final int[] absoluteX,
+        final int[] absoluteY,
+        final int[] absoluteZ,
+        final int count,
+        final int originX,
+        final int originY,
+        final int originZ,
+        final int[] out
+    ) {
+        final int length = Math.min(count, Math.min(Math.min(absoluteX.length, absoluteY.length), Math.min(absoluteZ.length, out.length)));
+        if (length <= 0) {
+            return;
+        }
+
+        if (!enabled) {
+            for (int i = 0; i < length; i++) {
+                final int dx = absoluteX[i] - originX;
+                final int dy = absoluteY[i] - originY;
+                final int dz = absoluteZ[i] - originZ;
+                out[i] = dx * dx + dy * dy + dz * dz;
+            }
+            return;
+        }
+
+        final int speciesLength = I_SPEC.length();
+        final int upperBound = length - (length % speciesLength);
+        final IntVector ox = IntVector.broadcast(I_SPEC, originX);
+        final IntVector oy = IntVector.broadcast(I_SPEC, originY);
+        final IntVector oz = IntVector.broadcast(I_SPEC, originZ);
+
+        int i = 0;
+        for (; i < upperBound; i += speciesLength) {
+            final IntVector dx = IntVector.fromArray(I_SPEC, absoluteX, i).sub(ox);
+            final IntVector dy = IntVector.fromArray(I_SPEC, absoluteY, i).sub(oy);
+            final IntVector dz = IntVector.fromArray(I_SPEC, absoluteZ, i).sub(oz);
+            final IntVector dist = dx.mul(dx).add(dy.mul(dy)).add(dz.mul(dz));
+            dist.intoArray(out, i);
+        }
+
+        if (i < length) {
+            final VectorMask<Integer> mask = I_SPEC.indexInRange(i, length);
+            final IntVector dx = IntVector.fromArray(I_SPEC, absoluteX, i, mask).sub(ox);
+            final IntVector dy = IntVector.fromArray(I_SPEC, absoluteY, i, mask).sub(oy);
+            final IntVector dz = IntVector.fromArray(I_SPEC, absoluteZ, i, mask).sub(oz);
+            final IntVector dist = dx.mul(dx).add(dy.mul(dy)).add(dz.mul(dz));
+            dist.intoArray(out, i, mask);
+        }
+    }
+}

--- a/canvas-api/src/main/java/io/canvasmc/canvas/simd/VectorizedChunkGeneration.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/simd/VectorizedChunkGeneration.java
@@ -37,7 +37,7 @@ public final class VectorizedChunkGeneration {
     }
 
     public static boolean hasAvx3fCompatibleWidth() {
-        return I_SPEC.vectorBitSize() >= 512;
+        return I_SPEC.vectorBitSize() >= 256;
     }
 
     public static long squaredDistancePair(

--- a/canvas-api/src/main/java/io/canvasmc/canvas/simd/VectorizedNoiseChunkWrapCache.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/simd/VectorizedNoiseChunkWrapCache.java
@@ -1,0 +1,71 @@
+package io.canvasmc.canvas.simd;
+
+import jdk.incubator.vector.IntVector;
+import jdk.incubator.vector.VectorMask;
+import jdk.incubator.vector.VectorSpecies;
+
+public final class VectorizedNoiseChunkWrapCache {
+
+    private static final VectorSpecies<Integer> PAIR_SPEC = IntVector.SPECIES_64;
+    private static final ThreadLocal<CacheState> STATE = ThreadLocal.withInitial(CacheState::new);
+
+    private VectorizedNoiseChunkWrapCache() {
+    }
+
+    public static Object getCached(final Object owner, final Object function) {
+        final CacheState state = STATE.get();
+        return state.get(owner, function);
+    }
+
+    public static void cache(final Object owner, final Object function, final Object wrapped) {
+        final CacheState state = STATE.get();
+        state.put(owner, function, wrapped);
+    }
+
+    private static final class CacheState {
+        private final int[] ownerHashes = new int[PAIR_SPEC.length()];
+        private final int[] functionHashes = new int[PAIR_SPEC.length()];
+        private final Object[] owners = new Object[PAIR_SPEC.length()];
+        private final Object[] functions = new Object[PAIR_SPEC.length()];
+        private final Object[] wrapped = new Object[PAIR_SPEC.length()];
+
+        private int nextSlot;
+
+        private Object get(final Object owner, final Object function) {
+            if (owners[0] == null && owners[1] == null) {
+                return null;
+            }
+
+            final int ownerHash = System.identityHashCode(owner);
+            final int functionHash = System.identityHashCode(function);
+
+            final IntVector ownerVec = IntVector.fromArray(PAIR_SPEC, ownerHashes, 0);
+            final IntVector functionVec = IntVector.fromArray(PAIR_SPEC, functionHashes, 0);
+            final VectorMask<Integer> mask = ownerVec.eq(ownerHash).and(functionVec.eq(functionHash));
+            if (!mask.anyTrue()) {
+                return null;
+            }
+
+            final int first = mask.firstTrue();
+            if (owners[first] == owner && functions[first] == function) {
+                return wrapped[first];
+            }
+
+            final int second = first ^ 1;
+            if (mask.laneIsSet(second) && owners[second] == owner && functions[second] == function) {
+                return wrapped[second];
+            }
+            return null;
+        }
+
+        private void put(final Object owner, final Object function, final Object wrappedValue) {
+            final int slot = nextSlot;
+            owners[slot] = owner;
+            functions[slot] = function;
+            wrapped[slot] = wrappedValue;
+            ownerHashes[slot] = System.identityHashCode(owner);
+            functionHashes[slot] = System.identityHashCode(function);
+            nextSlot = slot ^ 1;
+        }
+    }
+}

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Aquifer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Aquifer.java.patch
@@ -126,9 +126,16 @@
 +                    int dx1 = ((gx + 1) << 4) + c2me$unpackPackedX(position1) - x;
 +                    int dy1 = gymul + c2me$unpackPackedY(position1) - y;
 +                    int dz1 = gzmul + c2me$unpackPackedZ(position1) - z;
-+                    long simdDistPair = io.canvasmc.canvas.simd.VectorizedChunkGeneration.squaredDistancePair(dx0, dy0, dz0, dx1, dy1, dz1);
-+                    int dist_0 = (int)(simdDistPair >>> 32);
-+                    int dist_1 = (int)simdDistPair;
++                    final int dist_0;
++                    final int dist_1;
++                    if (io.canvasmc.canvas.GlobalConfiguration.isSimdChunkGenerationEnabled()) {
++                        long simdDistPair = io.canvasmc.canvas.simd.VectorizedChunkGeneration.squaredDistancePair(dx0, dy0, dz0, dx1, dy1, dz1);
++                        dist_0 = (int)(simdDistPair >>> 32);
++                        dist_1 = (int)simdDistPair;
++                    } else {
++                        dist_0 = dx0 * dx0 + dy0 * dy0 + dz0 * dz0;
++                        dist_1 = dx1 * dx1 + dy1 * dy1 + dz1 * dz1;
++                    }
 +
 +                    int p0 = (dist_0 << 20) | (index0 << 16) | posIdx0;
 +                    if (p0 <= C) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Aquifer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Aquifer.java.patch
@@ -10,6 +10,10 @@
 +        private int c2me$packed3;
 +        private int c2me$packed4;
 +
++        private static final int C2ME_PACKED_DIST_SHIFT = 20;
++        private static final int C2ME_PACKED_INDEX_SHIFT = 16;
++        private static final int C2ME_PACKED_MAX_DIST = 0xFFF;
++
 +        private double c2me$mutableDoubleThingy;
 +        private short[] c2me$packedBlockPositions;
 +
@@ -31,6 +35,19 @@
 +
 +        private static int c2me$unpackPackedPosIdx(int packed) {
 +            return packed & 0xffff;
++        }
++
++        private static int c2me$packCandidate(final int dist, final int index, final int posIdx) {
++            if (dist < 0 || dist > C2ME_PACKED_MAX_DIST) {
++                return Integer.MAX_VALUE;
++            }
++            if (index < 0 || index > 0xF) {
++                return Integer.MAX_VALUE;
++            }
++            if (posIdx < 0 || posIdx > 0xFFFF) {
++                return Integer.MAX_VALUE;
++            }
++            return (dist << C2ME_PACKED_DIST_SHIFT) | (index << C2ME_PACKED_INDEX_SHIFT) | posIdx;
 +        }
 +
 +        private @Nullable BlockState aquiferExtracted$applyPost(DensityFunction.FunctionContext pos, double density, int j, int i, int k) {
@@ -99,7 +116,7 @@
 +            return false;
 +        }
 +
-+        private void aquiferExtracted$refreshDistPosIdx(int x, int y, int z) {
++        private boolean aquiferExtracted$refreshDistPosIdx(int x, int y, int z) {
 +            int gx = (x - 5) >> 4;
 +            int gy = Math.floorDiv(y + 1, 12);
 +            int gz = (z - 5) >> 4;
@@ -137,7 +154,7 @@
 +                        dist_1 = dx1 * dx1 + dy1 * dy1 + dz1 * dz1;
 +                    }
 +
-+                    int p0 = (dist_0 << 20) | (index0 << 16) | posIdx0;
++                    int p0 = c2me$packCandidate(dist_0, index0, posIdx0);
 +                    if (p0 <= C) {
 +                        int n01 = Math.max(A, p0);
 +                        A = Math.min(A, p0);
@@ -151,7 +168,7 @@
 +                        D = Math.min(D, n03);
 +                    }
 +
-+                    int p1 = (dist_1 << 20) | (index1 << 16) | posIdx1;
++                    int p1 = c2me$packCandidate(dist_1, index1, posIdx1);
 +                    if (p1 <= C) {
 +                        int n11 = Math.max(A, p1);
 +                        A = Math.min(A, p1);
@@ -179,6 +196,7 @@
 +            this.c2me$packed2 = B;
 +            this.c2me$packed3 = C;
 +            this.c2me$packed4 = D;
++            return A != Integer.MAX_VALUE && B != Integer.MAX_VALUE && C != Integer.MAX_VALUE && D != Integer.MAX_VALUE;
 +        }
 +
 +        private Aquifer.FluidStatus c2me$getWaterLevelIndexed(int index) {
@@ -332,8 +350,7 @@
 +                    } if (fluidLevel.at(by).is(Blocks.LAVA)) {
 +                        this.shouldScheduleFluidUpdate = false;
 +                        return Blocks.LAVA.defaultBlockState();
-+                    } else {
-+                        aquiferExtracted$refreshDistPosIdx(bx, by, bz);
++                    } else if (aquiferExtracted$refreshDistPosIdx(bx, by, bz)) {
 +                        return aquiferExtracted$applyPost(context, density, by, bx, bz);
 +                    }
 +                }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Aquifer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Aquifer.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/level/levelgen/Aquifer.java
 +++ b/net/minecraft/world/level/levelgen/Aquifer.java
-@@ -99,6 +_,259 @@
+@@ -99,6 +_,261 @@
          private static final int[][] SURFACE_SAMPLING_OFFSETS_IN_CHUNKS = new int[][]{
              {0, 0}, {-2, -1}, {-1, -1}, {0, -1}, {1, -1}, {-3, 0}, {-2, 0}, {-1, 0}, {1, 0}, {-2, 1}, {-1, 1}, {0, 1}, {1, 1}
          };
@@ -120,15 +120,15 @@
 +                    int dx0 = (gx << 4) + c2me$unpackPackedX(position0) - x;
 +                    int dy0 = gymul + c2me$unpackPackedY(position0) - y;
 +                    int dz0 = gzmul + c2me$unpackPackedZ(position0) - z;
-+                    int dist_0 = dx0 * dx0 + dy0 * dy0 + dz0 * dz0;
-+
 +                    int index1 = index - 2;
 +                    int posIdx1 = posIdx0 + 1;
 +                    int position1 = this.c2me$packedBlockPositions[posIdx1];
 +                    int dx1 = ((gx + 1) << 4) + c2me$unpackPackedX(position1) - x;
 +                    int dy1 = gymul + c2me$unpackPackedY(position1) - y;
 +                    int dz1 = gzmul + c2me$unpackPackedZ(position1) - z;
-+                    int dist_1 = dx1 * dx1 + dy1 * dy1 + dz1 * dz1;
++                    long simdDistPair = io.canvasmc.canvas.simd.VectorizedChunkGeneration.squaredDistancePair(dx0, dy0, dz0, dx1, dy1, dz1);
++                    int dist_0 = (int)(simdDistPair >>> 32);
++                    int dist_1 = (int)simdDistPair;
 +
 +                    int p0 = (dist_0 << 20) | (index0 << 16) | posIdx0;
 +                    if (p0 <= C) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseChunk.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseChunk.java.patch
@@ -1,17 +1,30 @@
 --- a/net/minecraft/world/level/levelgen/NoiseChunk.java
 +++ b/net/minecraft/world/level/levelgen/NoiseChunk.java
-@@ -382,7 +_,17 @@
+@@ -382,7 +_,29 @@
      }
  
      protected DensityFunction wrap(final DensityFunction function) {
 -        return this.wrapped.computeIfAbsent(function, this::wrapNew);
 +        // Canvas start - reduce worldgen allocations
-+        // avoid lambda allocation
++        // avoid lambda allocation + keep a tiny SIMD-assisted wrap cache
++        if (io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.simdChunkGeneration
++            && io.canvasmc.canvas.simd.VectorizedChunkGeneration.isEnabled()) {
++            final DensityFunction cached = (DensityFunction) io.canvasmc.canvas.simd.VectorizedNoiseChunkWrapCache.getCached(this, function);
++            if (cached != null) {
++                return cached;
++            }
++        }
++
 +        DensityFunction func = this.wrapped.get(function);
 +
 +        if (func == null) {
 +            func = this.wrapNew(function);
 +            this.wrapped.put(function, func);
++        }
++
++        if (io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.simdChunkGeneration
++            && io.canvasmc.canvas.simd.VectorizedChunkGeneration.isEnabled()) {
++            io.canvasmc.canvas.simd.VectorizedNoiseChunkWrapCache.cache(this, function, func);
 +        }
 +
 +        return func;

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseChunk.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseChunk.java.patch
@@ -7,8 +7,7 @@
 -        return this.wrapped.computeIfAbsent(function, this::wrapNew);
 +        // Canvas start - reduce worldgen allocations
 +        // avoid lambda allocation + keep a tiny SIMD-assisted wrap cache
-+        if (io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.simdChunkGeneration
-+            && io.canvasmc.canvas.simd.VectorizedChunkGeneration.isEnabled()) {
++        if (io.canvasmc.canvas.GlobalConfiguration.isSimdChunkGenerationEnabled()) {
 +            final DensityFunction cached = (DensityFunction) io.canvasmc.canvas.simd.VectorizedNoiseChunkWrapCache.getCached(this, function);
 +            if (cached != null) {
 +                return cached;
@@ -22,8 +21,7 @@
 +            this.wrapped.put(function, func);
 +        }
 +
-+        if (io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.simdChunkGeneration
-+            && io.canvasmc.canvas.simd.VectorizedChunkGeneration.isEnabled()) {
++        if (io.canvasmc.canvas.GlobalConfiguration.isSimdChunkGenerationEnabled()) {
 +            io.canvasmc.canvas.simd.VectorizedNoiseChunkWrapCache.cache(this, function, func);
 +        }
 +

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -7,6 +7,7 @@ import io.canvasmc.canvas.configuration.Resolver;
 import io.canvasmc.canvas.configuration.Style;
 import io.canvasmc.canvas.configuration.Validator;
 import io.canvasmc.canvas.simd.SIMDDetection;
+import io.canvasmc.canvas.simd.VectorizedChunkGeneration;
 import io.canvasmc.canvas.tick.AffinitySchedulerThreadPool;
 import io.canvasmc.canvas.util.FasterRandomSource;
 import io.canvasmc.canvas.util.version.ApiClient;
@@ -177,6 +178,20 @@ public class GlobalConfiguration extends Part {
                 LOGGER.warn("If you have already added this flag, then SIMD operations are not supported on your JVM or CPU.");
                 LOGGER.warn("Debug: Java: {}, test run: {}", System.getProperty("java.version"), SIMDDetection.testRun);
             }
+
+            VectorizedChunkGeneration.configureStartup(configuration.chunkSystem.simdChunkGeneration, SIMDDetection.isEnabled);
+            if (configuration.chunkSystem.simdChunkGeneration) {
+                if (VectorizedChunkGeneration.isEnabled()) {
+                    LOGGER.info("Chunk generation SIMD acceleration is enabled. Preferred vector width: {} bits.", VectorizedChunkGeneration.preferredVectorBitSize());
+                    if (VectorizedChunkGeneration.hasAvx3fCompatibleWidth()) {
+                        LOGGER.info("AVX3F-class vector width detected. AM5 platforms are a strong fit for this path.");
+                    } else {
+                        LOGGER.info("AM5 platforms are supported for SIMD chunk generation. AVX3F-class width was not detected on this runtime.");
+                    }
+                } else {
+                    LOGGER.warn("Chunk generation SIMD was requested but could not be enabled. Verify JVM Vector API flags and CPU support.");
+                }
+            }
         }
 
         broadcast("Using " + configuration.regionScheduler.defaultTickRate + " as default tick rate", INFO);
@@ -344,6 +359,13 @@ public class GlobalConfiguration extends Part {
                     "helps to mitigate MSPT spiking issues during chunk generation"
                 );
             option("endBiomeCacheSize").greaterThan(0.0F);
+            option("simdChunkGeneration")
+                .docs(
+                    "Enables SIMD-backed chunk generation math in worldgen hot loops.",
+                    "Startup-only setting: changes require a full restart and are ignored by /canvas reload.",
+                    "Java 25 compatible with the Vector API module flag: --add-modules=jdk.incubator.vector.",
+                    "AM5 platforms are supported. AVX3F-class vector width is recommended for best throughput."
+                );
             option("structureOptimizations").docs(
                 "These options are ported from the mod StructureLayoutOptimizer, https://modrinth.com/mod/structure-layout-optimizer",
                 "which optimizes the generation of Jigsaw Structures and NBT pieces"
@@ -363,6 +385,7 @@ public class GlobalConfiguration extends Part {
         public boolean optimizeAquifer = false;
         public boolean useEndBiomeCache = false;
         public int endBiomeCacheSize = 1024;
+        public boolean simdChunkGeneration = false;
         public boolean optimizeBeardifier = false;
         public boolean optimizeNoiseGeneration = false;
 

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -50,6 +50,7 @@ public class GlobalConfiguration extends Part {
     private static GlobalConfiguration INSTANCE;
     private static ApiClient.BuildStatus BUILD_STATUS;
     private static boolean ENABLE_FASTER_RANDOM = true;
+    private static boolean SIMD_CHUNK_GENERATION_ENABLED = false;
 
     static {
         reload();
@@ -179,19 +180,7 @@ public class GlobalConfiguration extends Part {
                 LOGGER.warn("Debug: Java: {}, test run: {}", System.getProperty("java.version"), SIMDDetection.testRun);
             }
 
-            VectorizedChunkGeneration.configureStartup(configuration.chunkSystem.simdChunkGeneration, SIMDDetection.isEnabled);
-            if (configuration.chunkSystem.simdChunkGeneration) {
-                if (VectorizedChunkGeneration.isEnabled()) {
-                    LOGGER.info("Chunk generation SIMD acceleration is enabled. Preferred vector width: {} bits.", VectorizedChunkGeneration.preferredVectorBitSize());
-                    if (VectorizedChunkGeneration.hasAvx3fCompatibleWidth()) {
-                        LOGGER.info("AVX3F-class vector width detected. AM5 platforms are a strong fit for this path.");
-                    } else {
-                        LOGGER.info("AM5 platforms are supported for SIMD chunk generation. AVX3F-class width was not detected on this runtime.");
-                    }
-                } else {
-                    LOGGER.warn("Chunk generation SIMD was requested but could not be enabled. Verify JVM Vector API flags and CPU support.");
-                }
-            }
+            configureSimdChunkGeneration(configuration);
         }
 
         broadcast("Using " + configuration.regionScheduler.defaultTickRate + " as default tick rate", INFO);
@@ -203,6 +192,40 @@ public class GlobalConfiguration extends Part {
 
     public static ApiClient.BuildStatus getBuildStatus() {
         return BUILD_STATUS;
+    }
+
+    public static boolean isSimdChunkGenerationEnabled() {
+        return SIMD_CHUNK_GENERATION_ENABLED;
+    }
+
+    private static void configureSimdChunkGeneration(final GlobalConfiguration configuration) {
+        SIMD_CHUNK_GENERATION_ENABLED = false;
+        if (!configuration.chunkSystem.simdChunkGeneration) {
+            return;
+        }
+
+        try {
+            VectorizedChunkGeneration.configureStartup(true, SIMDDetection.isEnabled);
+            SIMD_CHUNK_GENERATION_ENABLED = VectorizedChunkGeneration.isEnabled();
+        } catch (final NoClassDefFoundError ex) {
+            LOGGER.warn("Chunk generation SIMD was requested but Vector API classes were unavailable at runtime.");
+            LOGGER.warn("Add \"--add-modules=jdk.incubator.vector\" to startup flags before \"-jar\".");
+            return;
+        } catch (final Throwable throwable) {
+            LOGGER.warn("Chunk generation SIMD was requested but failed to initialize: {}", throwable.toString());
+            return;
+        }
+
+        if (SIMD_CHUNK_GENERATION_ENABLED) {
+            LOGGER.info("Chunk generation SIMD acceleration is enabled. Preferred vector width: {} bits.", VectorizedChunkGeneration.preferredVectorBitSize());
+            if (VectorizedChunkGeneration.hasAvx3fCompatibleWidth()) {
+                LOGGER.info("AVX3F-class vector width detected. AM5 platforms are a strong fit for this path.");
+            } else {
+                LOGGER.info("AM5 platforms are supported for SIMD chunk generation. AVX3F-class width was not detected on this runtime.");
+            }
+        } else {
+            LOGGER.warn("Chunk generation SIMD was requested but could not be enabled. Verify JVM Vector API flags and CPU support.");
+        }
     }
 
     public static @NonNull RandomSource createFastRandom() {


### PR DESCRIPTION
###  This PR introduces SIMD-accelerated chunk generation for modern CPUs. (AVX3F-class support)

  ## What changed?

  - Added SIMD helpers for chunk generation.
  - Integrated SIMD-assisted paths into NoiseChunk and Aquifer hot paths.
  - Added a new config option: chunk-system.simd-chunk-generation.
  - This setting is startup-only (requires restart).
  - Added AVX3F/AM5 notes and startup logs.
  - Adjusted the AVX3F compatibility threshold for better AM5/JVM behavior.

  ## Benchmark notes

  - On my AM5 benchmarks, I did not observe regressions.
  - I have not tested AM4 yet. Although it should be supported, AM4 may show different behavior depending on SIMD execution characteristics.
  - I observed a notable CPS increase in my test setup:
      - CPU: Ryzen 7 7700X
      - Threads: 6 (server), 5 (Chunky workers)
      - Memory: 10 GiB container
      - Result: ~240 CPS -> ~320 CPS

  ## Testing note

  **Please add --add-modules=jdk.incubator.vector to startup flags (before -jar) when testing this PR.**