### PR TITLE
Optimize XP orb scanning frequency

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
@@ -1,11 +1,12 @@
 --- a/net/minecraft/world/entity/ExperienceOrb.java
 +++ b/net/minecraft/world/entity/ExperienceOrb.java
-@@ -242,7 +_,7 @@
+@@ -241,8 +_,8 @@
+     }
  
      private void scanForMerges() {
 -        if (this.level() instanceof ServerLevel) {
-+        if (this.level() instanceof ServerLevel && (!this.level().canvasConfig().entities.fastOrbs || this.tickCount % 2 == 0)) {
 -            for (ExperienceOrb orb : this.level().getEntities(EntityTypeTest.forClass(ExperienceOrb.class), this.getBoundingBox().inflate(0.5), this::canMerge)) {
++        if (this.level() instanceof ServerLevel && (!this.level().canvasConfig().entities.fastOrbs || this.tickCount % 2 == 0)) { // Canvas - fast orbs
 +            for (ExperienceOrb orb : this.level().getEntities(EntityTypeTest.forClass(ExperienceOrb.class), this.getBoundingBox().inflate(level().canvasConfig().entities.fastOrbs ? 0.9 : 0.5), this::canMerge)) { // Canvas - fast orbs
                  this.merge(orb);
              }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/ExperienceOrb.java.patch
@@ -3,7 +3,8 @@
 @@ -242,7 +_,7 @@
  
      private void scanForMerges() {
-         if (this.level() instanceof ServerLevel) {
+-        if (this.level() instanceof ServerLevel) {
++        if (this.level() instanceof ServerLevel && (!this.level().canvasConfig().entities.fastOrbs || this.tickCount % 2 == 0)) {
 -            for (ExperienceOrb orb : this.level().getEntities(EntityTypeTest.forClass(ExperienceOrb.class), this.getBoundingBox().inflate(0.5), this::canMerge)) {
 +            for (ExperienceOrb orb : this.level().getEntities(EntityTypeTest.forClass(ExperienceOrb.class), this.getBoundingBox().inflate(level().canvasConfig().entities.fastOrbs ? 0.9 : 0.5), this::canMerge)) { // Canvas - fast orbs
                  this.merge(orb);


### PR DESCRIPTION
Optimized experience orb scanning frequency to every 2 ticks when fast-orbs is enabled to reduce unnecessary CPU overhead.