### PR TITLE
Fix Folia Usages of `schedule` instead of `scheduleOrExecute`

### DIFF
--- a/canvas-server/minecraft-patches/base/0008-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0008-Fixup-Region-Threading.patch
@@ -1282,7 +1282,7 @@ index b9591a852c95b9d4a8420ef8b6aa254c25bce107..744928c62462e21e1bed74ecc6781b6c
              ComponentSerialization.TRUSTED_STREAM_CODEC.encode(output, this.playerPrefix);
              ComponentSerialization.TRUSTED_STREAM_CODEC.encode(output, this.playerSuffix);
 diff --git a/net/minecraft/server/MinecraftServer.java b/net/minecraft/server/MinecraftServer.java
-index 54a377f147edb24b88f72fcb0a45d337d818b128..5efdaac1f8dc5f88942d449c7eb61a6b2e73d679 100644
+index 54a377f147edb24b88f72fcb0a45d337d818b128..3f20aee4ee22eccb0d496f38000425efb2a0fc0b 100644
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
 @@ -209,7 +209,6 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
@@ -1525,6 +1525,22 @@ index 54a377f147edb24b88f72fcb0a45d337d818b128..5efdaac1f8dc5f88942d449c7eb61a6b
      }
  
      protected void setId(final String serverId) {
+@@ -2186,13 +2262,13 @@ public abstract class MinecraftServer extends ReentrantBlockableEventLoop<TickTa
+         int count = 0;
+ 
+         for (ServerPlayer player : this.getPlayerList().getPlayers()) {
+-            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer updatedPlayer) -> { // Folia - region threading
++            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer updatedPlayer) -> { // Folia - region threading // Canvas - region threading
+             // Paper start - Expand PlayerGameModeChangeEvent
+             org.bukkit.event.player.PlayerGameModeChangeEvent event = updatedPlayer.setGameMode(gameType, org.bukkit.event.player.PlayerGameModeChangeEvent.Cause.DEFAULT_GAMEMODE, null); // Folia - region threading
+             if (event == null || event.isCancelled()) {
+                 return; // Folia - region threading
+             }
+-            }, null, 1L); // Folia - region threading
++            }); // Folia - region threading // Canvas - region threading
+             count++;
+             // Paper end - Expand PlayerGameModeChangeEvent
+         }
 diff --git a/net/minecraft/server/ServerScoreboard.java b/net/minecraft/server/ServerScoreboard.java
 index 9bf09b888425e491072864265c8de3885154a0ba..7cb6d183be1a04c4f59b2d335fc706c1645deb9f 100644
 --- a/net/minecraft/server/ServerScoreboard.java
@@ -1729,6 +1745,37 @@ index fb55ed68a1f8470b551030a27ca2656555c93d9e..5756f7aca1a80782a88b0e82ef82a626
  
      public @Nullable CustomBossEvent get(final Identifier id) {
          return this.events.get(id);
+diff --git a/net/minecraft/server/commands/ExperienceCommand.java b/net/minecraft/server/commands/ExperienceCommand.java
+index 8eae0c33e3f37c388f3c7466e5733fb5da90258a..2b5a8893473a5d2c28c53095e9cec34f638c33c5 100644
+--- a/net/minecraft/server/commands/ExperienceCommand.java
++++ b/net/minecraft/server/commands/ExperienceCommand.java
+@@ -137,9 +137,9 @@ public class ExperienceCommand {
+         final CommandSourceStack source, final Collection<? extends ServerPlayer> players, final int amount, final ExperienceCommand.Type type
+     ) {
+         for (ServerPlayer player : players) {
+-            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> { // Folia - region threading
++            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Folia - region threading // Canvas - region threading
+             type.add.accept(newPlayer, amount); // Folia - region threading
+-            }, null, 1L); // Folia - region threading
++            }); // Folia - region threading // Canvas - region threading
+         }
+ 
+         if (players.size() == 1) {
+@@ -162,12 +162,12 @@ public class ExperienceCommand {
+         for (ServerPlayer player : players) {
+             // Folia start - region threading
+             ++success;
+-            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> {
++            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Canvas - region threading
+             if (type.set.test(newPlayer, amount)) {
+                 //success++;
+                 // Folia end - region threading
+             }
+-            }, null, 1L); // Folia - region threading
++            }); // Folia - region threading // Canvas - region threading
+         }
+ 
+         if (success == 0) {
 diff --git a/net/minecraft/server/commands/LootCommand.java b/net/minecraft/server/commands/LootCommand.java
 index 62cad9bb4b90ee5fd3c604713ce3ee071e9df250..d2fb1db4b616cb4f65e7509bc14f29d92e904050 100644
 --- a/net/minecraft/server/commands/LootCommand.java
@@ -1878,6 +1925,56 @@ index 62cad9bb4b90ee5fd3c604713ce3ee071e9df250..d2fb1db4b616cb4f65e7509bc14f29d9
      }
  
      private static int dropKillLoot(final CommandContext<CommandSourceStack> context, final Entity target, final LootCommand.DropConsumer output) throws CommandSyntaxException {
+diff --git a/net/minecraft/server/commands/RecipeCommand.java b/net/minecraft/server/commands/RecipeCommand.java
+index 37014e8da22b7cd72ca05988d7cbcc537b63d6b7..e8f4a96a30b4fe6b41af56dfd8ff86477f6192e0 100644
+--- a/net/minecraft/server/commands/RecipeCommand.java
++++ b/net/minecraft/server/commands/RecipeCommand.java
+@@ -83,9 +83,9 @@ public class RecipeCommand {
+         for (ServerPlayer player : players) {
+             // Folia start - region threading
+             ++success;
+-            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> {
++            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Canvas - region threading
+                 newPlayer.awardRecipes(recipes);
+-            }, null, 1L);
++            }); // Canvas - region threading
+             // Folia end - region threading
+         }
+ 
+@@ -110,9 +110,9 @@ public class RecipeCommand {
+         for (ServerPlayer player : players) {
+             // Folia start - region threading
+             ++success;
+-            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> {
++            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Canvas - region threading
+                 newPlayer.resetRecipes(recipes);
+-            }, null, 1L);
++            }); // Canvas - region threading
+             // Folia end - region threading
+         }
+ 
+diff --git a/net/minecraft/server/commands/RideCommand.java b/net/minecraft/server/commands/RideCommand.java
+index 59e5b876726948e31c0964df641f8027a11b073c..8a53d1f429f24ec0ae251be46ae4acf7800e4061 100644
+--- a/net/minecraft/server/commands/RideCommand.java
++++ b/net/minecraft/server/commands/RideCommand.java
+@@ -100,7 +100,7 @@ public class RideCommand {
+ 
+     // Folia start - region threading
+     private static int dismount(final CommandSourceStack source, final Entity targetOld) throws CommandSyntaxException {
+-        targetOld.getBukkitEntity().taskScheduler.schedule((Entity target) -> {
++        targetOld.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity target) -> { // Canvas - region threading
+             try {
+                 // Folia end - region threading
+         Entity vehicle = target.getVehicle();
+@@ -115,7 +115,7 @@ public class RideCommand {
+             } catch (CommandSyntaxException ex) {
+                 sendMessage(source, ex);
+             }
+-        }, null, 1L);
++        }); // Canvas - region threading
+         return 0;
+         // Folia end - region threading
+     }
 diff --git a/net/minecraft/server/commands/SaveAllCommand.java b/net/minecraft/server/commands/SaveAllCommand.java
 index a75f805051cbcca6a458dcc77e707e8e7c2e4a67..f593835d0603e065137cf10ad155494a9f9413ce 100644
 --- a/net/minecraft/server/commands/SaveAllCommand.java
@@ -2904,7 +3001,7 @@ index b64ca9b1125354dc1c3d1a844cc396adefcf5938..f59e8b0905bb9048feb1027f1dd72d7c
      }
  }
 diff --git a/net/minecraft/server/commands/TeleportCommand.java b/net/minecraft/server/commands/TeleportCommand.java
-index 369be2ad59cf05c76a44b4b00bec18d1c564688a..50cbf161de3ce23411e3a37e6e7d7df778a742bd 100644
+index 369be2ad59cf05c76a44b4b00bec18d1c564688a..e4d2cb8417d638d32c9de75e290e54db45e2c378 100644
 --- a/net/minecraft/server/commands/TeleportCommand.java
 +++ b/net/minecraft/server/commands/TeleportCommand.java
 @@ -241,8 +241,8 @@ public class TeleportCommand {
@@ -2918,6 +3015,24 @@ index 369be2ad59cf05c76a44b4b00bec18d1c564688a..50cbf161de3ce23411e3a37e6e7d7df7
          float newYRot = Mth.wrapDegrees(relativeOrAbsoluteYRot);
          float newXRot = Mth.wrapDegrees(relativeOrAbsoluteXRot);
          // Folia start - region threading
+@@ -250,7 +250,7 @@ public class TeleportCommand {
+             Vec3 posFinal = new Vec3(x, y, z);
+             Float yawFinal = Float.valueOf(newYRot);
+             Float pitchFinal = Float.valueOf(newXRot);
+-            victim.getBukkitEntity().taskScheduler.schedule((Entity nmsEntity) -> {
++            victim.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity nmsEntity) -> { // Canvas - region threading
+                 nmsEntity.stopRiding();
+                 nmsEntity.teleportAsync(
+                         level, posFinal, yawFinal, pitchFinal, Vec3.ZERO,
+@@ -258,7 +258,7 @@ public class TeleportCommand {
+                         Entity.TELEPORT_FLAG_LOAD_CHUNK | Entity.TELEPORT_FLAG_TELEPORT_PASSENGERS,
+                         null
+                 );
+-                }, null, 1L);
++                }); // Canvas - region threading
+             return;
+         }
+         // Folia end - region threading
 diff --git a/net/minecraft/server/commands/TriggerCommand.java b/net/minecraft/server/commands/TriggerCommand.java
 index 088b7b91154546fc9c020cab5cefbb4b89762ac8..9d5f76ff2892fd38a21397698a986027774f5832 100644
 --- a/net/minecraft/server/commands/TriggerCommand.java
@@ -3163,7 +3278,7 @@ index 24450c98da398d13a3f215d464356e7c67a318b6..bdee748016d6b032f5cd3ffbfde4d7db
          // Paper start - extra debug info
          if (entity.valid) {
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 145dc8559e570696baa3f1f2294a2258b94d7727..94301145d8f6caf33a45b92b57b11f2267b4ebbe 100644
+index 145dc8559e570696baa3f1f2294a2258b94d7727..49cfe2aa5281da3cfe8789bd148fe8dcee7a285e 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -267,7 +267,40 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -3544,6 +3659,24 @@ index 145dc8559e570696baa3f1f2294a2258b94d7727..94301145d8f6caf33a45b92b57b11f22
          org.bukkit.craftbukkit.event.CraftEventFactory.handleInventoryCloseEvent(this, reason); // CraftBukkit
          // Paper end - Inventory close reason
          this.connection.send(new ClientboundContainerClosePacket(this.containerMenu.containerId));
+@@ -3029,7 +3191,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+         Entity cameraFinal = this.camera;
+         // use the task scheduler, as we don't know where the caller is invoking from
+         if (this != cameraFinal) {
+-            this.getBukkitEntity().taskScheduler.schedule((final ServerPlayer newPlayer) -> {
++            this.getBukkitEntity().taskScheduler.scheduleOrExecute((final ServerPlayer newPlayer) -> { // Canvas - region threading
+                 io.papermc.paper.threadedregions.TeleportUtils.teleport(
+                         newPlayer, false, cameraFinal, null, null, 0L,
+                         org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.SPECTATE, null,
+@@ -3037,7 +3199,7 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+                             return newerPlayer.camera == cameraFinal;
+                         }
+                 );
+-            }, null, 1L);
++            }); // Canvas - region threading
+         } // else: do not bother teleporting to self
+     }
+     // Folia end - region threading
 @@ -3425,11 +3587,13 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
      }
  
@@ -3705,7 +3838,7 @@ index fbd0a4121a1db58e2576eaff1fece661315ab68f..439fc764794b3a67dffa898b91f50a18
              CompletableFuture<Vec3> spawnPosition = new java.util.concurrent.CompletableFuture<>();
              if (loadedPosition.position().isPresent()) {
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 30369b25a6ce90da118b01731a4316cf315cc349..97a6b96bd0a9ae06afb8fc0adaf754e85a2d2f5f 100644
+index 30369b25a6ce90da118b01731a4316cf315cc349..14c5848f0a6ebadbbef3b55edaf518e7e0303291 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -133,7 +133,7 @@ public abstract class PlayerList {
@@ -3781,6 +3914,30 @@ index 30369b25a6ce90da118b01731a4316cf315cc349..97a6b96bd0a9ae06afb8fc0adaf754e8
  
          level.removePlayerImmediately(player, Entity.RemovalReason.UNLOADED_WITH_PLAYER);
          player.retireScheduler(); // Paper - Folia schedulers
+@@ -904,9 +885,9 @@ public abstract class PlayerList {
+             );
+         ServerPlayer player = this.getPlayer(nameAndId.id());
+         if (player != null) {
+-            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer serverPlayer) -> { // Folia - region threading
++            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer serverPlayer) -> { // Folia - region threading // Canvas - region threading
+             this.sendPlayerPermissionLevel(serverPlayer); // Folia - region threading
+-            }, null, 1L); // Folia - region threading
++            }); // Folia - region threading // Canvas - region threading
+         }
+     }
+ 
+@@ -915,9 +896,9 @@ public abstract class PlayerList {
+             ServerPlayer player = this.getPlayer(nameAndId.id());
+             if (player != null) {
+                 // Folia start - region threading
+-                player.getBukkitEntity().taskScheduler.schedule((ServerPlayer serverPlayer) -> {
++                player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer serverPlayer) -> { // Canvas - region threading
+                     this.sendPlayerPermissionLevel(serverPlayer);
+-                }, null, 1L);
++                }); // Canvas - region threading
+                 // Folia end - region threading
+             }
+         }
 @@ -1033,14 +1014,14 @@ public abstract class PlayerList {
          // Paper start - Incremental chunk and player saving
              int numSaved = 0;
@@ -4764,7 +4921,7 @@ index 5d5a235549b210dd8223a1019c0ee0dbe3470fab..a56cad1c19a7825d6b7b6b338387ed26
                  Entity owner = this.getOwner();
                  if (owner instanceof LivingEntity) {
 diff --git a/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java b/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
-index 36f15967dfd1a5bde4332eec22bbb0dcc9732693..29b0ed706d622d4b9e636dd7b4d5c5ce5e8da6e6 100644
+index 36f15967dfd1a5bde4332eec22bbb0dcc9732693..79811d0383d7207788e48e99f708550fcf673cde 100644
 --- a/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
 +++ b/net/minecraft/world/entity/projectile/throwableitemprojectile/ThrownEnderpearl.java
 @@ -52,11 +52,15 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
@@ -4785,6 +4942,45 @@ index 36f15967dfd1a5bde4332eec22bbb0dcc9732693..29b0ed706d622d4b9e636dd7b4d5c5ce
      }
  
      @Override
+@@ -79,7 +83,7 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
+     private static void attemptTeleport(Entity source, ServerLevel checkWorld, net.minecraft.world.phys.Vec3 to) {
+         final boolean onPortalCooldown = source.isOnPortalCooldown();
+         // ignore retired callback, in those cases we do not want to teleport
+-        source.getBukkitEntity().taskScheduler.schedule(
++        source.getBukkitEntity().taskScheduler.scheduleOrExecute( // Canvas - region threading
+             (Entity entity) -> {
+                 if (!isAllowedToTeleportOwner(entity, checkWorld)) {
+                     return;
+@@ -144,8 +148,7 @@ public class ThrownEnderpearl extends ThrowableItemProjectile {
+                         }
+                     }
+                 );
+-            },
+-            null, 1L
++            } // Canvas - region threading
+         );
+     }
+     // Folia end - region threading
+diff --git a/net/minecraft/world/entity/raid/Raid.java b/net/minecraft/world/entity/raid/Raid.java
+index ecc97ec30f9ba0ff4f804f350ae03118be3d8b4f..81fd2f5d343fe25413102dac791965e84ce924e5 100644
+--- a/net/minecraft/world/entity/raid/Raid.java
++++ b/net/minecraft/world/entity/raid/Raid.java
+@@ -436,13 +436,13 @@ public class Raid {
+                                     winners.add(playerHero.getBukkitEntity()); // CraftBukkit
+                                 }
+                                 // Folia start - Fix off region raid heroes
+-                                hero.getBukkitEntity().taskScheduler.schedule((LivingEntity lv) -> {
++                                hero.getBukkitEntity().taskScheduler.scheduleOrExecute((LivingEntity lv) -> { // Canvas - region threading
+                                     lv.addEffect(new MobEffectInstance(MobEffects.HERO_OF_THE_VILLAGE, 48000, this.raidOmenLevel - 1, false, false, true));
+                                     if (lv instanceof ServerPlayer serverPlayer) {
+                                         serverPlayer.awardStat(Stats.RAID_WIN);
+                                         CriteriaTriggers.RAID_WIN.trigger(serverPlayer);
+                                     }
+-                                }, null, 1L);
++                                }); // Canvas - region threading
+                                 // Folia end - Fix off region raid heroes
+                             }
+                         }
 diff --git a/net/minecraft/world/item/Item.java b/net/minecraft/world/item/Item.java
 index 589b67f329e17f0a341e3c7600141b731fde9b52..9bc7d871fc133ee3604b807cc73f3ea97c8a4612 100644
 --- a/net/minecraft/world/item/Item.java

--- a/canvas-server/minecraft-patches/base/0011-Purpur-Ender-Chest-6-Rows-Config.patch
+++ b/canvas-server/minecraft-patches/base/0011-Purpur-Ender-Chest-6-Rows-Config.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Purpur Ender Chest 6 Rows Config
 
 
 diff --git a/net/minecraft/server/players/PlayerList.java b/net/minecraft/server/players/PlayerList.java
-index 97a6b96bd0a9ae06afb8fc0adaf754e85a2d2f5f..3b410f8717732db5807471766920fb855ba3417b 100644
+index 14c5848f0a6ebadbbef3b55edaf518e7e0303291..68c30fafdc56a0b4cb4addcf8668e823c0934b7f 100644
 --- a/net/minecraft/server/players/PlayerList.java
 +++ b/net/minecraft/server/players/PlayerList.java
 @@ -926,6 +926,27 @@ public abstract class PlayerList {


### PR DESCRIPTION
Changes out the calls that could be `scheduleOrExecute`. Anything left remaining should be delayed or is called in a context that no player would be owned