### PR TITLE
Fix desynchronized day cycle (#234)

### DIFF
--- a/canvas-server/minecraft-patches/base/0002-Remove-Vanilla-Profiler.patch
+++ b/canvas-server/minecraft-patches/base/0002-Remove-Vanilla-Profiler.patch
@@ -415,7 +415,7 @@ index 2bb8a18942a5e203181ac02c03dbc99200ff81be..6aa5ee89a3ae1e2c71ef5121de8c3be0
 -        profiler.push("timeSync");
          // Folia start - region threading
          final io.papermc.paper.threadedregions.RegionizedWorldData worldData = io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
-         ClientboundSetTimePacket timePacket = new ClientboundSetTimePacket(worldData.world.getGameTime(), Map.of());
+         ClientboundSetTimePacket timePacket = this.clockManager().createFullSyncPacket();
 @@ -2007,7 +1925,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
              }
          }


### PR DESCRIPTION
forceGameTimeSynchronization()` was sending an empty `Map.of()` for clock updates. Replaced with `this.clockManager().createFullSyncPacket()` so the client receives proper `WorldClock` states