### PR TITLE
Fix /tps callback retaining region data

### DIFF
--- a/canvas-server/minecraft-patches/base/0008-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0008-Fixup-Region-Threading.patch
@@ -880,7 +880,7 @@ index aca5a23f315f95129204229c25dff6776ab9469a..98d57582ee330644953f9d9b52609e61
                  executeChunkTask = queue.executeChunkTask();
                  executePacketTask = this.region.drainOnePacket();
 diff --git a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
-index 7826c50b7c7c59e148905337ddc0dc8085f3f7c1..37519ae684629e4bc7758fdefb1990d3ab97e7f9 100644
+index 7826c50b7c7c59e148905337ddc0dc8085f3f7c1..c9baa698657aab559476c97687e3508f7b5b4181 100644
 --- a/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 +++ b/io/papermc/paper/threadedregions/commands/CommandServerHealth.java
 @@ -55,14 +55,14 @@ public final class CommandServerHealth extends Command {
@@ -965,7 +965,7 @@ index 7826c50b7c7c59e148905337ddc0dc8085f3f7c1..37519ae684629e4bc7758fdefb1990d3
                  .append(Component.text(" TPS\n", PRIMARY))
  
                  .append(Component.text("    ", PRIMARY))
-@@ -274,6 +266,141 @@ public final class CommandServerHealth extends Command {
+@@ -274,6 +266,87 @@ public final class CommandServerHealth extends Command {
                  .append(Component.text(" - ", LIST, TextDecoration.BOLD))
                  .append(Component.text("Online Players: ", PRIMARY))
                  .append(Component.text(Bukkit.getOnlinePlayers().size() + "\n", INFORMATION))
@@ -1030,73 +1030,19 @@ index 7826c50b7c7c59e148905337ddc0dc8085f3f7c1..37519ae684629e4bc7758fdefb1990d3
 +                        worldBuilder.append(Component.text(ONE_DECIMAL_PLACES.get().format(worldUtil * 100.0) + "/" + ONE_DECIMAL_PLACES.get().format(maxThreadCount * 100.0) + "%", CommandUtil.getUtilisationColourRegion(worldUtil)));
 +                        worldBuilder.append(Component.text(" util\n", SECONDARY));
 +
++                        final String dimensionPath = world.dimension().identifier().getPath();
++                        final String worldName = world.getWorld().getName();
++                        final String worldKey = world.getWorld().getKey().toString();
++                        final Component detailComponent = Component.text()
++                            .append(Component.text("Highest ", HEADER, TextDecoration.BOLD))
++                            .append(Component.text(" utilisation regions in ", HEADER, TextDecoration.BOLD))
++                            .append(Component.text(dimensionPath + "\n", INFORMATION, TextDecoration.BOLD))
++                            .append(buildHighestRegionDetails(worldName, worldKey, lowestRegionsCount, list))
++                            .build();
++
 +                        mainBuilder.append(worldBuilder.build()
-+                            .hoverEvent(HoverEvent.showText(Component.text("Click to view highest utilizing regions for \"" + world.dimension().identifier().getPath() + "\"", SECONDARY)))
-+                            .clickEvent(ClickEvent.callback((audience) -> {
-+                                audience.sendMessage(Component.text()
-+                                    .append(Component.text("Highest ", HEADER, TextDecoration.BOLD))
-+                                    .append(Component.text(" utilisation regions in ", HEADER, TextDecoration.BOLD))
-+                                    .append(Component.text(world.dimension().identifier().getPath() + "\n", INFORMATION, TextDecoration.BOLD))
-+
-+                                    .append(((java.util.function.Supplier<Component>) () -> {
-+
-+                                        // copied from above
-+                                        final TextComponent.Builder worldRegionsBuilder = Component.text();
-+
-+                                        for (int i = 0, len = Math.min(lowestRegionsCount, list.size()); i < len; ++i) {
-+                                            final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>
-+                                                pair = list.get(i);
-+
-+                                            final TickData.TickReportData report = pair.right();
-+                                            final ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region =
-+                                                pair.left();
-+
-+                                            if (report == null) {
-+                                                // skip regions with no data
-+                                                continue;
-+                                            }
-+
-+                                            final ChunkPos chunkCenter = region.getCenterChunk();
-+                                            if (chunkCenter == null) {
-+                                                // region does not exist anymore
-+                                                continue;
-+                                            }
-+                                            final int centerBlockX = ((chunkCenter.x() << 4) | 7);
-+                                            final int centerBlockZ = ((chunkCenter.z() << 4) | 7);
-+                                            final double util = report.utilisation();
-+                                            final double tps = report.tpsData().segmentAll().average();
-+                                            final double mspt = report.timePerTickData().segmentAll().average() / 1.0E6;
-+
-+                                            final int yLoc = 80;
-+                                            final String location = "[w:'" + world.getWorld().getName() + "'," + centerBlockX + "," + yLoc + "," + centerBlockZ + "]";
-+                                            final Component line = Component.text()
-+                                                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
-+                                                .append(Component.text("Region around block ", PRIMARY))
-+                                                .append(Component.text(location, INFORMATION))
-+                                                .append(Component.text(":\n", PRIMARY))
-+
-+                                                .append(Component.text("    ", PRIMARY))
-+                                                .append(Component.text(ONE_DECIMAL_PLACES.get().format(util * 100.0), region.getData().getRegionSchedulingHandle().getTickManager().isSprinting() ? CommandUtil.SPRINTING_COLOR : CommandUtil.getUtilisationColourRegion(util))) // Canvas - region threading
-+                                                .append(Component.text("% util at ", PRIMARY))
-+                                                .append(Component.text(TWO_DECIMAL_PLACES.get().format(mspt), region.getData().getRegionSchedulingHandle().getTickManager().isSprinting() ? CommandUtil.SPRINTING_COLOR : CommandUtil.getColourForMSPT(mspt))) // Canvas - region threading
-+                                                .append(Component.text(" MSPT at ", PRIMARY))
-+                                                .append(Component.text(TWO_DECIMAL_PLACES.get().format(tps), region.getData().getRegionSchedulingHandle().getTickManager().isSprinting() ? CommandUtil.SPRINTING_COLOR : CommandUtil.getColourForTPS(tps))) // Canvas - region threading
-+                                                .append(Component.text(" TPS\n", PRIMARY))
-+
-+                                                .append(Component.text("    ", PRIMARY))
-+                                                .append(formatRegionStats(region.getData().getRegionStats(), (i + 1) != len))
-+                                                .build()
-+
-+                                                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + world.getWorld().getKey().toString() + " run tp " + centerBlockX + ".5 " + yLoc + " " + centerBlockZ + ".5"))
-+                                                .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, Component.text("Click to teleport to " + location, SECONDARY)));
-+
-+                                            worldRegionsBuilder.append(line);
-+                                        }
-+
-+                                        return worldRegionsBuilder.build();
-+                                    }).get())
-+                                );
-+                            }))
++                            .hoverEvent(HoverEvent.showText(Component.text("Click to view highest utilizing regions for \"" + dimensionPath + "\"", SECONDARY)))
++                            .clickEvent(ClickEvent.callback((audience) -> audience.sendMessage(detailComponent)))
 +                        );
 +                    }
 +
@@ -1107,7 +1053,7 @@ index 7826c50b7c7c59e148905337ddc0dc8085f3f7c1..37519ae684629e4bc7758fdefb1990d3
  
                  .append(Component.text(" - ", LIST, TextDecoration.BOLD))
                  .append(Component.text("Total regions: ", PRIMARY))
-@@ -293,16 +420,13 @@ public final class CommandServerHealth extends Command {
+@@ -293,16 +366,13 @@ public final class CommandServerHealth extends Command {
                  .append(Component.text(TWO_DECIMAL_PLACES.get().format(genRate) + "\n", INFORMATION))
  
                  .append(Component.text(" - ", LIST, TextDecoration.BOLD))
@@ -1131,11 +1077,73 @@ index 7826c50b7c7c59e148905337ddc0dc8085f3f7c1..37519ae684629e4bc7758fdefb1990d3
                  .append(Component.text(TWO_DECIMAL_PLACES.get().format(maxTps) + "\n", CommandUtil.getColourForTPS(maxTps)))
  
                  .append(Component.text("Highest ", HEADER, TextDecoration.BOLD))
-@@ -315,6 +439,21 @@ public final class CommandServerHealth extends Command {
+@@ -315,6 +385,83 @@ public final class CommandServerHealth extends Command {
  
          return true;
      }
 +    // Canvas start - expand TPS cmd
++
++    private static Component buildHighestRegionDetails(
++        final String worldName,
++        final String worldKey,
++        final int lowestRegionsCount,
++        final List<ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>> list
++    ) {
++        final TextComponent.Builder worldRegionsBuilder = Component.text();
++
++        for (int i = 0, len = Math.min(lowestRegionsCount, list.size()); i < len; ++i) {
++            final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData>
++                pair = list.get(i);
++
++            final TickData.TickReportData report = pair.right();
++            final ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region =
++                pair.left();
++
++            if (report == null) {
++                // skip regions with no data
++                continue;
++            }
++
++            final ChunkPos chunkCenter = region.getCenterChunk();
++            if (chunkCenter == null) {
++                // region does not exist anymore
++                continue;
++            }
++            final int centerBlockX = ((chunkCenter.x() << 4) | 7);
++            final int centerBlockZ = ((chunkCenter.z() << 4) | 7);
++            final double util = report.utilisation();
++            final double tps = report.tpsData().segmentAll().average();
++            final double mspt = report.timePerTickData().segmentAll().average() / 1.0E6;
++            final boolean sprinting = region.getData().getRegionSchedulingHandle().getTickManager().isSprinting();
++
++            final int yLoc = 80;
++            final String location = "[w:'" + worldName + "'," + centerBlockX + "," + yLoc + "," + centerBlockZ + "]";
++            final Component line = Component.text()
++                .append(Component.text(" - ", LIST, TextDecoration.BOLD))
++                .append(Component.text("Region around block ", PRIMARY))
++                .append(Component.text(location, INFORMATION))
++                .append(Component.text(":\n", PRIMARY))
++
++                .append(Component.text("    ", PRIMARY))
++                .append(Component.text(ONE_DECIMAL_PLACES.get().format(util * 100.0), sprinting ? CommandUtil.SPRINTING_COLOR : CommandUtil.getUtilisationColourRegion(util))) // Canvas - region threading
++                .append(Component.text("% util at ", PRIMARY))
++                .append(Component.text(TWO_DECIMAL_PLACES.get().format(mspt), sprinting ? CommandUtil.SPRINTING_COLOR : CommandUtil.getColourForMSPT(mspt))) // Canvas - region threading
++                .append(Component.text(" MSPT at ", PRIMARY))
++                .append(Component.text(TWO_DECIMAL_PLACES.get().format(tps), sprinting ? CommandUtil.SPRINTING_COLOR : CommandUtil.getColourForTPS(tps))) // Canvas - region threading
++                .append(Component.text(" TPS\n", PRIMARY))
++
++                .append(Component.text("    ", PRIMARY))
++                .append(formatRegionStats(region.getData().getRegionStats(), (i + 1) != len))
++                .build()
++
++                .clickEvent(ClickEvent.clickEvent(ClickEvent.Action.RUN_COMMAND, "/minecraft:execute as @s in " + worldKey + " run tp " + centerBlockX + ".5 " + yLoc + " " + centerBlockZ + ".5"))
++                .hoverEvent(HoverEvent.hoverEvent(HoverEvent.Action.SHOW_TEXT, Component.text("Click to teleport to " + location, SECONDARY)));
++
++            worldRegionsBuilder.append(line);
++        }
++
++        return worldRegionsBuilder.build();
++    }
 +
 +    private static int sortPair(
 +        final ObjectObjectImmutablePair<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>, TickData.TickReportData> p1,


### PR DESCRIPTION
Prebuild the expanded `/tps` region details before registering the click callback so the callback does not retain live region data/list objects.

This avoids the callback manager keeping region/tick objects reachable longer than intended.