### PR TITLE
Optimize block entity map fetching with intelligent caching

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkAccess.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/chunk/ChunkAccess.java.patch
@@ -43,6 +43,8 @@
 +        return bucket[canvas$sectionIndex(globalX, globalZ)];
 +    }
 +
++    private Map<BlockPos, BlockEntity> canvas$cachedBlockEntityMap = null;
++
 +    @Nullable
 +    // Note: if removing a block entity, don't use this, use remove method. The block entity is expected non-null
 +    public BlockEntity canvas$setBlockEntityInBuckets(final int globalX, final int y, final int globalZ, final BlockEntity blockEntity) {
@@ -56,16 +58,19 @@
 +        int i = canvas$sectionIndex(globalX, globalZ);
 +        BlockEntity old = bucket[i];
 +        bucket[i] = blockEntity;
++        this.canvas$cachedBlockEntityMap = null;
 +        return old;
 +    }
 +
 +    public void canvas$removeAll(final int y) {
 +        if (y < this.canvas$minY || y > this.canvas$maxY) return;
 +        canvas$blockEntitySections[canvas$toSectionIndex(y)] = null;
++        this.canvas$cachedBlockEntityMap = null;
 +    }
 +
 +    public void canvas$removeAll() {
 +        java.util.Arrays.fill(canvas$blockEntitySections, null);
++        this.canvas$cachedBlockEntityMap = null;
 +    }
 +
 +    @Nullable
@@ -77,6 +82,7 @@
 +            int i = canvas$sectionIndex(globalX, globalZ);
 +            BlockEntity removed = bucket[i];
 +            bucket[i] = null;
++            this.canvas$cachedBlockEntityMap = null;
 +
 +            for (final BlockEntity entry : bucket) {
 +                if (entry != null) return removed;
@@ -158,11 +164,12 @@
 +    }
 +
 +    public Map<BlockPos, BlockEntity> canvas$buildBlockEntityMap() {
++        if (this.canvas$cachedBlockEntityMap != null) return this.canvas$cachedBlockEntityMap;
 +        Map<BlockPos, BlockEntity> blockEntities = new Object2ObjectOpenHashMap<>();
 +        this.canvas$iterateOverBlockEntities((blockEntity) -> {
 +            blockEntities.put(blockEntity.getBlockPos(), blockEntity);
 +        });
-+        return blockEntities;
++        return this.canvas$cachedBlockEntityMap = java.util.Collections.unmodifiableMap(blockEntities);
 +    }
 +    // Canvas end - optimize block entity fetching
      protected final LevelHeightAccessor levelHeightAccessor;


### PR DESCRIPTION
- Added a caching mechanism for `canvas$buildBlockEntityMap` in `ChunkAccess` to avoid redundant map allocations.
- The cache is automatically invalidated whenever a block entity is added, removed, or all are cleared.
- This significantly improves performance for block-entity-heavy operations (like hoppers) by reusing the unmodifiable map until the underlying data changes.