### PR TITLE
fix: restore CANVAS brand compatibility in isBrandCompatible

### DIFF
--- a/canvas-server/paper-patches/base/0001-Rebrand.patch
+++ b/canvas-server/paper-patches/base/0001-Rebrand.patch
@@ -94,7 +94,7 @@ index 10a0be7a4db1a51579d113d279af7a9effe7f438..0e9dcc8bcabcb7c6fbf93a470f8f53b4
      @Override
      public boolean isBrandCompatible(final @NotNull Key brandId) {
 -        return brandId.equals(this.brandId);
-+        return brandId.equals(this.brandId) || brandId.equals(BRAND_PAPER_ID) || brandId.equals(BRAND_FOLIA_ID); // Canvas - Rebrand
++        return brandId.equals(this.brandId) || brandId.equals(BRAND_PAPER_ID) || brandId.equals(BRAND_FOLIA_ID) || brandId.equals(BRAND_CANVAS_ID); // Canvas - Rebrand
      }
  
      @Override


### PR DESCRIPTION
This fix resolves this following bug: 

```java
    @Override
    public boolean isAvailable() {
        var BRAND_CANVAS_ID = Key.key("canvasmc", "canvas");
        var buildInfo = ServerBuildInfo.buildInfo();
        boolean isCanvas = buildInfo.isBrandCompatible(BRAND_CANVAS_ID);
        log.info("Use CANVAS : {}", isCanvas);
        return isCanvas;
    }
```

Response without the fix : 
[15:56:41 INFO]: [fr.euphyllia.skyllia.hook.canvas.CanvasHook] Use CANVAS : false