### PR TITLE
Fix stale player list GUI

### DIFF
--- a/canvas-server/minecraft-patches/base/0024-Remove-MinecraftServer-tickables-and-fix-GUI-updates.patch
+++ b/canvas-server/minecraft-patches/base/0024-Remove-MinecraftServer-tickables-and-fix-GUI-updates.patch
@@ -56,7 +56,7 @@ diff --git a/net/minecraft/server/gui/PlayerListComponent.java b/net/minecraft/s
 index 37c9f983ae89c497f44a1b7967d741abf909e0a0..0ea633984c8927a492aae945f2be6c47dabc7df5 100644
 --- a/net/minecraft/server/gui/PlayerListComponent.java
 +++ b/net/minecraft/server/gui/PlayerListComponent.java
-@@ -10,18 +10,31 @@ public class PlayerListComponent extends JList<String> {
+@@ -10,18 +10,25 @@ public class PlayerListComponent extends JList<String> {
  
      public PlayerListComponent(final MinecraftServer server) {
          this.server = server;
@@ -70,7 +70,6 @@ index 37c9f983ae89c497f44a1b7967d741abf909e0a0..0ea633984c8927a492aae945f2be6c47
 -            Vector<String> players = new Vector<>();
 +    private static final io.canvasmc.canvas.util.CanonicalReference<PlayerListComponent> COMPONENT_REF = new io.canvasmc.canvas.util.CanonicalReference<>();
 +    private static int TICK = 0;
-+    private static int LAST_SIZE = 0;
  
 -            for (int i = 0; i < this.server.getPlayerList().getPlayers().size(); i++) {
 -                players.add(this.server.getPlayerList().getPlayers().get(i).getGameProfile().name());
@@ -82,15 +81,11 @@ index 37c9f983ae89c497f44a1b7967d741abf909e0a0..0ea633984c8927a492aae945f2be6c47
 -            this.setListData(players);
 +        final Vector<String> players = new java.util.Vector<>();
 +
-+        // if the size hasn't changed, why the fuck would we update this
 +        final java.util.List<net.minecraft.server.level.ServerPlayer> playerList = net.minecraft.server.MinecraftServer.getServer().getPlayerList().players;
-+        if (playerList.size() == LAST_SIZE) return;
 +
 +        for (final net.minecraft.server.level.ServerPlayer entityPlayer : playerList) {
 +            players.add(entityPlayer.gameProfile.name());
          }
-+
-+        LAST_SIZE = players.size();
 +
 +        COMPONENT_REF.value().setListData(players);
      }


### PR DESCRIPTION
Fixes a stale player list GUI issue where the list could fail to update if one player leaves and another joins between refreshes. The previous logic skipped updates when the player count stayed the same, but the displayed player names may still have changed.

