### PR TITLE
Add customizable configuration mappers

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -501,7 +501,7 @@ public class GlobalConfiguration extends Part {
                 "different world due to setup reasoning, like needing to send players to the \"spawn\" world or something.",
                 "This also applies to the end portal and nether portal, in replacement of the overworld, meaning the",
                 "target dimension for entities going from the nether for example will be sent here"
-            ).identifier(); // TODO - object mapping?
+            ).identifier();
     }
 
     public String serverModName = ServerBuildInfo.buildInfo().brandName();
@@ -510,6 +510,10 @@ public class GlobalConfiguration extends Part {
     public boolean cacheMinecraft2BukkitEntityTypeConversion = false;
     public boolean tileEntitySnapshotCreation = false;
     public String defaultRespawnDimensionKey = "minecraft:overworld";
+
+    static {
+        ConfigurationProvider.registerTypeMapper(Identifier.class, Identifier::parse);
+    }
 
     public static @NonNull ResourceKey<@NonNull Level> fetchRespawnDimensionKey() {
         return ResourceKey.create(Registries.DIMENSION, Identifier.parse(GlobalConfiguration.getInstance().defaultRespawnDimensionKey));

--- a/canvas-server/src/main/java/io/canvasmc/canvas/configuration/ConfigurationProvider.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/configuration/ConfigurationProvider.java
@@ -10,10 +10,15 @@ import java.io.StringWriter;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Function;
 import java.util.function.Supplier;
+import net.minecraft.core.registries.Registries;
+import net.minecraft.resources.Identifier;
+import net.minecraft.resources.ResourceKey;
 import org.jetbrains.annotations.Contract;
 import org.jspecify.annotations.NonNull;
 import org.jspecify.annotations.Nullable;
@@ -41,6 +46,12 @@ public class ConfigurationProvider {
     private static final DumperOptions DUMPER_OPTIONS;
     // note: if we want to preserve comments, we have to use compose() on file reads
     private static final Yaml YAML;
+
+    private static final Map<Class<?>, Function<String, Object>> TYPE_MAPPERS = new HashMap<>();
+
+    public static <T> void registerTypeMapper(Class<T> clazz, Function<String, T> mapper) {
+        TYPE_MAPPERS.put(clazz, (Function<String, Object>) mapper);
+    }
 
     static {
         LOADER_OPTIONS = new LoaderOptions();
@@ -102,7 +113,7 @@ public class ConfigurationProvider {
 
             @Override
             protected Tag getTag(@NonNull Class<?> clazz, Tag defaultTag) {
-                if (clazz.isEnum()) {
+                if (clazz.isEnum() || TYPE_MAPPERS.containsKey(clazz)) {
                     return Tag.STR;
                 }
                 return super.getTag(clazz, defaultTag);
@@ -111,7 +122,21 @@ public class ConfigurationProvider {
         representer.setPropertyUtils(propertyUtils);
         representer.getPropertyUtils().setBeanAccess(BeanAccess.FIELD);
 
-        Constructor constructor = new Constructor(LOADER_OPTIONS);
+        Constructor constructor = new Constructor(LOADER_OPTIONS) {
+            {
+                this.yamlConstructors.put(Tag.STR, new ConstructScalar() {
+                    @Override
+                    public Object construct(org.yaml.snakeyaml.nodes.Node node) {
+                        String value = (String) super.construct(node);
+                        Function<String, Object> mapper = TYPE_MAPPERS.get(node.getType());
+                        if (mapper != null) {
+                            return mapper.apply(value);
+                        }
+                        return value;
+                    }
+                });
+            }
+        };
         constructor.setPropertyUtils(propertyUtils);
         constructor.getPropertyUtils().setBeanAccess(BeanAccess.FIELD);
 


### PR DESCRIPTION
Adds a registry-based system for configuration object mappers, making the system flexible and extensible instead of hardcoding types