### PR TITLE
Add per category entity tick intervals

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -208,3 +208,20 @@
              csvOutput.writeRow(blockPos.getX(), blockPos.getY(), blockPos.getZ(), ticker.getType());
          }
      }
+
+@@ -1467,6 +_,13 @@
+         entity.setOldPosAndRot();
+         entity.tickCount++;
+         entity.totalEntityAge++; // Paper - age-like counter for all entities
++        // Canvas start - entity tick intervals
++        if (io.canvasmc.canvas.entity.EntityTickController.shouldSkipTick(entity)) {
++            entity.inactiveTick();
++            for (Entity passenger : entity.getPassengers()) {
++                this.tickPassenger(entity, passenger, false);
++            }
++            return;
++        }
++        // Canvas end - entity tick intervals
+         final boolean isActive = io.papermc.paper.entity.activation.ActivationRange.checkIfActive(entity); // Paper - EAR 2
+         if (isActive) { // Paper - EAR 2
+         entity.tick();

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -416,6 +416,31 @@ public class WorldConfig extends Part {
         }
 
         {
+            option("tickIntervals")
+                .docs(
+                    "Controls how often each entity category ticks. A value of 1 means every tick, 2 means every",
+                    "other tick, 3 means every third tick, etc. Higher values reduce CPU usage for large mob farms",
+                    "and entity-dense areas but may cause noticeable AI delays. Players always tick every tick."
+                );
+        }
+
+        public TickIntervals tickIntervals = new TickIntervals();
+        public static class TickIntervals extends Part {
+            {
+                option("monster").docs("Hostile mobs (zombies, skeletons, creepers, etc.)").greaterThan(0.0F);
+                option("creature").docs("Passive animals (sheep, cows, pigs, etc.)").greaterThan(0.0F);
+                option("ambient").docs("Ambient entities (bats)").greaterThan(0.0F);
+                option("waterCreature").docs("Water creatures (squid, dolphins, fish, axolotls)").greaterThan(0.0F);
+                option("misc").docs("Miscellaneous entities (minecarts, boats, item frames, etc.)").greaterThan(0.0F);
+            }
+            public int monster = 1;
+            public int creature = 1;
+            public int ambient = 1;
+            public int waterCreature = 1;
+            public int misc = 1;
+        }
+
+        {
             option("skeletonAimAccuracy").docs("Defines the inaccuracy of skeleton bow shots. 14 is Vanilla, higher is more inaccurate and lower is more accurate");
             option("villagers")
                 .docs(

--- a/canvas-server/src/sources/java/io/canvasmc/canvas/entity/EntityTickController.java
+++ b/canvas-server/src/sources/java/io/canvasmc/canvas/entity/EntityTickController.java
@@ -1,0 +1,35 @@
+package io.canvasmc.canvas.entity;
+
+import io.canvasmc.canvas.WorldConfig;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.MobCategory;
+import net.minecraft.world.entity.player.Player;
+
+public final class EntityTickController {
+
+    private EntityTickController() {
+    }
+
+    public static boolean shouldSkipTick(final Entity entity) {
+        if (entity instanceof Player) {
+            return false;
+        }
+        if (!(entity.level() instanceof ServerLevel level)) {
+            return false;
+        }
+        final WorldConfig.Entities.TickIntervals intervals = level.canvasConfig().entities.tickIntervals;
+        final int interval = resolveInterval(intervals, entity.getType().getCategory());
+        return interval > 1 && (entity.tickCount % interval != 0);
+    }
+
+    private static int resolveInterval(final WorldConfig.Entities.TickIntervals config, final MobCategory category) {
+        return switch (category) {
+            case MONSTER -> config.monster;
+            case CREATURE -> config.creature;
+            case AMBIENT -> config.ambient;
+            case WATER_CREATURE, WATER_AMBIENT, UNDERGROUND_WATER_CREATURE -> config.waterCreature;
+            case MISC -> config.misc;
+        };
+    }
+}


### PR DESCRIPTION
Each entity category monster creature ambient waterCreature misc can have a separate tick interval 1 means every tick default backward compatible Higher values reduce CPU in mob farms and dense areas Players always tick every tick