### PR TITLE
Fix race condition in AffinitySchedulerThreadPool

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/AffinitySchedulerThreadPool.java
@@ -74,8 +74,9 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
     private final boolean enableIntermediateTasks;
     private final Consumer<Throwable> onException;
 
+    private final java.util.concurrent.atomic.AtomicInteger nextSteal = new java.util.concurrent.atomic.AtomicInteger(0);
+
     private volatile boolean halted;
-    private int nextSteal = 0;
 
     public AffinitySchedulerThreadPool(
         final int threads,
@@ -290,11 +291,7 @@ public final class AffinitySchedulerThreadPool extends Scheduler {
             best = globalHead;
         }
 
-        if (nextSteal >= runners.length) {
-            nextSteal = 0;
-        }
-
-        final TickThreadRunner stealingFrom = runners[nextSteal++];
+        final TickThreadRunner stealingFrom = runners[nextSteal.getAndUpdate(v -> (v + 1) % runners.length)];
 
         if (stealingFrom != runner) {
             final ScheduledState stealCandidate = stealingFrom.localQueue.peek();


### PR DESCRIPTION
- Replaced the `int nextSteal` variable with `AtomicInteger` to ensure thread-safe work stealing across multiple tick threads.
- Updated the steal logic to use `getAndUpdate` for atomic increments and modulo operations.
- This prevents potential race conditions where threads might skip tasks or conflict during high-load scheduling.