### PR TITLE
Improve command execution in region threading

### DIFF
--- a/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
@@ -1843,7 +1843,7 @@ index fb55ed68a1f8470b551030a27ca2656555c93d9e..5756f7aca1a80782a88b0e82ef82a626
      public @Nullable CustomBossEvent get(final Identifier id) {
          return this.events.get(id);
 diff --git a/net/minecraft/server/commands/AdvancementCommands.java b/net/minecraft/server/commands/AdvancementCommands.java
-index dfabf9b9870091087ab8b48634ecf9e2316b7f68..c72e69136b591947d0901d9f64b353706262520c 100644
+index dfabf9b9870091087ab8b48634ecf9e2316b7f68..ffdf3e49d9366e89940a043907b2d83ab62b22ba 100644
 --- a/net/minecraft/server/commands/AdvancementCommands.java
 +++ b/net/minecraft/server/commands/AdvancementCommands.java
 @@ -238,23 +238,38 @@ public class AdvancementCommands {
@@ -1874,8 +1874,8 @@ index dfabf9b9870091087ab8b48634ecf9e2316b7f68..c72e69136b591947d0901d9f64b35370
 +            .executes((ServerPlayer entityPlayer) -> {
 +                int changedAdvancements = action.perform(entityPlayer, advancements, showAdvancements);
 +                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.mapPairBoth(
-+                    (ac) -> ac + changedAdvancements,
-+                    (pc) -> changedAdvancements > 0 ? pc + 1 : pc
++                    (advancementCount) -> advancementCount + changedAdvancements,
++                    (playerCount) -> changedAdvancements > 0 ? playerCount + 1 : playerCount
 +                );
 +            })
 +            .onComplete((pair, _, css) -> performCallback(

--- a/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
@@ -2271,7 +2271,7 @@ index 1aead2cd0b8fa8e61ba4820ec116ec9e0a5c0bfe..2cca48a398f296bc193d35994ffcae4b
  
      private static Component getAttributeDescription(final Holder<Attribute> attribute) {
 diff --git a/net/minecraft/server/commands/BossBarCommands.java b/net/minecraft/server/commands/BossBarCommands.java
-index 5cbe5da7013faadc7d0e9eb03ff5738dc1afab17..3de09a5e689049cbb94268d257556bc2c7af39f9 100644
+index 5cbe5da7013faadc7d0e9eb03ff5738dc1afab17..89c7ca62c01d43e6899a57ee978e7a121d11140e 100644
 --- a/net/minecraft/server/commands/BossBarCommands.java
 +++ b/net/minecraft/server/commands/BossBarCommands.java
 @@ -176,16 +176,21 @@ public class BossBarCommands {
@@ -2416,7 +2416,7 @@ index 5cbe5da7013faadc7d0e9eb03ff5738dc1afab17..3de09a5e689049cbb94268d257556bc2
          CustomBossEvents events = source.getServer().getCustomBossEvents();
          if (events.get(id) != null) {
              throw ERROR_ALREADY_EXISTS.create(id.toString());
-@@ -333,17 +358,21 @@ public class BossBarCommands {
+@@ -333,14 +358,17 @@ public class BossBarCommands {
          );
          source.sendSuccess(() -> Component.translatable("commands.bossbar.create.success", event.getDisplayName()), true);
          return events.getEvents().size();
@@ -2434,10 +2434,6 @@ index 5cbe5da7013faadc7d0e9eb03ff5738dc1afab17..3de09a5e689049cbb94268d257556bc2
      }
  
      public static CustomBossEvent getBossBar(final CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
-+        io.papermc.paper.threadedregions.RegionizedServer.ensureGlobalTickThread("Cannot get bossbar async"); // Canvas - region threading
-         Identifier id = IdentifierArgument.getId(context, "id");
-         CustomBossEvent event = context.getSource().getServer().getCustomBossEvents().get(id);
-         if (event == null) {
 diff --git a/net/minecraft/server/commands/ClearInventoryCommands.java b/net/minecraft/server/commands/ClearInventoryCommands.java
 index dc68446fa7959848ad8d6497b8f5118d55e910a6..d5ddf780a45daaf27bdaf72b1bf20c35634e4c37 100644
 --- a/net/minecraft/server/commands/ClearInventoryCommands.java

--- a/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
@@ -212,7 +212,7 @@ index 0ce4643d526368b85ead19dd5d63aa41ec41afc6..8834c7fb6edff6c0a02231dd61e01620
          LOGGER.info("Halting chunk systems...");
          for (final ServerLevel world : MinecraftServer.getServer().getAllLevels()) {
 diff --git a/io/papermc/paper/threadedregions/RegionizedServer.java b/io/papermc/paper/threadedregions/RegionizedServer.java
-index 918d58644ac028a1025811ebd459112ff6a0e78f..be02125b9f01ee60df771f83aa91551f54755f57 100644
+index 918d58644ac028a1025811ebd459112ff6a0e78f..54baa6300da3209c912a0405e23492c86cf28254 100644
 --- a/io/papermc/paper/threadedregions/RegionizedServer.java
 +++ b/io/papermc/paper/threadedregions/RegionizedServer.java
 @@ -31,7 +31,7 @@ import java.util.function.BooleanSupplier;
@@ -272,11 +272,11 @@ index 918d58644ac028a1025811ebd459112ff6a0e78f..be02125b9f01ee60df771f83aa91551f
          // connection tick
 +        // ender pearls
 +        // gui tick
-+        // scoreboard
++        // scoreboard, stopwatches
  
          // tick player ping sample
          this.tickPlayerSample();
-@@ -362,6 +377,17 @@ public final class RegionizedServer {
+@@ -362,7 +377,63 @@ public final class RegionizedServer {
  
          // player list
          MinecraftServer.getServer().getPlayerList().tick();
@@ -288,13 +288,59 @@ index 918d58644ac028a1025811ebd459112ff6a0e78f..be02125b9f01ee60df771f83aa91551f
 +        // gui tick
 +        net.minecraft.server.gui.PlayerListComponent.tick();
 +
-+        // scoreboard
-+        MinecraftServer.getServer().getScoreboard().autosave();
++        // scoreboards, stopwatches
++        autosaveSafeGlobalData(false, false);
 +        // Canvas end - region threading
++    }
++    // Canvas start - region threading
++
++    private static final java.util.concurrent.atomic.AtomicLong LAST_GLOBAL_AUTOSAVE = new java.util.concurrent.atomic.AtomicLong(System.nanoTime());
++
++    // note: not everything is thread-safe, only a few things are thread-safe
++    //       due to specific design of these reimplementations. those are:
++    //  - scoreboards: from Canvas scoreboards rewrite
++    //  - stopwatches: we made this SWMR fully, and only the global tick can
++    //                 write to the backend map so this is safe to save here
++    // note: this does not save maps at all, those are per-world
++    public void autosaveSafeGlobalData(final boolean force, final boolean sync) {
++        ensureGlobalTickThread("Cannot save global data async");
++
++        final MinecraftServer server = MinecraftServer.getServer();
++
++        final int autoSavePeriod = server.autosavePeriod;
++        if (autoSavePeriod <= 0 && !force) return;
++        final long periodNanos = autoSavePeriod * io.papermc.paper.threadedregions.TickRegionScheduler.getTimeBetweenTicks();
++        final long currTime = System.nanoTime();
++        final long last = LAST_GLOBAL_AUTOSAVE.get();
++
++        if (force || ((currTime - last) > periodNanos && LAST_GLOBAL_AUTOSAVE.compareAndSet(last, currTime))) {
++
++            // these 2 are the only safe global data ones besides maps,
++            // however those are per-world and saved in world global tick
++
++            // we have to do this for the scoreboard system or else the scoreboard
++            // system won't actually save. see MinecraftServer#saveGlobalData
++
++            server.getScoreboard().storeToSaveDataIfDirty(server.getDataStorage().computeIfAbsent(net.minecraft.world.scores.ScoreboardSaveData.TYPE));
++
++            java.util.concurrent.CompletableFuture<?> future = server.getDataStorage().saveSpecific(
++                net.minecraft.world.scores.ScoreboardSaveData.class,
++                net.minecraft.world.Stopwatches.class
++            );
++
++            // if sync we need to just join here. this shouldn't be done
++            // for autosave or every tick since this blocks waiting for completion
++
++            if (sync) {
++                future.join();
++            }
++        }
      }
++    // Canvas end - region threading
  
      private void tickPlayerSample() {
-@@ -402,9 +428,14 @@ public final class RegionizedServer {
+         final MinecraftServer mcServer = MinecraftServer.getServer();
+@@ -402,9 +473,14 @@ public final class RegionizedServer {
              }
  
              if (isNotOwnedByGlobalRegion(conn)) {
@@ -312,7 +358,7 @@ index 918d58644ac028a1025811ebd459112ff6a0e78f..be02125b9f01ee60df771f83aa91551f
              }
  
              if (!conn.isConnected()) {
-@@ -435,6 +466,12 @@ public final class RegionizedServer {
+@@ -435,6 +511,12 @@ public final class RegionizedServer {
      // A global tick only updates things like weather / worldborder, basically anything in the world that is
      // NOT tied to a specific region, but rather shared amongst all of them.
      private void globalTick(final ServerLevel world, final long tickCount) {
@@ -325,7 +371,7 @@ index 918d58644ac028a1025811ebd459112ff6a0e78f..be02125b9f01ee60df771f83aa91551f
          // needs
          // worldborder tick
          // advancing the weather cycle
-@@ -480,6 +517,7 @@ public final class RegionizedServer {
+@@ -480,6 +562,7 @@ public final class RegionizedServer {
      }
  
      private void advanceWeatherCycle(final ServerLevel world) {
@@ -333,7 +379,7 @@ index 918d58644ac028a1025811ebd459112ff6a0e78f..be02125b9f01ee60df771f83aa91551f
          world.advanceWeatherCycle();
      }
  
-@@ -492,11 +530,13 @@ public final class RegionizedServer {
+@@ -492,11 +575,13 @@ public final class RegionizedServer {
      }
  
      private void tickClocks() {
@@ -347,7 +393,7 @@ index 918d58644ac028a1025811ebd459112ff6a0e78f..be02125b9f01ee60df771f83aa91551f
                  level.clockManager().tick();
              }
          }
-@@ -504,6 +544,7 @@ public final class RegionizedServer {
+@@ -504,6 +589,7 @@ public final class RegionizedServer {
      }
  
      private void tickTime(final ServerLevel world, final long tickCount) {
@@ -1607,10 +1653,10 @@ index f233c2fea9e2008f0c15aa80eb07cae3bb68b005..09146997c3d82b96224b392862926a0e
  
      public static CompletableFuture<ReloadableServerResources> loadResources(
 diff --git a/net/minecraft/server/ServerScoreboard.java b/net/minecraft/server/ServerScoreboard.java
-index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e769809a383 100644
+index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..a1b32f272a6f1df2e48fafc5bf99d445ab745232 100644
 --- a/net/minecraft/server/ServerScoreboard.java
 +++ b/net/minecraft/server/ServerScoreboard.java
-@@ -26,24 +26,45 @@ import org.jspecify.annotations.Nullable;
+@@ -26,24 +26,29 @@ import org.jspecify.annotations.Nullable;
  
  public class ServerScoreboard extends Scoreboard {
      private final MinecraftServer server;
@@ -1619,22 +1665,6 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
 +    // Canvas start - region threading
 +    private final Set<Objective> trackedObjectives = new java.util.concurrent.CopyOnWriteArraySet<>();
 +    private final java.util.concurrent.atomic.AtomicBoolean dirty = new java.util.concurrent.atomic.AtomicBoolean(false);
-+
-+    private static final java.util.concurrent.atomic.AtomicLong LAST_AUTOSAVE = new java.util.concurrent.atomic.AtomicLong(System.nanoTime());
-+
-+    public void autosave() {
-+        ensureMainThread("Cannot autosave async");
-+        // autosave every minute if dirty
-+        final int autoSavePeriod = MinecraftServer.getServer().autosavePeriod;
-+        if (autoSavePeriod <= 0) return;
-+        final long periodNanos = autoSavePeriod * io.papermc.paper.threadedregions.TickRegionScheduler.getTimeBetweenTicks();
-+        final long currTime = System.nanoTime();
-+        final long last = LAST_AUTOSAVE.get();
-+        if ((currTime - last) > periodNanos && LAST_AUTOSAVE.compareAndSet(last, currTime) && dirty.compareAndExchange(true, false)) {
-+            MinecraftServer.getServer().getDataStorage().computeIfAbsent(ScoreboardSaveData.TYPE).setData(this.store());
-+            MinecraftServer.getServer().getDataStorage().scheduleSave();
-+        }
-+    }
 +    // Canvas end - region threading
  
      public ServerScoreboard(final MinecraftServer server) {
@@ -1661,7 +1691,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          return new ScoreboardSaveData.Packed(this.packObjectives(), this.packPlayerScores(), this.packDisplaySlots(), this.packPlayerTeams());
      }
  
-@@ -90,6 +111,7 @@ public class ServerScoreboard extends Scoreboard {
+@@ -90,6 +95,7 @@ public class ServerScoreboard extends Scoreboard {
  
      @Override
      public void setDisplayObjective(final DisplaySlot slot, final @Nullable Objective objective) {
@@ -1669,7 +1699,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          Objective old = this.getDisplayObjective(slot);
          super.setDisplayObjective(slot, objective);
          if (old != objective && old != null) {
-@@ -163,12 +185,14 @@ public class ServerScoreboard extends Scoreboard {
+@@ -163,12 +169,14 @@ public class ServerScoreboard extends Scoreboard {
  
      @Override
      public void onObjectiveAdded(final Objective objective) {
@@ -1684,7 +1714,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          super.onObjectiveChanged(objective);
          if (this.trackedObjectives.contains(objective)) {
              this.broadcastAll(new ClientboundSetObjectivePacket(objective, ClientboundSetObjectivePacket.METHOD_CHANGE)); // CraftBukkit
-@@ -179,6 +203,7 @@ public class ServerScoreboard extends Scoreboard {
+@@ -179,6 +187,7 @@ public class ServerScoreboard extends Scoreboard {
  
      @Override
      public void onObjectiveRemoved(final Objective objective) {
@@ -1692,7 +1722,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          super.onObjectiveRemoved(objective);
          if (this.trackedObjectives.contains(objective)) {
              this.stopTrackingObjective(objective);
-@@ -189,6 +214,8 @@ public class ServerScoreboard extends Scoreboard {
+@@ -189,6 +198,8 @@ public class ServerScoreboard extends Scoreboard {
  
      @Override
      public void onTeamAdded(final PlayerTeam team) {
@@ -1701,7 +1731,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          super.onTeamAdded(team);
          this.broadcastAll(ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, true)); // CraftBukkit
          this.setDirty();
-@@ -196,6 +223,7 @@ public class ServerScoreboard extends Scoreboard {
+@@ -196,6 +207,7 @@ public class ServerScoreboard extends Scoreboard {
  
      @Override
      public void onTeamChanged(final PlayerTeam team) {
@@ -1709,7 +1739,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          super.onTeamChanged(team);
          this.broadcastAll(ClientboundSetPlayerTeamPacket.createAddOrModifyPacket(team, false)); // CraftBukkit
          this.updateTeamWaypoints(team);
-@@ -204,6 +232,8 @@ public class ServerScoreboard extends Scoreboard {
+@@ -204,6 +216,8 @@ public class ServerScoreboard extends Scoreboard {
  
      @Override
      public void onTeamRemoved(final PlayerTeam team) {
@@ -1718,7 +1748,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          super.onTeamRemoved(team);
          this.broadcastAll(ClientboundSetPlayerTeamPacket.createRemovePacket(team)); // CraftBukkit
          this.updateTeamWaypoints(team);
-@@ -211,12 +241,14 @@ public class ServerScoreboard extends Scoreboard {
+@@ -211,12 +225,14 @@ public class ServerScoreboard extends Scoreboard {
      }
  
      protected void setDirty() {
@@ -1736,7 +1766,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
              saveData.setData(this.store());
          }
      }
-@@ -269,6 +301,7 @@ public class ServerScoreboard extends Scoreboard {
+@@ -269,6 +285,7 @@ public class ServerScoreboard extends Scoreboard {
      }
  
      public void stopTrackingObjective(final Objective objective) {
@@ -1744,7 +1774,7 @@ index 7ffd683c42557052d7bfa963d87e68f4e8f62d6c..62806133f13e8938983018c8330e6e76
          List<Packet<?>> packets = this.getStopTrackingPackets(objective);
  
          for (ServerPlayer player : this.server.getPlayerList().getPlayers()) {
-@@ -293,19 +326,23 @@ public class ServerScoreboard extends Scoreboard {
+@@ -293,19 +310,23 @@ public class ServerScoreboard extends Scoreboard {
          return count;
      }
  
@@ -4223,59 +4253,95 @@ index 2f6c0784126e1ab22ca7e138452325ebc425001c..032e0bc99a703c8bd5789fffcd99d9ce
      }
  }
 diff --git a/net/minecraft/server/commands/SaveAllCommand.java b/net/minecraft/server/commands/SaveAllCommand.java
-index 299991905c24a7018f8ac60d0c16e56fa43cd710..abbb8f14a1acc05a647d6a18c23a3cc75bae72e8 100644
+index 299991905c24a7018f8ac60d0c16e56fa43cd710..4e05380b283c804ffe791ad0c44d302d75faf68c 100644
 --- a/net/minecraft/server/commands/SaveAllCommand.java
 +++ b/net/minecraft/server/commands/SaveAllCommand.java
-@@ -24,12 +24,49 @@ public class SaveAllCommand {
+@@ -24,12 +24,84 @@ public class SaveAllCommand {
      private static int saveAll(final CommandSourceStack source, final boolean flush) throws CommandSyntaxException {
          source.sendSuccess(() -> Component.translatable("commands.save.saving"), false);
          MinecraftServer server = source.getServer();
 -        boolean success = server.saveEverything(true, flush, true);
 -        if (!success) {
 -            throw ERROR_FAILED.create();
-+
-+        // Canvas start - region threading
-+        final java.util.concurrent.atomic.AtomicInteger regionCount = new java.util.concurrent.atomic.AtomicInteger();
-+        final java.util.concurrent.atomic.AtomicInteger totalCount = new java.util.concurrent.atomic.AtomicInteger();
-+        Runnable callback = () -> {
-+            if (regionCount.decrementAndGet() == 0 || totalCount.get() == 0) {
-+                source.sendSuccess(() -> Component.translatable("commands.save.success"), true);
-+            }
-+        };
-+        for (final net.minecraft.server.level.ServerLevel world : server.getAllLevels()) {
-+            world.regioniser.computeForAllRegions((region) -> {
-+                regionCount.getAndIncrement();
-+                totalCount.getAndIncrement();
-+                region.getData().canvas$saveAllTicket.propagate(
-+                    new io.canvasmc.canvas.util.ticket.SaveAllTicket(callback, (ex) -> {
-+                        source.sendFailure(Component.literal(ERROR_FAILED.create().getMessage()));
-+                        MinecraftServer.LOGGER.error(ERROR_FAILED.create().getMessage(), ex);
-+                    }, flush)
-+                );
-+            });
-         }
+-        }
  
 -        source.sendSuccess(() -> Component.translatable("commands.save.success"), true);
-+        // pearl save rewrite
-+        MinecraftServer.getServer().pearls.save((result) -> {
-+            if (result) {
-+                source.sendSuccess(() -> Component.literal("Saved pearl data"), true);
-+            } else {
-+                source.sendFailure(Component.literal("Failed to save pearl data, check console for details"));
++        // Canvas start - region threading
++
++        // we are going to order this in a chain-like fashion:
++        // - global data
++        // - pearls
++        // - regions
++
++        // scoreboards, stopwatches, maps
++        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
++            // by setting the last map autosave to 0 we can just force an autosave to occur
++            for (final net.minecraft.server.level.ServerLevel world : io.papermc.paper.threadedregions.RegionizedServer.getInstance().worlds) {
++                world.lastMapAutoSave = 0;
++            }
++
++            // as for scoreboards and stopwatches, those can only be written to on the global tick
++            // meaning we need to pack/save on the global tick too, but we can't save everything
++            // because not everything is infact thread-safe, so we force a global data autosave
++
++            io.papermc.paper.threadedregions.RegionizedServer.getInstance().autosaveSafeGlobalData(true, true);
++            source.sendSuccess(() -> Component.literal("Saved global data"), true);
++
++            // pearl save rewrite
++            MinecraftServer.getServer().pearls.save((result) -> {
++                if (result) {
++                    source.sendSuccess(() -> Component.literal("Saved pearl data"), true);
++                }
++                else {
++                    source.sendFailure(Component.literal("Failed to save pearl data, check console for details"));
++                }
++            }).join(); // synchronize this
++
++            // regions next
++            final java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(0);
++            final java.util.concurrent.atomic.AtomicInteger total = new java.util.concurrent.atomic.AtomicInteger(0);
++            final Runnable callback = () -> {
++                if (count.decrementAndGet() <= 0) {
++                    source.sendSuccess(() -> Component.translatable("commands.save.success"), true);
++                }
++            };
++
++            for (final net.minecraft.server.level.ServerLevel level : server.getAllLevels()) {
++                level.regioniser.computeForAllRegions((region) -> {
++
++                    // if has no alive sections, this region is basically dead
++                    // so we have no reason to actually save this
++
++                    // note: we are holding the read lock in this, so technically
++                    //       we can assume the region data is safe and won't change
++                    //       while we are iterating over regions in this world
++
++                    if (region.hasNoAliveSections() || region.isDead()) {
++                        return;
++                    }
++
++                    // increment counts
++                    count.incrementAndGet();
++                    total.incrementAndGet();
++
++                    // propagate the ticket
++                    region.getData().canvas$saveAllTicket.propagate(
++                        new io.canvasmc.canvas.util.ticket.SaveAllTicket(callback, (ex) -> {
++                            source.sendFailure(Component.literal(ERROR_FAILED.create().getMessage()));
++                            MinecraftServer.LOGGER.error(ERROR_FAILED.create().getMessage(), ex);
++                        }, flush)
++                    );
++                });
++            }
++
++            if (total.get() == 0) {
++                source.sendSuccess(() -> Component.literal("No regions to save"), true);
++                callback.run();
++            }
++            else {
++                source.sendSuccess(() -> Component.literal("Saving " + total.get() + " regions"), true);
 +            }
 +        });
-+
-+        // scoreboards
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            // TODO - run full autosave
-+            MinecraftServer.getServer().getScoreboard().storeToSaveDataIfDirty(
-+                MinecraftServer.getServer().getDataStorage().computeIfAbsent(net.minecraft.world.scores.ScoreboardSaveData.TYPE)
-+            );
-+        });
-+
-+        // if no regions loaded, run callback
-+        source.sendSuccess(() -> Component.literal("Saving " + totalCount.get() + " regions"), true);
-+        if (totalCount.get() == 0) callback.run();
 +        // Canvas end - region threading
          return Command.SINGLE_SUCCESS;
      }
@@ -8815,6 +8881,63 @@ index eb52accfdd16a07b2e59a2e65c1007e8920aea36..18c5121d24268cfa5fa7ed22b1dce93a
  
      public void postProcessGeneration(final ServerLevel level) {
          ChunkPos chunkPos = this.getPos();
+diff --git a/net/minecraft/world/level/storage/SavedDataStorage.java b/net/minecraft/world/level/storage/SavedDataStorage.java
+index 81c1541d8fa272e84316e87c3418ee727111a65c..0b99cf09d3abeb06ea4f653b63a96185c069eab6 100644
+--- a/net/minecraft/world/level/storage/SavedDataStorage.java
++++ b/net/minecraft/world/level/storage/SavedDataStorage.java
+@@ -216,6 +216,52 @@ public class SavedDataStorage implements AutoCloseable {
+         }
+     }
+     // Folia end - region threading
++    // Canvas start - region threading
++
++    @SafeVarargs
++    public final CompletableFuture<?> saveSpecific(final Class<? extends SavedData>... classTypes) {
++        Map<SavedDataType<?>, CompoundTag> savedData = new HashMap<>();
++        RegistryOps<Tag> registryOps = this.registries.createSerializationContext(NbtOps.INSTANCE);
++        for (Map.Entry<SavedDataType<?>, Optional<SavedData>> entry : this.cache.entrySet()) {
++            SavedDataType<?> key = entry.getKey();
++            SavedData state = entry.getValue().orElse(null);
++
++            if (state == null || !state.isDirty()) {
++                continue;
++            }
++
++            // check if the type passes, since we only want specific data to pass through
++            // similar to how Folia does the saveMaps function
++
++            boolean pass = false;
++            for (final Class<? extends SavedData> classType : classTypes) {
++                if (classType.isInstance(state)) {
++                    pass = true;
++                    break;
++                }
++            }
++            if (!pass) {
++                continue;
++            }
++
++            state.setDirty(false);
++
++            savedData.put(key, this.encodeUnchecked(key, state, registryOps));
++        }
++
++        if (savedData.isEmpty()) {
++            return CompletableFuture.completedFuture(null);
++        } else {
++            this.pendingWriteFuture = this.pendingWriteFuture
++                .thenCompose(
++                    v -> CompletableFuture.allOf(
++                        savedData.entrySet().stream().map(entry -> CompletableFuture.runAsync(() -> tryWrite(entry.getKey(), entry.getValue()), Util.DIMENSION_DATA_IO_POOL)).toArray(CompletableFuture[]::new)
++                    )
++                );
++            return this.pendingWriteFuture;
++        }
++    }
++    // Canvas end - region threading
+ 
+     public CompletableFuture<?> scheduleSave() {
+         if (this.closed) {
 diff --git a/net/minecraft/world/scores/Objective.java b/net/minecraft/world/scores/Objective.java
 index 64ea4741b7ed58fe7914b9431353abd1f658a935..d4ddbdf895e19cf15929bc6ba4ea2258ab92d0da 100644
 --- a/net/minecraft/world/scores/Objective.java

--- a/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
+++ b/canvas-server/minecraft-patches/base/0004-Fixup-Region-Threading.patch
@@ -1290,7 +1290,7 @@ index 1e82bc45ce3c285360da5dad2c488db24422371f..6cddf70a1d4e7639deff3753eb875339
  
      public static ServerPlayer getPlayer(final String name) {
 diff --git a/net/minecraft/commands/Commands.java b/net/minecraft/commands/Commands.java
-index 585dcf881008e28aba077092943d4cbf4eb5f5b4..1307beab98cd028ac8087aa32aa499fb920cc5e7 100644
+index 585dcf881008e28aba077092943d4cbf4eb5f5b4..8f56122af431b8ed03f43da146c027b7d9e62ec6 100644
 --- a/net/minecraft/commands/Commands.java
 +++ b/net/minecraft/commands/Commands.java
 @@ -196,15 +196,15 @@ public class Commands {
@@ -1343,7 +1343,7 @@ index 585dcf881008e28aba077092943d4cbf4eb5f5b4..1307beab98cd028ac8087aa32aa499fb
 -        //TagCommand.register(this.dispatcher); // Folia - region threading - TODO later
 -        //TeamCommand.register(this.dispatcher, context); // Folia - region threading - TODO later
 -        //TeamMsgCommand.register(this.dispatcher); // Folia - region threading - TODO later
-+        TagCommand.register(this.dispatcher); // Canvas - TODO - do better
++        TagCommand.register(this.dispatcher);
 +        TeamCommand.register(this.dispatcher, context);
 +        TeamMsgCommand.register(this.dispatcher);
          TeleportCommand.register(this.dispatcher);
@@ -1812,8 +1812,643 @@ index fb55ed68a1f8470b551030a27ca2656555c93d9e..5756f7aca1a80782a88b0e82ef82a626
  
      public @Nullable CustomBossEvent get(final Identifier id) {
          return this.events.get(id);
+diff --git a/net/minecraft/server/commands/AdvancementCommands.java b/net/minecraft/server/commands/AdvancementCommands.java
+index dfabf9b9870091087ab8b48634ecf9e2316b7f68..c72e69136b591947d0901d9f64b353706262520c 100644
+--- a/net/minecraft/server/commands/AdvancementCommands.java
++++ b/net/minecraft/server/commands/AdvancementCommands.java
+@@ -238,23 +238,38 @@ public class AdvancementCommands {
+         final Collection<AdvancementHolder> advancements,
+         final boolean showAdvancements
+     ) throws CommandSyntaxException {
+-        int advancementCount = 0;
+-        int playerCount = 0;
+-
+-        for (ServerPlayer player : players) {
+-            // Folia start - region threading
+-            int changedAdvancements = 1;
+-            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> {
+-                action.perform(newPlayer, advancements, showAdvancements);
+-            });
+-            // Folia end - region threading
+-            if (changedAdvancements > 0) {
+-                playerCount++;
+-            }
+-
+-            advancementCount += changedAdvancements;
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.
++                <io.canvasmc.canvas.command.execution.ExecutionCallbacks.NumericPair<Integer, Integer>, ServerPlayer>
++                _abstract(new io.canvasmc.canvas.command.execution.ExecutionCallbacks.NumericPair<>(0, 0))
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                int changedAdvancements = action.perform(entityPlayer, advancements, showAdvancements);
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.mapPairBoth(
++                    (ac) -> ac + changedAdvancements,
++                    (pc) -> changedAdvancements > 0 ? pc + 1 : pc
++                );
++            })
++            .onComplete((pair, _, css) -> performCallback(
++                pair.first(), pair.second(),
++                css,
++                players,
++                action,
++                advancements
++            ))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int performCallback(
++        final int advancementCount,
++        final int playerCount,
++        final CommandSourceStack source,
++        final Collection<ServerPlayer> players,
++        final AdvancementCommands.Action action,
++        final Collection<AdvancementHolder> advancements
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (advancementCount == 0) {
+             if (advancements.size() == 1) {
+                 Component advancementName = Advancement.name(Iterables.getOnlyElement(advancements));
+@@ -312,23 +327,40 @@ public class AdvancementCommands {
+         final AdvancementHolder holder,
+         final String criterion
+     ) throws CommandSyntaxException {
+-        int playerCount = 0;
++        // Canvas - region threading
+         Advancement advancement = holder.value();
+         if (!advancement.criteria().containsKey(criterion)) {
+             throw ERROR_CRITERION_NOT_FOUND.create(Advancement.name(holder), criterion);
+         }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                if (action.performCriterion(entityPlayer, holder, criterion)) {
++                    return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((playerCount, _, css) -> criterionCallback(
++                playerCount, css,
++                players,
++                action,
++                holder,
++                criterion
++            ))
++            .start(source);
++        return 1;
++    }
+ 
+-        for (ServerPlayer player : players) {
+-            // Folia start - region threading
+-            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> {
+-                action.performCriterion(newPlayer, holder, criterion);
+-            });
+-            if (true) {
+-            // Folia end - region threading
+-                playerCount++;
+-            }
+-        }
+-
++    private static int criterionCallback(
++        final int playerCount,
++        final CommandSourceStack source,
++        final Collection<ServerPlayer> players,
++        final AdvancementCommands.Action action,
++        final AdvancementHolder holder,
++        final String criterion
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (playerCount == 0) {
+             if (players.size() == 1) {
+                 throw ERROR_NO_ACTION_PERFORMED.create(
+diff --git a/net/minecraft/server/commands/AttributeCommand.java b/net/minecraft/server/commands/AttributeCommand.java
+index 1aead2cd0b8fa8e61ba4820ec116ec9e0a5c0bfe..2cca48a398f296bc193d35994ffcae4b25406ea4 100644
+--- a/net/minecraft/server/commands/AttributeCommand.java
++++ b/net/minecraft/server/commands/AttributeCommand.java
+@@ -257,80 +257,72 @@ public class AttributeCommand {
+         }
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
++    // Canvas - region threading
+     private static int getAttributeValue(final CommandSourceStack source, final Entity target, final Holder<Attribute> attribute, final double scale) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newTarget) -> {
+-            try {
+-                // Folia end - region threading
+-        LivingEntity livingEntity = getEntityWithAttribute(newTarget, attribute); // Folia - region threading
+-        double result = livingEntity.getAttributeValue(attribute);
+-        source.sendSuccess(
+-            () -> Component.translatable("commands.attribute.value.get.success", getAttributeDescription(attribute), newTarget.getName(), result), false // Folia - region threading
+-        );
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._double()
++            .with(target)
++            .executes((Entity entity) -> {
++                LivingEntity livingEntity = getEntityWithAttribute(entity, attribute);
++                return (_) -> livingEntity.getAttributeValue(attribute);
++            })
++            .onComplete((result, targets, css) -> {
++                css.sendSuccess(
++                    () -> Component.translatable("commands.attribute.value.get.success", getAttributeDescription(attribute), targets.getFirst().getName(), result), false
++                );
++                return (int)(result * scale);
++            })
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++        // Canvas end - region threading
+     }
+ 
+     private static int getAttributeBase(final CommandSourceStack source, final Entity target, final Holder<Attribute> attribute, final double scale) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newTarget) -> {
+-            try {
+-                // Folia end - region threading
+-        LivingEntity livingEntity = getEntityWithAttribute(newTarget, attribute); // Folia - region threading
+-        double result = livingEntity.getAttributeBaseValue(attribute);
+-        source.sendSuccess(
+-            () -> Component.translatable("commands.attribute.base_value.get.success", getAttributeDescription(attribute), newTarget.getName(), result), false // Folia - region threading
+-        );
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._double()
++            .with(target)
++            .executes((Entity entity) -> {
++                LivingEntity livingEntity = getEntityWithAttribute(entity, attribute);
++                return (_) -> livingEntity.getAttributeBaseValue(attribute);
++            })
++            .onComplete((result, targets, css) -> {
++                css.sendSuccess(
++                    () -> Component.translatable("commands.attribute.base_value.get.success", getAttributeDescription(attribute), targets.getFirst().getName(), result), false
++                );
++                return (int)(result * scale);
++            })
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++        // Canvas end - region threading
+     }
+ 
+     private static int getAttributeModifier(
+         final CommandSourceStack source, final Entity target, final Holder<Attribute> attribute, final Identifier id, final double scale
+     ) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newTarget) -> {
+-            try {
+-                // Folia end - region threading
+-        LivingEntity livingEntity = getEntityWithAttribute(newTarget, attribute); // Folia - region threading
+-        AttributeMap attributes = livingEntity.getAttributes();
+-        if (!attributes.hasModifier(attribute, id)) {
+-            throw ERROR_NO_SUCH_MODIFIER.create(newTarget.getName(), getAttributeDescription(attribute), id); // Folia - region threading
+-        }
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._double()
++            .with(target)
++            .executes((Entity entity) -> {
++                LivingEntity livingEntity = getEntityWithAttribute(entity, attribute);
++                AttributeMap attributes = livingEntity.getAttributes();
++                if (!attributes.hasModifier(attribute, id)) {
++                    throw ERROR_NO_SUCH_MODIFIER.create(entity.getName(), getAttributeDescription(attribute), id);
++                }
+ 
+-        double result = attributes.getModifierValue(attribute, id);
+-        source.sendSuccess(
+-            () -> Component.translatable(
+-                "commands.attribute.modifier.value.get.success", Component.translationArg(id), getAttributeDescription(attribute), newTarget.getName(), result // Folia - region threading
+-            ),
+-            false
+-        );
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++                return (_) -> attributes.getModifierValue(attribute, id);
++            })
++            .onComplete((result, targets, css) -> {
++                css.sendSuccess(
++                    () -> Component.translatable(
++                        "commands.attribute.modifier.value.get.success", Component.translationArg(id), getAttributeDescription(attribute), targets.getFirst().getName(), result
++                    ),
++                    false
++                );
++                return (int)(result * scale);
++            })
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++        // Canvas end - region threading
+     }
+ 
+     private static Stream<Identifier> getAttributeModifiers(final Entity target, final Holder<Attribute> attribute) throws CommandSyntaxException {
+@@ -339,34 +331,44 @@ public class AttributeCommand {
+     }
+ 
+     private static int setAttributeBase(final CommandSourceStack source, final Entity target, final Holder<Attribute> attribute, final double value) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newTarget) -> {
+-            try {
+-                // Folia end - region threading
+-        getAttributeInstance(newTarget, attribute).setBaseValue(value); // Folia - region threading
+-        source.sendSuccess(
+-            () -> Component.translatable("commands.attribute.base_value.set.success", getAttributeDescription(attribute), newTarget.getName(), value), false // Folia - region threading
+-        );
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(target)
++            .executes((Entity entity) -> {
++                getAttributeInstance(entity, attribute).setBaseValue(value);
++                return (_) -> null;
++            })
++            .onComplete((_, targets, css) -> {
++                css.sendSuccess(
++                    () -> Component.translatable("commands.attribute.base_value.set.success", getAttributeDescription(attribute), targets.getFirst().getName(), value), false
++                );
++                return Command.SINGLE_SUCCESS;
++            })
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++        // Canvas end - region threading
+     }
+ 
+     private static int resetAttributeBase(final CommandSourceStack source, final Entity target, final Holder<Attribute> attribute) throws CommandSyntaxException {
+-        LivingEntity livingTarget = getLivingEntity(target);
+-        if (!livingTarget.getAttributes().resetBaseValue(attribute)) {
+-            throw ERROR_NO_SUCH_ATTRIBUTE.create(target.getName(), getAttributeDescription(attribute));
+-        }
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._double()
++            .with(target)
++            .executes((Entity entity) -> {
++                LivingEntity livingTarget = getLivingEntity(entity);
++                if (!livingTarget.getAttributes().resetBaseValue(attribute)) {
++                    throw ERROR_NO_SUCH_ATTRIBUTE.create(entity.getName(), getAttributeDescription(attribute));
++                }
+ 
+-        double value = livingTarget.getAttributeBaseValue(attribute);
+-        source.sendSuccess(
+-            () -> Component.translatable("commands.attribute.base_value.reset.success", getAttributeDescription(attribute), target.getName(), value), false
+-        );
++                return (_) -> livingTarget.getAttributeBaseValue(attribute);
++            })
++            .onComplete((value, targets, css) -> {
++                css.sendSuccess(
++                    () -> Component.translatable("commands.attribute.base_value.reset.success", getAttributeDescription(attribute), targets.getFirst().getName(), value), false
++                );
++                return Command.SINGLE_SUCCESS;
++            })
++            .start(source);
++        // Canvas end - region threading
+         return Command.SINGLE_SUCCESS;
+     }
+ 
+@@ -378,57 +380,58 @@ public class AttributeCommand {
+         final double value,
+         final AttributeModifier.Operation operation
+     ) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newTarget) -> {
+-            try {
+-                // Folia end - region threading
+-        AttributeInstance attributeInstance = getAttributeInstance(newTarget, attribute); // Folia - region threading
+-        AttributeModifier modifier = new AttributeModifier(id, value, operation);
+-        if (attributeInstance.hasModifier(id)) {
+-            throw ERROR_MODIFIER_ALREADY_PRESENT.create(newTarget.getName(), getAttributeDescription(attribute), id); // Folia - region threading
+-        }
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(target)
++            .executes((Entity entity) -> {
++                AttributeInstance attributeInstance = getAttributeInstance(entity, attribute);
++                AttributeModifier modifier = new AttributeModifier(id, value, operation);
++                if (attributeInstance.hasModifier(id)) {
++                    throw ERROR_MODIFIER_ALREADY_PRESENT.create(entity.getName(), getAttributeDescription(attribute), id);
++                }
+ 
+-        attributeInstance.addPermanentModifier(modifier);
+-        source.sendSuccess(
+-            () -> Component.translatable(
+-                "commands.attribute.modifier.add.success", Component.translationArg(id), getAttributeDescription(attribute), newTarget.getName() // Folia - region threading
+-            ),
+-            false
+-        );
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++                attributeInstance.addPermanentModifier(modifier);
++                return (_) -> null;
++            })
++            .onComplete((_, targets, css) -> {
++                css.sendSuccess(
++                    () -> Component.translatable(
++                        "commands.attribute.modifier.add.success", Component.translationArg(id), getAttributeDescription(attribute), targets.getFirst().getName()
++                    ),
++                    false
++                );
++                return Command.SINGLE_SUCCESS;
++            })
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++        // Canvas end - region threading
+     }
+ 
+     private static int removeModifier(final CommandSourceStack source, final Entity target, final Holder<Attribute> attribute, final Identifier id) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newTarget) -> {
+-            try {
+-                // Folia end - region threading
+-        AttributeInstance attributeInstance = getAttributeInstance(newTarget, attribute); // Folia - region threading
+-        if (attributeInstance.removeModifier(id)) {
+-            source.sendSuccess(
+-                () -> Component.translatable(
+-                    "commands.attribute.modifier.remove.success", Component.translationArg(id), getAttributeDescription(attribute), newTarget.getName() // Folia - region threading
+-                ),
+-                false
+-            );
+-            return; // Folia - region threading
+-        } else {
+-            throw ERROR_NO_SUCH_MODIFIER.create(newTarget.getName(), getAttributeDescription(attribute), id); // Folia - region threading
+-        }
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._boolean(false)
++            .with(target)
++            .executes((Entity entity) -> {
++                AttributeInstance attributeInstance = getAttributeInstance(entity, attribute);
++                boolean pass = attributeInstance.removeModifier(id);
++                return (_) -> pass;
++            })
++            .onComplete((pass, targets, css) -> {
++                Entity entity = targets.getFirst();
++                if (!pass) {
++                    throw ERROR_NO_SUCH_MODIFIER.create(entity.getName(), getAttributeDescription(attribute), id);
++                }
++                css.sendSuccess(
++                    () -> Component.translatable(
++                        "commands.attribute.modifier.remove.success", Component.translationArg(id), getAttributeDescription(attribute), entity.getName()
++                    ),
++                    false
++                );
++                return Command.SINGLE_SUCCESS;
++            })
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++        // Canvas end - region threading
+     }
+ 
+     private static Component getAttributeDescription(final Holder<Attribute> attribute) {
+diff --git a/net/minecraft/server/commands/BossBarCommands.java b/net/minecraft/server/commands/BossBarCommands.java
+index 5cbe5da7013faadc7d0e9eb03ff5738dc1afab17..3de09a5e689049cbb94268d257556bc2c7af39f9 100644
+--- a/net/minecraft/server/commands/BossBarCommands.java
++++ b/net/minecraft/server/commands/BossBarCommands.java
+@@ -176,16 +176,21 @@ public class BossBarCommands {
+     }
+ 
+     private static int getValue(final CommandSourceStack source, final CustomBossEvent bossBar) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.get.value", bossBar.getDisplayName(), bossBar.value()), true);
+         return bossBar.value();
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int getMax(final CommandSourceStack source, final CustomBossEvent bossBar) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.get.max", bossBar.getDisplayName(), bossBar.max()), true);
+         return bossBar.max();
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int getVisible(final CommandSourceStack source, final CustomBossEvent bossBar) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         if (bossBar.isVisible()) {
+             source.sendSuccess(() -> Component.translatable("commands.bossbar.get.visible.visible", bossBar.getDisplayName()), true);
+             return 1;
+@@ -193,9 +198,11 @@ public class BossBarCommands {
+             source.sendSuccess(() -> Component.translatable("commands.bossbar.get.visible.hidden", bossBar.getDisplayName()), true);
+             return 0;
+         }
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int getPlayers(final CommandSourceStack source, final CustomBossEvent bossBar) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         if (bossBar.getPlayers().isEmpty()) {
+             source.sendSuccess(() -> Component.translatable("commands.bossbar.get.players.none", bossBar.getDisplayName()), true);
+         } else {
+@@ -211,9 +218,11 @@ public class BossBarCommands {
+         }
+ 
+         return bossBar.getPlayers().size();
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setVisible(final CommandSourceStack source, final CustomBossEvent bossBar, final boolean visible) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         if (bossBar.isVisible() == visible) {
+             if (visible) {
+                 throw ERROR_ALREADY_VISIBLE.create();
+@@ -230,9 +239,11 @@ public class BossBarCommands {
+ 
+             return 0;
+         }
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setValue(final CommandSourceStack source, final CustomBossEvent bossBar, final int value) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         if (bossBar.value() == value) {
+             throw ERROR_NO_VALUE_CHANGE.create();
+         }
+@@ -240,9 +251,11 @@ public class BossBarCommands {
+         bossBar.setValue(value);
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.set.value.success", bossBar.getDisplayName(), value), true);
+         return value;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setMax(final CommandSourceStack source, final CustomBossEvent bossBar, final int value) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         if (bossBar.max() == value) {
+             throw ERROR_NO_MAX_CHANGE.create();
+         }
+@@ -250,9 +263,11 @@ public class BossBarCommands {
+         bossBar.setMax(value);
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.set.max.success", bossBar.getDisplayName(), value), true);
+         return value;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setColor(final CommandSourceStack source, final CustomBossEvent bossBar, final BossEvent.BossBarColor color) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         if (bossBar.getColor().equals(color)) {
+             throw ERROR_NO_COLOR_CHANGE.create();
+         }
+@@ -260,9 +275,11 @@ public class BossBarCommands {
+         bossBar.setColor(color);
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.set.color.success", bossBar.getDisplayName()), true);
+         return 0;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setStyle(final CommandSourceStack source, final CustomBossEvent bossBar, final BossEvent.BossBarOverlay style) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         if (bossBar.getOverlay().equals(style)) {
+             throw ERROR_NO_STYLE_CHANGE.create();
+         }
+@@ -270,9 +287,11 @@ public class BossBarCommands {
+         bossBar.setOverlay(style);
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.set.style.success", bossBar.getDisplayName()), true);
+         return 0;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setName(final CommandSourceStack source, final CustomBossEvent bossBar, final Component name) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         Component replaced = ComponentUtils.resolve(ResolutionContext.builder().withSource(source).withEntityOverride(null).build(), name);
+         if (bossBar.getName().equals(replaced)) {
+             throw ERROR_NO_NAME_CHANGE.create();
+@@ -281,9 +300,11 @@ public class BossBarCommands {
+         bossBar.setName(replaced);
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.set.name.success", bossBar.getDisplayName()), true);
+         return 0;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setPlayers(final CommandSourceStack source, final CustomBossEvent bossBar, final Collection<ServerPlayer> targets) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         boolean changed = bossBar.setPlayers(targets);
+         if (!changed) {
+             throw ERROR_NO_PLAYER_CHANGE.create();
+@@ -304,9 +325,11 @@ public class BossBarCommands {
+         }
+ 
+         return bossBar.getPlayers().size();
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int listBars(final CommandSourceStack source) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         Collection<CustomBossEvent> events = source.getServer().getCustomBossEvents().getEvents();
+         if (events.isEmpty()) {
+             source.sendSuccess(() -> Component.translatable("commands.bossbar.list.bars.none"), false);
+@@ -320,9 +343,11 @@ public class BossBarCommands {
+         }
+ 
+         return events.size();
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int createBar(final CommandSourceStack source, final Identifier id, final Component name) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         CustomBossEvents events = source.getServer().getCustomBossEvents();
+         if (events.get(id) != null) {
+             throw ERROR_ALREADY_EXISTS.create(id.toString());
+@@ -333,17 +358,21 @@ public class BossBarCommands {
+         );
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.create.success", event.getDisplayName()), true);
+         return events.getEvents().size();
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int removeBar(final CommandSourceStack source, final CustomBossEvent bossBar) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         CustomBossEvents events = source.getServer().getCustomBossEvents();
+         bossBar.removeAllPlayers();
+         events.remove(bossBar);
+         source.sendSuccess(() -> Component.translatable("commands.bossbar.remove.success", bossBar.getDisplayName()), true);
+         return events.getEvents().size();
++        }, source); // Canvas - region threading
+     }
+ 
+     public static CustomBossEvent getBossBar(final CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
++        io.papermc.paper.threadedregions.RegionizedServer.ensureGlobalTickThread("Cannot get bossbar async"); // Canvas - region threading
+         Identifier id = IdentifierArgument.getId(context, "id");
+         CustomBossEvent event = context.getSource().getServer().getCustomBossEvents().get(id);
+         if (event == null) {
+diff --git a/net/minecraft/server/commands/ClearInventoryCommands.java b/net/minecraft/server/commands/ClearInventoryCommands.java
+index dc68446fa7959848ad8d6497b8f5118d55e910a6..d5ddf780a45daaf27bdaf72b1bf20c35634e4c37 100644
+--- a/net/minecraft/server/commands/ClearInventoryCommands.java
++++ b/net/minecraft/server/commands/ClearInventoryCommands.java
+@@ -62,19 +62,22 @@ public class ClearInventoryCommands {
+     private static int clearInventory(
+         final CommandSourceStack source, final Collection<ServerPlayer> players, final Predicate<ItemStack> predicate, final int maxCount
+     ) throws CommandSyntaxException {
+-        int count = 0;
+-
+-        for (ServerPlayer player : players) {
+-            // Folia start - region threading
+-            ++count;
+-            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> {
+-                newPlayer.getInventory().clearOrCountMatchingItems(predicate, maxCount, newPlayer.inventoryMenu.getCraftSlots());
+-                newPlayer.containerMenu.broadcastChanges();
+-                newPlayer.inventoryMenu.slotsChanged(newPlayer.getInventory());
+-            });
+-            // Folia end - region threading
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                int count = entityPlayer.getInventory().clearOrCountMatchingItems(predicate, maxCount, entityPlayer.inventoryMenu.getCraftSlots());
++                entityPlayer.containerMenu.broadcastChanges();
++                entityPlayer.inventoryMenu.slotsChanged(entityPlayer.getInventory());
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(count);
++            })
++            .onComplete((count, _, css) -> callback(count, players, maxCount, css))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int callback(final int count, final Collection<ServerPlayer> players, final int maxCount, final CommandSourceStack source) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (count == 0) {
+             if (players.size() == 1) {
+                 throw ERROR_SINGLE.create(players.iterator().next().getName());
 diff --git a/net/minecraft/server/commands/CloneCommands.java b/net/minecraft/server/commands/CloneCommands.java
-index 50d671bc5a8860883239590c030881043c791ca1..92f1416b3994e7f1334bdf41f8c00f619288e92d 100644
+index 50d671bc5a8860883239590c030881043c791ca1..c8ef526593ee12edbf2fa91a1bccf976003fcabb 100644
 --- a/net/minecraft/server/commands/CloneCommands.java
 +++ b/net/minecraft/server/commands/CloneCommands.java
 @@ -163,6 +163,70 @@ public class CloneCommands {
@@ -1887,7 +2522,7 @@ index 50d671bc5a8860883239590c030881043c791ca1..92f1416b3994e7f1334bdf41f8c00f61
  
      private static int clone(
          final CommandSourceStack source,
-@@ -199,6 +263,168 @@ public class CloneCommands {
+@@ -199,6 +263,176 @@ public class CloneCommands {
              throw ERROR_FAILED.create();
          }
  
@@ -1899,9 +2534,14 @@ index 50d671bc5a8860883239590c030881043c791ca1..92f1416b3994e7f1334bdf41f8c00f61
 +
 +            // we need to schedule to "from" first to collect our snapshot
 +
++            // physics can spill into neighbor chunks, so we add a buffer for precaution
++            final int buffer = 32;
++
 +            fromDimension.canvas$loadOrRunAtChunksAsync(
-+                // min/max x, min/max z
-+                from.minX() >> 4, from.maxX() >> 4, from.minZ() >> 4, from.maxZ() >> 4,
++                (from.minX() - buffer) >> 4,
++                (from.maxX() + buffer) >> 4,
++                (from.minZ() - buffer) >> 4,
++                (from.maxZ() + buffer) >> 4,
 +                ca.spottedleaf.concurrentutil.util.Priority.NORMAL, () -> {
 +
 +                    // we need to collect the blocks in this area now and copy-paste
@@ -1962,7 +2602,10 @@ index 50d671bc5a8860883239590c030881043c791ca1..92f1416b3994e7f1334bdf41f8c00f61
 +                        // we have finished our work in the source dimension, now we move to the destination
 +
 +                        toDimension.canvas$loadOrRunAtChunksAsync(
-+                            destination.minX() >> 4, destination.maxX() >> 4, destination.minZ() >> 4, destination.maxZ() >> 4,
++                            (destination.minX() - buffer) >> 4,
++                            (destination.maxX() + buffer) >> 4,
++                            (destination.minZ() - buffer) >> 4,
++                            (destination.maxZ() + buffer) >> 4,
 +                            ca.spottedleaf.concurrentutil.util.Priority.NORMAL, () -> {
 +
 +                                // we need the reversed version of this for later usage
@@ -2056,69 +2699,881 @@ index 50d671bc5a8860883239590c030881043c791ca1..92f1416b3994e7f1334bdf41f8c00f61
          List<CloneCommands.CloneBlockInfo> solidList = Lists.newArrayList();
          List<CloneCommands.CloneBlockInfo> blockEntitiesList = Lists.newArrayList();
          List<CloneCommands.CloneBlockInfo> otherBlocksList = Lists.newArrayList();
+diff --git a/net/minecraft/server/commands/DamageCommand.java b/net/minecraft/server/commands/DamageCommand.java
+index 6f837759d77f2461898be62974b72dd5bb4c79d9..d3573a35d469e80b3507f35eff7047bce1a46e72 100644
+--- a/net/minecraft/server/commands/DamageCommand.java
++++ b/net/minecraft/server/commands/DamageCommand.java
+@@ -103,29 +103,20 @@ public class DamageCommand {
+         );
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
+-    private static int damage(final CommandSourceStack stack, final Entity target, final float amount, final DamageSource source) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newTarget) -> {
+-            try {
+-                // Folia end - region threading
+-        if (newTarget.hurtServer(stack.getLevel(), source, amount)) { // Folia - region threading
+-            stack.sendSuccess(() -> Component.translatable("commands.damage.success", amount, newTarget.getDisplayName()), true); // Folia - region threading
+-            return; // Folia - region threading
+-        } else {
+-            throw ERROR_INVULNERABLE.create();
+-        }
+-        // Folia start - region threading
+-        } catch (CommandSyntaxException ex) {
+-            sendMessage(stack, ex);
+-        }
+-        });
+-        return 0;
+-        // Folia end - region threading
++    // Canvas start - region threading
++    private static int damage(final CommandSourceStack stack, final Entity selected, final float amount, final DamageSource source) throws CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._boolean(false)
++            .with(selected)
++            .executes((Entity target) -> (_) -> target.hurtServer(stack.getLevel(), source, amount))
++            .onComplete((passed, targets, css) -> {
++                if (!passed) {
++                    throw ERROR_INVULNERABLE.create();
++                }
++                css.sendSuccess(() -> Component.translatable("commands.damage.success", amount, targets.getFirst().getDisplayName()), true);
++                return Command.SINGLE_SUCCESS;
++            })
++            .start(stack);
++        return Command.SINGLE_SUCCESS;
+     }
++    // Canvas end - region threading
+ }
+diff --git a/net/minecraft/server/commands/DefaultGameModeCommands.java b/net/minecraft/server/commands/DefaultGameModeCommands.java
+index 7bdeda13c9f9fdaccf462286712713bae277e6e5..950cecd1449eadb6788646963373f9873bb7c5a3 100644
+--- a/net/minecraft/server/commands/DefaultGameModeCommands.java
++++ b/net/minecraft/server/commands/DefaultGameModeCommands.java
+@@ -21,10 +21,12 @@ public class DefaultGameModeCommands {
+     }
+ 
+     private static int setMode(final CommandSourceStack source, final GameType type) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         MinecraftServer server = source.getServer();
+         server.setDefaultGameType(type);
+         int count = server.enforceGameTypeForPlayers(server.getForcedGameType());
+         source.sendSuccess(() -> Component.translatable("commands.defaultgamemode.success", type.getLongDisplayName()), true);
+         return count;
++        }, source); // Canvas - region threading
+     }
+ }
 diff --git a/net/minecraft/server/commands/DialogCommand.java b/net/minecraft/server/commands/DialogCommand.java
-index fcbe76e95a7de7c79afd0a116b6cbcf286ba85ff..7bc0ac279913ffd436cbeaa09ab965bd4995acd2 100644
+index fcbe76e95a7de7c79afd0a116b6cbcf286ba85ff..fe5d2aa9f7357bafbe17179fcde5a03fa946a7c5 100644
 --- a/net/minecraft/server/commands/DialogCommand.java
 +++ b/net/minecraft/server/commands/DialogCommand.java
-@@ -46,7 +46,11 @@ public class DialogCommand {
+@@ -44,11 +44,21 @@ public class DialogCommand {
+         );
+     }
  
-     private static int showDialog(final CommandSourceStack sender, final Collection<ServerPlayer> targets, final Holder<Dialog> dialog) {
-         for (ServerPlayer target : targets) {
+-    private static int showDialog(final CommandSourceStack sender, final Collection<ServerPlayer> targets, final Holder<Dialog> dialog) {
+-        for (ServerPlayer target : targets) {
 -            target.openDialog(dialog);
-+            // Canvas start - region threading
-+            target.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer player) -> {
-+                player.openDialog(dialog);
-+            });
-+            // Canvas end - region threading
-         }
+-        }
++    // Canvas start - region threading
++    private static int showDialog(final CommandSourceStack sender, final Collection<ServerPlayer> targets, final Holder<Dialog> dialog) throws com.mojang.brigadier.exceptions.CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.openDialog(dialog);
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> showCallback(selected, css))
++            .start(sender);
++        return 1;
++    }
  
++    private static int showCallback(final Collection<? extends ServerPlayer> targets, final CommandSourceStack sender) {
++    // Canvas end - region threading
          if (targets.size() == 1) {
-@@ -60,7 +64,11 @@ public class DialogCommand {
+             sender.sendSuccess(() -> Component.translatable("commands.dialog.show.single", targets.iterator().next().getDisplayName()), true);
+         } else {
+@@ -58,11 +68,21 @@ public class DialogCommand {
+         return targets.size();
+     }
  
-     private static int clearDialog(final CommandSourceStack sender, final Collection<ServerPlayer> targets) {
-         for (ServerPlayer target : targets) {
+-    private static int clearDialog(final CommandSourceStack sender, final Collection<ServerPlayer> targets) {
+-        for (ServerPlayer target : targets) {
 -            target.connection.send(ClientboundClearDialogPacket.INSTANCE);
-+            // Canvas start - region threading
-+            target.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer player) -> {
-+                player.connection.send(ClientboundClearDialogPacket.INSTANCE);
-+            });
-+            // Canvas end - region threading
+-        }
++    // Canvas start - region threading
++    private static int clearDialog(final CommandSourceStack sender, final Collection<ServerPlayer> targets) throws com.mojang.brigadier.exceptions.CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.send(ClientboundClearDialogPacket.INSTANCE);
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> clearCallback(selected, css))
++            .start(sender);
++        return 1;
++    }
+ 
++    private static int clearCallback(final Collection<? extends ServerPlayer> targets, final CommandSourceStack sender) {
++    // Canvas end - region threading
+         if (targets.size() == 1) {
+             sender.sendSuccess(() -> Component.translatable("commands.dialog.clear.single", targets.iterator().next().getDisplayName()), true);
+         } else {
+diff --git a/net/minecraft/server/commands/DifficultyCommand.java b/net/minecraft/server/commands/DifficultyCommand.java
+index d4fea441a97799d7e2904f304b2a8635bb83776a..52397c3da5d73212a319d813d80a99c0ebe4279a 100644
+--- a/net/minecraft/server/commands/DifficultyCommand.java
++++ b/net/minecraft/server/commands/DifficultyCommand.java
+@@ -23,13 +23,16 @@ public class DifficultyCommand {
          }
  
-         if (targets.size() == 1) {
+         dispatcher.register(command.requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS)).executes(c -> {
++            return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+             Difficulty difficultyx = c.getSource().getLevel().getDifficulty();
+             c.getSource().sendSuccess(() -> Component.translatable("commands.difficulty.query", difficultyx.getDisplayName()), false);
+             return difficultyx.getId();
++            }, c.getSource()); // Canvas - region threading
+         }));
+     }
+ 
+     public static int setDifficulty(final CommandSourceStack source, final Difficulty difficulty) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         MinecraftServer server = source.getServer();
+         if (source.getLevel().getDifficulty() == difficulty) { // CraftBukkit
+             throw ERROR_ALREADY_SAME_DIFFICULTY.create(difficulty.getDisplayName());
+@@ -38,5 +41,6 @@ public class DifficultyCommand {
+         server.setDifficulty(source.getLevel(), difficulty, source, true); // Paper - per level difficulty; don't skip other difficulty-changing logic (fix upstream's fix); WorldDifficultyChangeEvent
+         source.sendSuccess(() -> Component.translatable("commands.difficulty.success", difficulty.getDisplayName()), true);
+         return 0;
++        }, source); // Canvas - region threading
+     }
+ }
+diff --git a/net/minecraft/server/commands/EffectCommands.java b/net/minecraft/server/commands/EffectCommands.java
+index bcf638eb91d205c674bc88340d229269df99a880..1dbb4f31c2c0c2e3638cff8850d4de262810e0b9 100644
+--- a/net/minecraft/server/commands/EffectCommands.java
++++ b/net/minecraft/server/commands/EffectCommands.java
+@@ -159,7 +159,7 @@ public class EffectCommands {
+         final boolean particles
+     ) throws CommandSyntaxException {
+         MobEffect effect = effectHolder.value();
+-        int count = 0;
++        // Canvas - region threading
+         int duration;
+         if (seconds != null) {
+             if (effect.isInstantaneous()) {
+@@ -175,19 +175,31 @@ public class EffectCommands {
+             duration = 600;
+         }
+ 
+-        for (Entity entity : entities) {
+-            if (entity instanceof LivingEntity livingEntity) {
+-                MobEffectInstance instance = new MobEffectInstance(effectHolder, duration, amplifier, false, particles);
+-                entity.getBukkitEntity().taskScheduler.scheduleOrExecute((LivingEntity newEntity) -> {
+-                    newEntity.addEffect(instance, source.getEntity(), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.COMMAND);
+-                });
+-                // Folia end - region threading
+-                if (true) { // CraftBukkit // CraftBukkit // Folia - region threading
+-                    count++;
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(entities)
++            .executes((Entity entity) -> {
++                if (entity instanceof LivingEntity livingEntity) {
++                    MobEffectInstance instance = new MobEffectInstance(effectHolder, duration, amplifier, false, particles);
++                    if (livingEntity.addEffect(instance, source.getEntity(), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.COMMAND)) { // CraftBukkit
++                        return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++                    }
+                 }
+-            }
+-        }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((count, selected, css) -> giveCallback(count, duration, selected, css, effect))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int giveCallback(
++        final int count,
++        final int duration,
++        final Collection<? extends Entity> entities,
++        final CommandSourceStack source,
++        final MobEffect effect
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (count == 0) {
+             throw ERROR_GIVE_FAILED.create();
+         }
+@@ -209,19 +221,27 @@ public class EffectCommands {
+     }
+ 
+     private static int clearEffects(final CommandSourceStack source, final Collection<? extends Entity> entities) throws CommandSyntaxException {
+-        int count = 0;
+-
+-        for (Entity entity : entities) {
+-            if (entity instanceof LivingEntity && true) { // CraftBukkit // Folia - region threading
+-                // Folia start - region threading
+-                entity.getBukkitEntity().taskScheduler.scheduleOrExecute((LivingEntity newEntity) -> {
+-                    newEntity.removeAllEffects(org.bukkit.event.entity.EntityPotionEffectEvent.Cause.COMMAND);
+-                });
+-                // Folia end - region threading
+-                count++;
+-            }
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(entities)
++            .executes((Entity entity) -> {
++                if (entity instanceof LivingEntity livingEntity &&
++                    livingEntity.removeAllEffects(org.bukkit.event.entity.EntityPotionEffectEvent.Cause.COMMAND)) { // CraftBukkit
++                    return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete(EffectCommands::clearEverythingCallback)
++            .start(source);
++        return 1;
++    }
+ 
++    private static int clearEverythingCallback(
++        final int count,
++        final Collection<? extends Entity> entities,
++        final CommandSourceStack source
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (count == 0) {
+             throw ERROR_CLEAR_EVERYTHING_FAILED.create();
+         }
+@@ -239,19 +259,28 @@ public class EffectCommands {
+ 
+     private static int clearEffect(final CommandSourceStack source, final Collection<? extends Entity> entities, final Holder<MobEffect> effectHolder) throws CommandSyntaxException {
+         MobEffect effect = effectHolder.value();
+-        int count = 0;
+-
+-        for (Entity entity : entities) {
+-            if (entity instanceof LivingEntity livingEntity && true) { // CraftBukkit // Folia - region threading
+-                // Folia start - region threading
+-                entity.getBukkitEntity().taskScheduler.scheduleOrExecute((LivingEntity newEntity) -> {
+-                    newEntity.removeEffect(effectHolder, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.COMMAND);
+-                });
+-                // Folia end - region threading
+-                count++;
+-            }
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(entities)
++            .executes((entity) -> {
++                if (entity instanceof LivingEntity livingEntity &&
++                    livingEntity.removeEffect(effectHolder, org.bukkit.event.entity.EntityPotionEffectEvent.Cause.COMMAND)) { // CraftBukkit
++                    return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((count, selected, css) -> clearCallback(count, selected, css, effect))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int clearCallback(
++        final int count,
++        final Collection<? extends Entity> entities,
++        final CommandSourceStack source,
++        final MobEffect effect
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (count == 0) {
+             throw ERROR_CLEAR_SPECIFIC_FAILED.create();
+         }
+diff --git a/net/minecraft/server/commands/EnchantCommand.java b/net/minecraft/server/commands/EnchantCommand.java
+index 093eefd7735111dc26f5154e3bae8b25a0b9e605..354c7a8e9659dea9bf4e23d27b3e8d42e6f51462 100644
+--- a/net/minecraft/server/commands/EnchantCommand.java
++++ b/net/minecraft/server/commands/EnchantCommand.java
+@@ -63,12 +63,6 @@ public class EnchantCommand {
+         );
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
+     private static int enchant(
+         final CommandSourceStack source, final Collection<? extends Entity> targets, final Holder<Enchantment> enchantmentHolder, final int level
+     ) throws CommandSyntaxException {
+@@ -77,71 +71,68 @@ public class EnchantCommand {
+             throw ERROR_LEVEL_TOO_HIGH.create(level, enchantment.getMaxLevel());
+         }
+ 
+-        final java.util.concurrent.atomic.AtomicInteger changed = new java.util.concurrent.atomic.AtomicInteger(0); // Folia - region threading
+-        final java.util.concurrent.atomic.AtomicInteger count = new java.util.concurrent.atomic.AtomicInteger(targets.size()); // Folia - region threading
+-        final java.util.concurrent.atomic.AtomicReference<Component> possibleSingleDisplayName = new java.util.concurrent.atomic.AtomicReference<>(); // Folia - region threading
++        // Canvas start - region threading
++
++        // note: not all of this is annotated with Canvas start/end
++        //       comments, since we revert this to Paper's version before
++        //       we do any patching since Folia's is... interesting
+ 
+-        for (Entity entity : targets) {
++        // also why tf does Vanilla have a weird issue where if 1 entity
++        // in the selection passes, it says all of them passed in the feedback?
++        // we fix this now...
++
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<Entity>())
++            .with(targets)
++            .executes((Entity entity) -> {
++        // Canvas end - region threading
+             if (entity instanceof LivingEntity target) {
+-                // Folia start - region threading
+-                entity.getBukkitEntity().taskScheduler.schedule((LivingEntity nmsEntity) -> {
+-                    try {
+-                        ItemStack item = target.getMainHandItem();
+-                        if (!item.isEmpty()) {
+-                            if (enchantment.canEnchant(item)
+-                                && EnchantmentHelper.isEnchantmentCompatible(EnchantmentHelper.getEnchantmentsForCrafting(item).keySet(), enchantmentHolder)) {
+-                                item.enchant(enchantmentHolder, level);
+-                                possibleSingleDisplayName.set(target.getDisplayName());
+-                                changed.incrementAndGet();
+-                            } else if (targets.size() == 1) {
+-                                throw ERROR_INCOMPATIBLE.create(item.getHoverName().getString());
+-                            }
+-                        } else if (targets.size() == 1) {
+-                            throw ERROR_NO_ITEM.create(target.getName().getString());
+-                        }
+-                    } catch (final CommandSyntaxException exception) {
+-                        sendMessage(source, exception);
+-                        return; // don't send feedback twice
++                ItemStack item = target.getMainHandItem();
++                if (!item.isEmpty()) {
++                    if (enchantment.canEnchant(item)
++                        && EnchantmentHelper.isEnchantmentCompatible(EnchantmentHelper.getEnchantmentsForCrafting(item).keySet(), enchantmentHolder)) {
++                        item.enchant(enchantmentHolder, level);
++                        return (list) -> list.add(entity); // Canvas - region threading
++                    } else if (targets.size() == 1) {
++                        throw ERROR_INCOMPATIBLE.create(item.getHoverName().getString());
+                     }
+-                    sendFeedback(source, enchantmentHolder, level, possibleSingleDisplayName, count, changed);
+-                }, ignored -> sendFeedback(source, enchantmentHolder, level, possibleSingleDisplayName, count, changed), 1L);
++                } else if (targets.size() == 1) {
++                    throw ERROR_NO_ITEM.create(target.getName().getString());
++                }
+             } else if (targets.size() == 1) {
+                 throw ERROR_NOT_LIVING_ENTITY.create(entity.getName().getString());
+-            } else {
+-                sendFeedback(source, enchantmentHolder, level, possibleSingleDisplayName, count, changed);
+-                // Folia end - region threading
+             }
+-        }
+-        return targets.size(); // Folia - region threading
++    // Canvas start - region threading
++            return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((changed, _, css) -> enchantCallback(css, changed, enchantmentHolder, level))
++            .start(source);
++        return 1;
++    }
++
++    private static int enchantCallback(
++        final CommandSourceStack source,
++        final io.canvasmc.canvas.util.CollectingList<Entity> targets,
++        final Holder<Enchantment> enchantmentHolder,
++        final int level
++    ) throws CommandSyntaxException {
++        if (targets.isEmpty()) {
++    // Canvas end - region threading
++            throw ERROR_NOTHING_HAPPENED.create();
+         }
+ 
+-    // Folia start - region threading
+-    private static void sendFeedback(
+-            final CommandSourceStack source, final Holder<Enchantment> enchantmentHolder, final int level,
+-            final java.util.concurrent.atomic.AtomicReference<Component> possibleSingleDisplayName,
+-            final java.util.concurrent.atomic.AtomicInteger count,
+-            final java.util.concurrent.atomic.AtomicInteger changed
+-    ) {
+-        if (count.decrementAndGet() == 0) {
+-            final int i = changed.get();
+-            if (i == 0) {
+-                sendMessage(source, ERROR_NOTHING_HAPPENED.create());
+-            } else {
+-                if (i == 1) {
+-                    source.sendSuccess(
+-                        () -> Component.translatable(
+-                            "commands.enchant.success.single", Enchantment.getFullname(enchantmentHolder, level), possibleSingleDisplayName.get()
+-                        ),
+-                        true
+-                    );
+-                } else {
+-                    source.sendSuccess(
+-                        () -> Component.translatable("commands.enchant.success.multiple", Enchantment.getFullname(enchantmentHolder, level), i),
+-                        true
+-                    );
+-                }
+-            }
++        if (targets.size() == 1) {
++            source.sendSuccess(
++                () -> Component.translatable(
++                    "commands.enchant.success.single", Enchantment.getFullname(enchantmentHolder, level), targets.iterator().next().getDisplayName()
++                ),
++                true
++            );
++        } else {
++            source.sendSuccess(
++                () -> Component.translatable("commands.enchant.success.multiple", Enchantment.getFullname(enchantmentHolder, level), targets.size()), true
++            );
+         }
++
++        return targets.size(); // Canvas - region threading
+     }
+-    // Folia end - region threading
+ }
 diff --git a/net/minecraft/server/commands/ExperienceCommand.java b/net/minecraft/server/commands/ExperienceCommand.java
-index 8eae0c33e3f37c388f3c7466e5733fb5da90258a..2b5a8893473a5d2c28c53095e9cec34f638c33c5 100644
+index 8eae0c33e3f37c388f3c7466e5733fb5da90258a..1b5e59b47c66ed9994e91566d1d4c4565f8fef0f 100644
 --- a/net/minecraft/server/commands/ExperienceCommand.java
 +++ b/net/minecraft/server/commands/ExperienceCommand.java
-@@ -137,9 +137,9 @@ public class ExperienceCommand {
+@@ -122,26 +122,45 @@ public class ExperienceCommand {
+         dispatcher.register(Commands.literal("xp").requires(Commands.hasPermission(Commands.LEVEL_GAMEMASTERS)).redirect(command));
+     }
+ 
+-    private static int queryExperience(final CommandSourceStack source, final ServerPlayer target, final ExperienceCommand.Type type) {
+-        // Folia start - region threading
+-        target.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newTarget) -> {
+-            int result = type.query.applyAsInt(newTarget);
+-            source.sendSuccess(() -> Component.translatable("commands.experience.query." + type.name, newTarget.getDisplayName(), result), false);
+-            return;
+-        });
+-        return 0;
+-        // Folia end - region threading
++    // Canvas start - region threading
++    private static int queryExperience(final CommandSourceStack source, final ServerPlayer target, final ExperienceCommand.Type type) throws CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(target)
++            .executes((ServerPlayer entityPlayer) -> {
++                int result = type.query.applyAsInt(entityPlayer);
++                return (_) -> result;
++            })
++            .onComplete((result, targets, css) -> {
++                css.sendSuccess(() -> Component.translatable("commands.experience.query." + type.name, targets.getFirst().getDisplayName(), result), false);
++                return result;
++            })
++            .start(source);
++        return 1;
++    // Canvas end - region threading
+     }
+ 
+     private static int addExperience(
          final CommandSourceStack source, final Collection<? extends ServerPlayer> players, final int amount, final ExperienceCommand.Type type
-     ) {
-         for (ServerPlayer player : players) {
+-    ) {
+-        for (ServerPlayer player : players) {
 -            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> { // Folia - region threading
-+            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Folia - region threading // Canvas - region threading
-             type.add.accept(newPlayer, amount); // Folia - region threading
+-            type.add.accept(newPlayer, amount); // Folia - region threading
 -            }, null, 1L); // Folia - region threading
-+            }); // Folia - region threading // Canvas - region threading
-         }
+-        }
++    // Canvas start - region threading
++    ) throws CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                type.add.accept(entityPlayer, amount);
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> addCallback(css, selected, amount, type))
++            .start(source);
++        return 1;
++    }
  
++    private static int addCallback(
++        final CommandSourceStack source,
++        final Collection<? extends ServerPlayer> players,
++        final int amount,
++        final ExperienceCommand.Type type
++    ) {
++    // Canvas end - region threading
          if (players.size() == 1) {
-@@ -162,12 +162,12 @@ public class ExperienceCommand {
-         for (ServerPlayer player : players) {
-             // Folia start - region threading
-             ++success;
+             source.sendSuccess(
+                 () -> Component.translatable("commands.experience.add." + type.name + ".success.single", amount, players.iterator().next().getDisplayName()),
+@@ -157,19 +176,28 @@ public class ExperienceCommand {
+     private static int setExperience(
+         final CommandSourceStack source, final Collection<? extends ServerPlayer> players, final int amount, final ExperienceCommand.Type type
+     ) throws CommandSyntaxException {
+-        int success = 0;
+-
+-        for (ServerPlayer player : players) {
+-            // Folia start - region threading
+-            ++success;
 -            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> {
-+            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Canvas - region threading
-             if (type.set.test(newPlayer, amount)) {
-                 //success++;
-                 // Folia end - region threading
-             }
+-            if (type.set.test(newPlayer, amount)) {
+-                //success++;
+-                // Folia end - region threading
+-            }
 -            }, null, 1L); // Folia - region threading
-+            }); // Folia - region threading // Canvas - region threading
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                if (type.set.test(entityPlayer, amount)) {
++                    return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((success, selected, css) -> setCallback(css, selected, amount, type, success))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int setCallback(
++        final CommandSourceStack source,
++        final Collection<? extends ServerPlayer> players,
++        final int amount,
++        final ExperienceCommand.Type type,
++        final int success
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (success == 0) {
+             throw ERROR_SET_POINTS_INVALID.create();
+         }
+diff --git a/net/minecraft/server/commands/ForceLoadCommand.java b/net/minecraft/server/commands/ForceLoadCommand.java
+index d426e93f7f84e48a3e193abfb322d46dcb80d6fa..e59ed4feb319aa2291730cb645570924aa3b2759 100644
+--- a/net/minecraft/server/commands/ForceLoadCommand.java
++++ b/net/minecraft/server/commands/ForceLoadCommand.java
+@@ -86,17 +86,9 @@ public class ForceLoadCommand {
+         );
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
++    // Canvas - region threading
+     private static int queryForceLoad(final CommandSourceStack source, final ColumnPos pos) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-        // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         ChunkPos chunkPos = pos.toChunkPos();
+         ServerLevel level = source.getLevel();
+         ResourceKey<Level> dimension = level.dimension();
+@@ -111,18 +103,12 @@ public class ForceLoadCommand {
+         } else {
+             throw ERROR_NOT_TICKING.create(chunkPos, dimension.identifier());
+         }
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return Command.SINGLE_SUCCESS;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int listForceLoad(final CommandSourceStack source) {
+         ServerLevel level = source.getLevel();
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         ResourceKey<Level> dimension = level.dimension();
+         LongSet forcedChunks = level.getForceLoadedChunks();
+         int chunkCount = forcedChunks.size();
+@@ -141,27 +127,21 @@ public class ForceLoadCommand {
+         } else {
+             source.sendFailure(Component.translatable("commands.forceload.added.none", Component.translationArg(dimension.identifier())));
+         }
+-        }); // Folia - region threading
+-
+-        return Command.SINGLE_SUCCESS; // Folia - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int removeAll(final CommandSourceStack source) {
+         ServerLevel level = source.getLevel();
+         ResourceKey<Level> dimension = level.dimension();
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         LongSet forcedChunks = level.getForceLoadedChunks();
+         forcedChunks.forEach(chunk -> level.setChunkForced(ChunkPos.getX(chunk), ChunkPos.getZ(chunk), false));
+         source.sendSuccess(() -> Component.translatable("commands.forceload.removed.all", Component.translationArg(dimension.identifier())), true);
+-        }); // Folia - region threading
+-        return 0;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int changeForceLoad(final CommandSourceStack source, final ColumnPos from, final ColumnPos to, final boolean add) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         int minX = Math.min(from.x(), to.x());
+         int minZ = Math.min(from.z(), to.z());
+         int maxX = Math.max(from.x(), to.x());
+@@ -227,12 +207,6 @@ public class ForceLoadCommand {
+         } else {
+             throw BlockPosArgument.ERROR_OUT_OF_WORLD.create();
+         }
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return Command.SINGLE_SUCCESS;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ }
+diff --git a/net/minecraft/server/commands/GameModeCommand.java b/net/minecraft/server/commands/GameModeCommand.java
+index 75ca0ead45a7ea2b8e104acac8b11de603721c3c..90fb5a3d7234300aaefc7305ffe5acd9d7e1cdc8 100644
+--- a/net/minecraft/server/commands/GameModeCommand.java
++++ b/net/minecraft/server/commands/GameModeCommand.java
+@@ -47,23 +47,27 @@ public class GameModeCommand {
+         }
+     }
+ 
+-    private static int setMode(final CommandContext<CommandSourceStack> context, final Collection<ServerPlayer> players, final GameType type) {
+-        int count = 0;
+-        MinecraftServer server = context.getSource().getServer();
++    // Canvas start - region threading
++    private static int setMode(final CommandContext<CommandSourceStack> context, final Collection<ServerPlayer> players, final GameType type) throws com.mojang.brigadier.exceptions.CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
+ 
+-        for (ServerPlayer player : players) {
+-            if (server.isSingleplayerOwner(player.nameAndId())) {
+-                server.setDefaultGameType(type);
+-            }
++                // this is always false so we don't care
++                // if (server.isSingleplayerOwner(entityPlayer.nameAndId())) {
++                //     server.setDefaultGameType(type);
++                // }
+ 
+-            ++count; player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Folia - region threading
+-            if (setGameMode(context.getSource(), newPlayer, type)) { // Folia - region threading
+-                //count++; // Folia - region threading
+-            }
+-            }); // Folia - region threading
+-        }
++                if (setGameMode(context.getSource(), entityPlayer, type)) {
++                    return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++                }
+ 
+-        return count;
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((count,_,_) -> count)
++            .start(context.getSource());
++        return 1;
++    // Canvas end - region threading
+     }
+ 
+     public static void setGameMode(final ServerPlayer player, final GameType type) {
+diff --git a/net/minecraft/server/commands/GameRuleCommand.java b/net/minecraft/server/commands/GameRuleCommand.java
+index ea6517b152417575be7c24bf06a75141a6061c1d..2288f60a3e3e1c5613b2ad11481ffc6637eec351 100644
+--- a/net/minecraft/server/commands/GameRuleCommand.java
++++ b/net/minecraft/server/commands/GameRuleCommand.java
+@@ -34,14 +34,18 @@ public class GameRuleCommand {
+ 
+     private static <T> int setRule(final CommandContext<CommandSourceStack> context, final GameRule<T> gameRule) {
+         CommandSourceStack source = context.getSource();
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         T value = org.bukkit.craftbukkit.event.CraftEventFactory.handleGameRuleSet(gameRule, context.getArgument("value", gameRule.valueClass()), source.getLevel(), source.getBukkitSender()).value(); // Paper - per-world game rules and event
+         source.sendSuccess(() -> Component.translatable("commands.gamerule.set", gameRule.id(), gameRule.serialize(value)), true);
+         return gameRule.getCommandResult(value);
++        }, source); // Canvas - region threading
+     }
+ 
+     private static <T> int queryRule(final CommandSourceStack source, final GameRule<T> gameRule) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         T value = source.getLevel().getGameRules().get(gameRule);
+         source.sendSuccess(() -> Component.translatable("commands.gamerule.query", gameRule.id(), gameRule.serialize(value)), false);
+         return gameRule.getCommandResult(value);
++        }, source); // Canvas - region threading
+     }
+ }
+diff --git a/net/minecraft/server/commands/GiveCommand.java b/net/minecraft/server/commands/GiveCommand.java
+index be357d315f5c83349a7f7287ff45e92137950a8c..afcfba3f7159ad86905cfbee1b8101c757df1364 100644
+--- a/net/minecraft/server/commands/GiveCommand.java
++++ b/net/minecraft/server/commands/GiveCommand.java
+@@ -54,44 +54,60 @@ public class GiveCommand {
+             return 0;
          }
  
-         if (success == 0) {
+-        for (ServerPlayer player : players) {
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(players)
++            // we use "player" instead of "entityPlayer" to minimize diff against Vanilla
++            .executes((ServerPlayer player) -> {
++        // Canvas end - region threading
+             int remaining = count;
+ 
+             while (remaining > 0) {
+                 int size = Math.min(maxStackSize, remaining);
+                 remaining -= size;
+                 ItemStack copyToDrop = prototypeItemStack.copyWithCount(size);
+-                player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Folia - region threading
+-                boolean added = newPlayer.getInventory().add(copyToDrop); // Folia - region threading
++                boolean added = player.getInventory().add(copyToDrop);
+                 if (added && copyToDrop.isEmpty()) {
+-                    ItemEntity drop = newPlayer.drop(prototypeItemStack.copy(), false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command // Folia - region threading
++                    ItemEntity drop = player.drop(prototypeItemStack.copy(), false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command
+                     if (drop != null) {
+                         drop.makeFakeItem();
+                     }
+ 
+-                    newPlayer.level() // Folia - region threading
++                    player.level()
+                         .playSound(
+                             null,
+-                            newPlayer.getX(), // Folia - region threading
+-                            newPlayer.getY(), // Folia - region threading
+-                            newPlayer.getZ(), // Folia - region threading
++                            player.getX(),
++                            player.getY(),
++                            player.getZ(),
+                             SoundEvents.ITEM_PICKUP,
+                             SoundSource.PLAYERS,
+                             0.2F,
+-                            ((newPlayer.getRandom().nextFloat() - newPlayer.getRandom().nextFloat()) * 0.7F + 1.0F) * 2.0F // Folia - region threading
++                            ((player.getRandom().nextFloat() - player.getRandom().nextFloat()) * 0.7F + 1.0F) * 2.0F
+                         );
+-                    newPlayer.containerMenu.broadcastChanges(); // Folia - region threading
++                    player.containerMenu.broadcastChanges();
+                 } else {
+-                    ItemEntity drop = newPlayer.drop(copyToDrop, false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command // Folia - region threading
++                    ItemEntity drop = player.drop(copyToDrop, false, false, false, null); // Paper - do not fire PlayerDropItemEvent for /give command
+                     if (drop != null) {
+                         drop.setNoPickUpDelay();
+-                        drop.setTarget(newPlayer.getUUID()); // Folia - region threading
++                        drop.setTarget(player.getUUID());
+                     }
+                 }
+-                }); // Folia - region threading
+             }
+-        }
++    // Canvas start - region threading
++            return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> giveCallback(css, selected, prototypeItemStack, count))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int giveCallback(
++        final CommandSourceStack source,
++        final Collection<? extends ServerPlayer> players,
++        final ItemStack prototypeItemStack,
++        final int count
++    ) {
++    // Canvas end - region threading
+         if (players.size() == 1) {
+             source.sendSuccess(
+                 () -> Component.translatable(
+diff --git a/net/minecraft/server/commands/KickCommand.java b/net/minecraft/server/commands/KickCommand.java
+index 808c36bd2324c7b956cf1f32d9a4dac0ce4ad828..f6671addee16db82fec11bf5661897ee8c4521b0 100644
+--- a/net/minecraft/server/commands/KickCommand.java
++++ b/net/minecraft/server/commands/KickCommand.java
+@@ -39,20 +39,29 @@ public class KickCommand {
+             throw ERROR_SINGLEPLAYER.create();
+         }
+ 
+-        int count = 0;
++        // Canvas start - region threading
+ 
+-        for (ServerPlayer player : players) {
+-            if (!source.getServer().isSingleplayerOwner(player.nameAndId())) {
+-                player.connection.disconnect(reason, org.bukkit.event.player.PlayerKickEvent.Cause.KICK_COMMAND); // Paper - kick event cause
+-                source.sendSuccess(() -> Component.translatable("commands.kick.success", player.getDisplayName(), reason), true);
+-                count++;
+-            }
+-        }
++        // note: while technically not required, since the disconnect function
++        //       we call has handling for if we aren't on the owning context,
++        //       but we rewrite this one anyway for the proper response ordering
+ 
+-        if (count == 0) {
+-            throw ERROR_KICKING_OWNER.create();
+-        } else {
+-            return count;
+-        }
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.disconnect(reason, org.bukkit.event.player.PlayerKickEvent.Cause.KICK_COMMAND); // Paper - kick event cause
++                source.sendSuccess(() -> Component.translatable("commands.kick.success", entityPlayer.getDisplayName(), reason), true);
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++            })
++            .onComplete((count, _,_) -> {
++                if (count == 0) {
++                    throw ERROR_KICKING_OWNER.create();
++                }
++                // else, the command feedback is handled in execution,
++                // so we don't really care about anything else
++                return count;
++            })
++            .start(source);
++        return 1;
++        // Canvas end - region threading
+     }
+ }
+diff --git a/net/minecraft/server/commands/KillCommand.java b/net/minecraft/server/commands/KillCommand.java
+index a4cfbbbe2a2c3219c0dc996f7b8acd5a2be20d39..1efb8d1599a6451873b36fd66518bcb07169a92e 100644
+--- a/net/minecraft/server/commands/KillCommand.java
++++ b/net/minecraft/server/commands/KillCommand.java
+@@ -19,13 +19,21 @@ public class KillCommand {
+         );
+     }
+ 
+-    private static int kill(final CommandSourceStack source, final Collection<? extends Entity> victims) {
+-        for (Entity entity : victims) {
+-            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity newEntity) -> { // Folia - region threading
+-                newEntity.kill(source.getLevel()); // Folia - region threading
+-            }); // Folia - region threading
+-        }
++    // Canvas start - region threading
++    private static int kill(final CommandSourceStack source, final Collection<? extends Entity> victims) throws com.mojang.brigadier.exceptions.CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<Entity>())
++            .with(victims)
++            .executes((Entity victim) -> {
++                victim.kill(source.getLevel());
++                return (list) -> list.add(victim);
++            })
++            .onComplete((finalVictims, _, css) -> killCallback(css, finalVictims))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int killCallback(final CommandSourceStack source, final io.canvasmc.canvas.util.CollectingList<? extends Entity> victims) {
++    // Canvas end - region threading
+         if (victims.size() == 1) {
+             source.sendSuccess(() -> Component.translatable("commands.kill.success.single", victims.iterator().next().getDisplayName()), true);
+         } else {
+diff --git a/net/minecraft/server/commands/ListPlayersCommand.java b/net/minecraft/server/commands/ListPlayersCommand.java
+index b850c908a594f839ce124c6bd01762d31cc3aa1e..1974f59d2ec2e074e893a511cd517c569496942a 100644
+--- a/net/minecraft/server/commands/ListPlayersCommand.java
++++ b/net/minecraft/server/commands/ListPlayersCommand.java
+@@ -31,6 +31,7 @@ public class ListPlayersCommand {
+     }
+ 
+     private static int format(final CommandSourceStack source, final Function<ServerPlayer, Component> formatter) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         PlayerList playerList = source.getServer().getPlayerList();
+         // CraftBukkit start
+         List<ServerPlayer> playersTemp = playerList.getPlayers();
+@@ -43,5 +44,6 @@ public class ListPlayersCommand {
+         Component listComponent = ComponentUtils.formatList(players, formatter);
+         source.sendSuccess(() -> Component.translatable("commands.list.players", players.size(), playerList.getMaxPlayers(), listComponent), false);
+         return players.size();
++        }, source); // Canvas - region threading
+     }
+ }
 diff --git a/net/minecraft/server/commands/LootCommand.java b/net/minecraft/server/commands/LootCommand.java
-index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe371fb549cb 100644
+index 57e8501f4adc66a11a474905bed045c34a44c9cb..36a61bb4faf3014988cf927dde6e90d9973563d9 100644
 --- a/net/minecraft/server/commands/LootCommand.java
 +++ b/net/minecraft/server/commands/LootCommand.java
 @@ -207,8 +207,7 @@ public class LootCommand {
@@ -2157,40 +3612,28 @@ index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe37
          if (source.getLevel().getBlockEntity(pos) instanceof Container container) {
              return container;
          } else {
-@@ -265,7 +264,13 @@ public class LootCommand {
+@@ -265,7 +264,8 @@ public class LootCommand {
          }
      }
  
 -    private static int blockDistribute(final CommandSourceStack source, final BlockPos pos, final List<ItemStack> drops, final LootCommand.Callback callback) throws CommandSyntaxException {
 +    private static int blockDistribute(final CommandSourceStack source, final BlockPos pos, final List<ItemStack> drops, final CommandSourceStack callback) throws CommandSyntaxException { // Canvas - region threading
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
-+            source.getLevel(), pos.getX() >> 4, pos.getZ() >> 4,
-+            () -> {
-+                try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> { // Canvas - region threading
          Container container = getContainer(source, pos);
          List<ItemStack> usedItems = Lists.newArrayListWithCapacity(drops.size());
  
-@@ -276,8 +281,15 @@ public class LootCommand {
+@@ -276,8 +276,8 @@ public class LootCommand {
              }
          }
  
 -        callback.accept(usedItems);
 -        return usedItems.size();
 +        source.sendSuccess(() -> Component.translatable("commands.drop.success.multiple", usedItems.size()), false); // Canvas - region threading
-+        // Canvas start - region threading
-+                } catch (CommandSyntaxException cse) {
-+                    source.sendFailure(Component.literal(cse.getMessage()));
-+                }
-+            }
-+        );
-+        return 0;
-+        // Canvas end - region threading
++        }, pos, source.getLevel(), source); // Canvas - region threading
      }
  
      private static boolean distributeToContainer(final Container container, final ItemStack itemStack) {
-@@ -310,9 +322,14 @@ public class LootCommand {
+@@ -310,9 +310,9 @@ public class LootCommand {
          final BlockPos pos,
          final int startSlot,
          final int slotCount,
@@ -2198,16 +3641,11 @@ index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe37
 -        final LootCommand.Callback callback
 +        final List<ItemStack> drops // Canvas - region threading
      ) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
-+            source.getLevel(), pos.getX() >> 4, pos.getZ() >> 4,
-+            () -> {
-+                try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> { // Canvas - region threading
          Container container = getContainer(source, pos);
          int maxSlot = container.getContainerSize();
          if (startSlot >= 0 && startSlot < maxSlot) {
-@@ -327,29 +344,40 @@ public class LootCommand {
+@@ -327,30 +327,37 @@ public class LootCommand {
                  }
              }
  
@@ -2217,14 +3655,7 @@ index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe37
          } else {
              throw ItemCommands.ERROR_TARGET_INAPPLICABLE_SLOT.create(startSlot);
          }
-+        // Canvas start - region threading
-+                } catch (CommandSyntaxException cse) {
-+                    source.sendFailure(Component.literal(cse.getMessage()));
-+                }
-+            }
-+        );
-+        return 0;
-+        // Canvas end - region threading
++        }, pos, source.getLevel(), source); // Canvas - region threading
      }
  
      private static boolean canMergeItems(final ItemStack a, final ItemStack b) {
@@ -2232,29 +3663,41 @@ index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe37
      }
  
 -    private static int playerGive(final Collection<ServerPlayer> players, final List<ItemStack> drops, final LootCommand.Callback callback) throws CommandSyntaxException {
-+    private static int playerGive(final Collection<ServerPlayer> players, final List<ItemStack> drops, final CommandSourceStack source) throws CommandSyntaxException { // Canvas - region threading
-         List<ItemStack> usedItems = Lists.newArrayListWithCapacity(drops.size());
- 
-         for (ItemStack drop : drops) {
+-        List<ItemStack> usedItems = Lists.newArrayListWithCapacity(drops.size());
+-
+-        for (ItemStack drop : drops) {
 -            for (ServerPlayer player : players) {
 -                if (player.getInventory().add(drop.copy())) {
-+            // Canvas start - region threading
-+            for (ServerPlayer selected : players) {
-+                selected.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer entityPlayer) -> {
-+                if (entityPlayer.getInventory().add(drop.copy())) {
-+            // Canvas end - region threading
-                     usedItems.add(drop);
+-                    usedItems.add(drop);
++    private static int playerGive(final Collection<ServerPlayer> players, final List<ItemStack> drops, final CommandSourceStack source) throws CommandSyntaxException { // Canvas - region threading
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                int count = 0;
++                for (ItemStack drop : drops) {
++                    if (entityPlayer.getInventory().add(drop.copy())) {
++                        count++;
++                    }
                  }
-+                }); // Canvas - region threading
-             }
-         }
- 
+-            }
+-        }
+-
 -        callback.accept(usedItems);
-+        source.sendSuccess(() -> Component.translatable("commands.drop.success.multiple", drops.size() * players.size()), false); // Canvas - region threading - close enough
-         return usedItems.size();
+-        return usedItems.size();
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(count);
++            })
++            .onComplete((count, _, css) -> {
++                css.sendSuccess(() -> Component.translatable("commands.drop.success.multiple", count), false);
++                return count;
++            })
++            .start(source);
++        return 1;
++        // Canvas end - region threading
      }
  
-@@ -364,31 +392,49 @@ public class LootCommand {
+     private static void setSlots(final Entity entity, final List<ItemStack> itemsToSet, final int startSlot, final int count, final List<ItemStack> usedItems) {
+@@ -364,32 +371,46 @@ public class LootCommand {
      }
  
      private static int entityReplace(
@@ -2270,122 +3713,112 @@ index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe37
 -            } else {
 -                setSlots(entity, drops, startSlot, count, usedItems);
 -            }
-+        // Canvas start - region threading
-+        for (Entity selected : entities) {
-+            // copy this because CME is no no
-+            final List<ItemStack> itemsToSet = new java.util.ArrayList<>(drops);
-+            selected.getBukkitEntity().taskScheduler.scheduleOrExecute((entity) -> {
-+                for (int i = 0; i < count; i++) {
-+                    ItemStack item = i < itemsToSet.size() ? itemsToSet.get(i) : ItemStack.EMPTY;
-+                    SlotAccess slotAccess = entity.getSlot(startSlot + i);
-+                    if (slotAccess != null) {
-+                        slotAccess.set(item.copy());
-+                    }
-+                }
-+                if (entity instanceof ServerPlayer entityPlayer) {
-+                    entityPlayer.containerMenu.broadcastChanges();
-+                }
-+            });
-         }
- 
+-        }
+-
 -        callback.accept(usedItems);
 -        return usedItems.size();
-+        // close enough, guesstimate
-+        int assumption = drops.size() * entities.size();
-+        source.sendSuccess(() -> Component.translatable("commands.drop.success.multiple", assumption), false);
-+        return assumption;
++        // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(entities)
++            .executes((Entity entity) -> {
++                int toAdd = 0;
++                // Vanilla-copy of setSlots
++                for (int i = 0; i < count; i++) {
++                    ItemStack item = i < drops.size() ? drops.get(i) : ItemStack.EMPTY;
++                    SlotAccess slotAccess = entity.getSlot(startSlot + i);
++                    if (slotAccess != null && slotAccess.set(item.copy())) {
++                        toAdd++; // change this from adding to the usedItems set
++                    }
++                }
++                if (entity instanceof ServerPlayer player) {
++                    player.containerMenu.broadcastChanges();
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(toAdd);
++            })
++            .onComplete((finalCount, _, css) -> {
++                css.sendSuccess(() -> Component.translatable("commands.drop.success.multiple", finalCount), false);
++                return finalCount;
++            })
++            .start(source);
++        return 1;
 +        // Canvas end - region threading
      }
  
 -    private static int dropInWorld(final CommandSourceStack source, final Vec3 pos, final List<ItemStack> drops, final LootCommand.Callback callback) throws CommandSyntaxException {
 +    private static int dropInWorld(final CommandSourceStack source, final Vec3 pos, final List<ItemStack> drops) throws CommandSyntaxException { // Canvas - region threading
          ServerLevel level = source.getLevel();
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> { // Canvas - region threading
          drops.forEach(drop -> {
-+            // Canvas start - region threading
-+            io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
-+                level, ((int) pos.x) >> 4, ((int) pos.z) >> 4, () -> {
-+            // Canvas end - region threading
              ItemEntity entity = new ItemEntity(level, pos.x, pos.y, pos.z, drop.copy());
              entity.setDefaultPickUpDelay();
              level.addFreshEntity(entity);
-+            // Canvas start - region threading
-+                }
-+            );
-+            // Canvas end - region threading
          });
 -        callback.accept(drops);
 +        callback(source, drops); // Canvas - region threading
          return drops.size();
++        }, pos, level, source); // Canvas - region threading
      }
  
-@@ -431,6 +477,12 @@ public class LootCommand {
+     private static void callback(final CommandSourceStack source, final List<ItemStack> drops) {
+@@ -431,6 +452,7 @@ public class LootCommand {
      ) throws CommandSyntaxException {
          CommandSourceStack source = context.getSource();
          ServerLevel level = source.getLevel();
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
-+            source.getLevel(), pos.getX() >> 4, pos.getZ() >> 4,
-+            () -> {
-+                try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> { // Canvas - region threading
          BlockState blockState = level.getBlockState(pos);
          BlockEntity blockEntity = level.getBlockEntity(pos);
          Optional<ResourceKey<LootTable>> lootTable = blockState.getBlock().getLootTable();
-@@ -445,10 +497,22 @@ public class LootCommand {
+@@ -445,10 +467,18 @@ public class LootCommand {
              .withOptionalParameter(LootContextParams.THIS_ENTITY, source.getEntity())
              .withParameter(LootContextParams.TOOL, tool);
          List<ItemStack> drops = blockState.getDrops(lootParams);
 -        return output.accept(context, drops, usedItems -> callback(source, usedItems, lootTable.get()));
-+        output.accept(context, drops, context.getSource()); // Canvas - region threading
 +        // Canvas start - region threading
-+                } catch (CommandSyntaxException syntaxException) {
-+                    context.getSource().sendFailure(Component.literal(syntaxException.getMessage()));
-+                }
-+            }
-+        );
-+        return 0;
++        output.accept(context, drops, context.getSource());
++        }, pos, source.getLevel(), context.getSource());
 +        // Canvas end - region threading
      }
  
 -    private static int dropKillLoot(final CommandContext<CommandSourceStack> context, final Entity target, final LootCommand.DropConsumer output) throws CommandSyntaxException {
 +    // Canvas start - region threading
 +    private static int dropKillLoot(final CommandContext<CommandSourceStack> context, final Entity selected, final LootCommand.DropConsumer output) throws CommandSyntaxException {
-+        selected.getBukkitEntity().taskScheduler.scheduleOrExecute((target) -> {
-+            try {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(selected)
++            .executes((Entity target) -> {
 +    // Canvas end - region threading
          Optional<ResourceKey<LootTable>> lootTableId = target.getLootTable();
          if (lootTableId.isEmpty()) {
              throw ERROR_NO_ENTITY_LOOT_TABLE.create(target.getDisplayName());
-@@ -457,6 +521,12 @@ public class LootCommand {
+@@ -457,6 +487,12 @@ public class LootCommand {
          CommandSourceStack source = context.getSource();
          LootParams.Builder builder = new LootParams.Builder(source.getLevel());
          Entity killer = source.getEntity();
 +        // Canvas start - region threading
 +        if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(killer)) {
 +            source.sendFailure(Component.literal("Killer and target must be in same region to drop kill loot"));
-+            return;
++            return (_) -> null;
 +        }
 +        // Canvas end - region threading
          if (killer instanceof Player player) {
              builder.withParameter(LootContextParams.LAST_DAMAGE_PLAYER, player);
          }
-@@ -469,7 +539,14 @@ public class LootCommand {
+@@ -469,7 +505,14 @@ public class LootCommand {
          LootParams lootParams = builder.create(LootContextParamSets.ENTITY);
          LootTable lootTable = source.getServer().reloadableRegistries().getLootTable(lootTableId.get());
          List<ItemStack> drops = lootTable.getRandomItems(lootParams);
 -        return output.accept(context, drops, usedItems -> callback(source, usedItems, lootTableId.get()));
 +        // Canvas start - region threading
 +        output.accept(context, drops, context.getSource());
-+            } catch (CommandSyntaxException cse) {
-+                context.getSource().sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
++        return (_) -> null;
++            })
++            .noCompletion()
++            .start(context.getSource());
++        return 1;
 +        // Canvas end - region threading
      }
  
      private static int dropChestLoot(final CommandContext<CommandSourceStack> context, final Holder<LootTable> lootTable, final LootCommand.DropConsumer output) throws CommandSyntaxException {
-@@ -502,7 +579,7 @@ public class LootCommand {
+@@ -502,7 +545,7 @@ public class LootCommand {
      ) throws CommandSyntaxException {
          CommandSourceStack source = context.getSource();
          List<ItemStack> drops = lootTable.value().getRandomItems(lootParams);
@@ -2394,7 +3827,7 @@ index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe37
      }
  
      @FunctionalInterface
-@@ -512,7 +589,7 @@ public class LootCommand {
+@@ -512,7 +555,7 @@ public class LootCommand {
  
      @FunctionalInterface
      private interface DropConsumer {
@@ -2403,61 +3836,397 @@ index 57e8501f4adc66a11a474905bed045c34a44c9cb..a920e8594832e99acfe1cce667f9fe37
      }
  
      @FunctionalInterface
+diff --git a/net/minecraft/server/commands/ParticleCommand.java b/net/minecraft/server/commands/ParticleCommand.java
+index ce8a8e665ca68f14158739dd7a07f932a472203c..51a1aba2d5fb5bf66c7ff24645442311f0bfd357 100644
+--- a/net/minecraft/server/commands/ParticleCommand.java
++++ b/net/minecraft/server/commands/ParticleCommand.java
+@@ -149,9 +149,16 @@ public class ParticleCommand {
+         final boolean force,
+         final Collection<ServerPlayer> players
+     ) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> { // Canvas - region threading
+         int result = 0;
+ 
+         for (ServerPlayer player : players) {
++            // Canvas start - region threading
++            // if they aren't in the same region they can't see it anyway
++            if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(player)) {
++                continue;
++            }
++            // Canvas end - region threading
+             if (source.getLevel().sendParticles(player, particle, force, false, pos.x, pos.y, pos.z, count, delta.x, delta.y, delta.z, speed)) {
+                 result++;
+             }
+@@ -165,5 +172,6 @@ public class ParticleCommand {
+             () -> Component.translatable("commands.particle.success", BuiltInRegistries.PARTICLE_TYPE.getKey(particle.getType()).toString()), true
+         );
+         return result;
++        }, pos, source.getLevel(), source); // Canvas - region threading
+     }
+ }
+diff --git a/net/minecraft/server/commands/PlaceCommand.java b/net/minecraft/server/commands/PlaceCommand.java
+index a28eb4e4c55e33ca9feae68518363c79bc1008eb..1837f8c1987c6f627b17d7309c04c30b05de7876 100644
+--- a/net/minecraft/server/commands/PlaceCommand.java
++++ b/net/minecraft/server/commands/PlaceCommand.java
+@@ -250,39 +250,21 @@ public class PlaceCommand {
+         );
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
++    // Canvas - region threading
+     public static int placeFeature(final CommandSourceStack source, final Holder.Reference<ConfiguredFeature<?, ?>> featureHolder, final BlockPos pos) throws CommandSyntaxException {
+         ServerLevel level = source.getLevel();
+         ConfiguredFeature<?, ?> feature = featureHolder.value();
+         ChunkPos chunkPos = ChunkPos.containing(pos);
+         checkLoaded(level, new ChunkPos(chunkPos.x() - 1, chunkPos.z() - 1), new ChunkPos(chunkPos.x() + 1, chunkPos.z() + 1));
+-        // Folia start - region threading
+-        level.moonrise$loadChunksAsync(
+-                pos, 16, net.minecraft.world.level.chunk.status.ChunkStatus.FULL,
+-                ca.spottedleaf.concurrentutil.util.Priority.NORMAL,
+-                (java.util.List<net.minecraft.world.level.chunk.ChunkAccess> _chunks) -> {
+-                    try {
+-                        // Folia end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPosWithRadius(() -> { // Canvas - region threading
+         if (!feature.place(level, level.getChunkSource().getGenerator(), level.getRandom(), pos)) {
+             throw ERROR_FEATURE_FAILED.create();
+         }
+ 
+         String id = featureHolder.key().identifier().toString();
+         source.sendSuccess(() -> Component.translatable("commands.place.feature.success", id, pos.getX(), pos.getY(), pos.getZ()), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-                    } catch (CommandSyntaxException ex) {
+-                        sendMessage(source, ex);
+-                    }
+-                }
+-        );
++        }, pos, 16, level, source); // Canvas - region threading
+         return Command.SINGLE_SUCCESS;
+-        // Folia end - region threading
+     }
+ 
+     public static int placeJigsaw(
+@@ -291,40 +273,21 @@ public class PlaceCommand {
+         ServerLevel level = source.getLevel();
+         ChunkPos chunk = ChunkPos.containing(pos);
+         checkLoaded(level, chunk, chunk);
+-        // Folia start - region threading
+-        level.moonrise$loadChunksAsync(
+-                pos, 16, net.minecraft.world.level.chunk.status.ChunkStatus.FULL,
+-                ca.spottedleaf.concurrentutil.util.Priority.NORMAL,
+-                (java.util.List<net.minecraft.world.level.chunk.ChunkAccess> _chunks) -> {
+-                    try {
+-                        // Folia end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPosWithRadius(() -> { // Canvas - region threading
+         if (!JigsawPlacement.generateJigsaw(level, pool, target, maxDepth, pos, false)) {
+             throw ERROR_JIGSAW_FAILED.create();
+         }
+ 
+         source.sendSuccess(() -> Component.translatable("commands.place.jigsaw.success", pos.getX(), pos.getY(), pos.getZ()), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-                    } catch (CommandSyntaxException ex) {
+-                        sendMessage(source, ex);
+-                    }
+-                }
+-        );
++        }, pos, 16, level, source); // Canvas - region threading
+         return Command.SINGLE_SUCCESS;
+-        // Folia end - region threading
+     }
+ 
+     public static int placeStructure(final CommandSourceStack source, final Holder.Reference<Structure> structureHolder, final BlockPos pos) throws CommandSyntaxException {
+         ServerLevel level = source.getLevel();
+         Structure structure = structureHolder.value();
+         ChunkGenerator chunkGenerator = level.getChunkSource().getGenerator();
+-        // Folia start - region threading
+-        level.moonrise$loadChunksAsync(
+-                pos, 16, net.minecraft.world.level.chunk.status.ChunkStatus.FULL,
+-                ca.spottedleaf.concurrentutil.util.Priority.NORMAL,
+-                (java.util.List<net.minecraft.world.level.chunk.ChunkAccess> _chunks) -> {
+-                    try {
+-                        // Folia end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPosWithRadius(() -> { // Canvas - region threading
+         StructureStart start = structure.generate(
+             structureHolder,
+             level.dimension(),
+@@ -361,15 +324,8 @@ public class PlaceCommand {
+             );
+         String id = structureHolder.key().identifier().toString();
+         source.sendSuccess(() -> Component.translatable("commands.place.structure.success", id, pos.getX(), pos.getY(), pos.getZ()), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-                    } catch (CommandSyntaxException ex) {
+-                        sendMessage(source, ex);
+-                    }
+-                }
+-        );
++        }, pos, 16, level, source); // Canvas - region threading
+         return Command.SINGLE_SUCCESS;
+-        // Folia end - region threading
+     }
+ 
+     public static int placeTemplate(
+@@ -383,13 +339,7 @@ public class PlaceCommand {
+         final boolean strict
+     ) throws CommandSyntaxException {
+         ServerLevel level = source.getLevel();
+-        // Folia start - region threading
+-        level.moonrise$loadChunksAsync(
+-                pos, 16, net.minecraft.world.level.chunk.status.ChunkStatus.FULL,
+-                ca.spottedleaf.concurrentutil.util.Priority.NORMAL,
+-                (java.util.List<net.minecraft.world.level.chunk.ChunkAccess> _chunks) -> {
+-                    try {
+-                        // Folia end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPosWithRadius(() -> { // Canvas - region threading
+         StructureTemplateManager manager = level.getStructureManager();
+ 
+         Optional<StructureTemplate> maybeStructureTemplate;
+@@ -420,15 +370,8 @@ public class PlaceCommand {
+         source.sendSuccess(
+             () -> Component.translatable("commands.place.template.success", Component.translationArg(template), pos.getX(), pos.getY(), pos.getZ()), true
+         );
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-                    } catch (CommandSyntaxException ex) {
+-                        sendMessage(source, ex);
+-                    }
+-                }
+-        );
++        }, pos, 16, level, source); // Canvas - region threading
+         return Command.SINGLE_SUCCESS;
+-        // Folia end - region threading
+     }
+ 
+     private static void checkLoaded(final ServerLevel level, final ChunkPos chunkMin, final ChunkPos chunkMax) throws CommandSyntaxException {
+diff --git a/net/minecraft/server/commands/PlaySoundCommand.java b/net/minecraft/server/commands/PlaySoundCommand.java
+index 53fe9c891456a618f27e85816d3a41bdb6533045..eabaff97357d0e829cc93094a270be8615b1f851 100644
+--- a/net/minecraft/server/commands/PlaySoundCommand.java
++++ b/net/minecraft/server/commands/PlaySoundCommand.java
+@@ -164,6 +164,14 @@ public class PlaySoundCommand {
+         long seed = level.getRandom().nextLong();
+         List<ServerPlayer> playedFor = new ArrayList<>();
+ 
++        // Canvas start - region threading
++
++        // we can't try and filter or do anything beyond this because
++        // the volume can be high enough that the source can be millions
++        // of blocks away, and it can still be heard
++
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> {
++        // Canvas end - region threading
+         for (ServerPlayer player : players) {
+             if (player.level() == level) {
+                 double deltaX = position.x - player.getX();
+@@ -184,10 +192,21 @@ public class PlaySoundCommand {
+                     localVolume = minVolume;
+                 }
+ 
+-                player.connection
++                // Canvas start - region threading
++
++                // we schedule this because the stop sound command is scheduled to the player
++                // so we schedule this to make sure everything remains in sync and ordered
++
++                final Vec3 finalPos = localPosition;
++                final float finalVolume = localVolume;
++
++                player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection
+                     .send(
+-                        new ClientboundSoundPacket(soundHolder, soundSource, localPosition.x(), localPosition.y(), localPosition.z(), localVolume, pitch, seed)
++                        new ClientboundSoundPacket(soundHolder, soundSource, finalPos.x(), finalPos.y(), finalPos.z(), finalVolume, pitch, seed)
+                     );
++                });
++                // Canvas end - region threading
+                 playedFor.add(player);
+             }
+         }
+@@ -206,5 +225,6 @@ public class PlaySoundCommand {
+         }
+ 
+         return count;
++        }, position, level, source); // Canvas - region threading
+     }
+ }
 diff --git a/net/minecraft/server/commands/RecipeCommand.java b/net/minecraft/server/commands/RecipeCommand.java
-index 37014e8da22b7cd72ca05988d7cbcc537b63d6b7..e8f4a96a30b4fe6b41af56dfd8ff86477f6192e0 100644
+index 37014e8da22b7cd72ca05988d7cbcc537b63d6b7..3f567d424bc0dad6f631aefd41eb932498b7b153 100644
 --- a/net/minecraft/server/commands/RecipeCommand.java
 +++ b/net/minecraft/server/commands/RecipeCommand.java
-@@ -83,9 +83,9 @@ public class RecipeCommand {
-         for (ServerPlayer player : players) {
-             // Folia start - region threading
-             ++success;
--            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> {
-+            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Canvas - region threading
-                 newPlayer.awardRecipes(recipes);
--            }, null, 1L);
-+            }); // Canvas - region threading
-             // Folia end - region threading
-         }
+@@ -78,17 +78,22 @@ public class RecipeCommand {
+     }
  
-@@ -110,9 +110,9 @@ public class RecipeCommand {
-         for (ServerPlayer player : players) {
-             // Folia start - region threading
-             ++success;
+     private static int giveRecipes(final CommandSourceStack source, final Collection<ServerPlayer> players, final Collection<RecipeHolder<?>> recipes) throws CommandSyntaxException {
+-        int success = 0;
+-
+-        for (ServerPlayer player : players) {
+-            // Folia start - region threading
+-            ++success;
 -            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> {
-+            player.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newPlayer) -> { // Canvas - region threading
-                 newPlayer.resetRecipes(recipes);
+-                newPlayer.awardRecipes(recipes);
 -            }, null, 1L);
-+            }); // Canvas - region threading
-             // Folia end - region threading
-         }
+-            // Folia end - region threading
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                int addedRecipes = entityPlayer.awardRecipes(recipes);
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(addedRecipes);
++            })
++            .onComplete((success, selected, css) -> giveCallback(success, css, selected, recipes))
++            .start(source);
++        return 1;
++    }
  
++    private static int giveCallback(
++        final int success, final CommandSourceStack source, final Collection<? extends ServerPlayer> players, final Collection<RecipeHolder<?>> recipes
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (success == 0) {
+             throw ERROR_GIVE_FAILED.create();
+         }
+@@ -105,17 +110,22 @@ public class RecipeCommand {
+     }
+ 
+     private static int takeRecipes(final CommandSourceStack source, final Collection<ServerPlayer> players, final Collection<RecipeHolder<?>> recipes) throws CommandSyntaxException {
+-        int success = 0;
+-
+-        for (ServerPlayer player : players) {
+-            // Folia start - region threading
+-            ++success;
+-            player.getBukkitEntity().taskScheduler.schedule((ServerPlayer newPlayer) -> {
+-                newPlayer.resetRecipes(recipes);
+-            }, null, 1L);
+-            // Folia end - region threading
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_int()
++            .with(players)
++            .executes((ServerPlayer entityPlayer) -> {
++                int removedRecipes = entityPlayer.resetRecipes(recipes);
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(removedRecipes);
++            })
++            .onComplete((success, selected, css) -> takeCallback(success, css, selected, recipes))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int takeCallback(
++        final int success, final CommandSourceStack source, final Collection<? extends ServerPlayer> players, final Collection<RecipeHolder<?>> recipes
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (success == 0) {
+             throw ERROR_TAKE_FAILED.create();
+         }
 diff --git a/net/minecraft/server/commands/RideCommand.java b/net/minecraft/server/commands/RideCommand.java
-index 2f6c0784126e1ab22ca7e138452325ebc425001c..ba4984212a674a4f3bb3ca48d4b40b1d86dccb8e 100644
+index 2f6c0784126e1ab22ca7e138452325ebc425001c..032e0bc99a703c8bd5789fffcd99d9ce9ee09980 100644
 --- a/net/minecraft/server/commands/RideCommand.java
 +++ b/net/minecraft/server/commands/RideCommand.java
-@@ -101,7 +101,7 @@ public class RideCommand {
- 
-     // Folia start - region threading
-     private static int dismount(final CommandSourceStack source, final Entity targetOld) throws CommandSyntaxException {
--        targetOld.getBukkitEntity().taskScheduler.schedule((Entity target) -> {
-+        targetOld.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity target) -> { // Canvas - region threading
-             try {
-                 // Folia end - region threading
-         Entity vehicle = target.getVehicle();
-@@ -116,7 +116,7 @@ public class RideCommand {
-             } catch (CommandSyntaxException ex) {
-                 sendMessage(source, ex);
-             }
--        }, null, 1L);
-+        }); // Canvas - region threading
-         return 0;
-         // Folia end - region threading
+@@ -51,22 +51,25 @@ public class RideCommand {
+         );
      }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
+-    private static int mount(final CommandSourceStack source, final Entity targetOld, final Entity vehicleOld) throws CommandSyntaxException { // Folia - region threading
+-        // Folia start - region threading
+-        targetOld.getBukkitEntity().taskScheduler.scheduleOrExecute((Entity target) -> {
+-            try {
+-                Entity vehicle = vehicleOld.getBukkitEntity().getHandleRaw();
++    // Canvas start - region threading
++    private static int mount(final CommandSourceStack source, final Entity target, final Entity vehicle) throws CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(target)
++            .executes((Entity entityTarget) -> {
++                Entity entityVehicle = vehicle.getBukkitEntity().getHandleRaw();
+                 if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(vehicle)) {
+-                    source.sendFailure(Component.literal("Cannot mount entities cross-region"));
+-                    return;
++                    throw io.canvasmc.canvas.command.execution.AbstractCommandExecution.CANNOT_DO_X_CROSS_REGION.create("mount entities");
+                 }
+-                // Folia end - region threading
++                mountAction(source, entityTarget, entityVehicle);
++                return (_) -> null;
++            })
++            .noCompletion()
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++    }
++
++    private static int mountAction(final CommandSourceStack source, final Entity target, final Entity vehicle) throws CommandSyntaxException {
++    // Canvas end - region threading
+         Entity currentVehicle = target.getVehicle();
+         if (currentVehicle != null) {
+             throw ERROR_ALREADY_RIDING.create(target.getDisplayName(), currentVehicle.getDisplayName());
+@@ -89,35 +92,26 @@ public class RideCommand {
+         }
+ 
+         source.sendSuccess(() -> Component.translatable("commands.ride.mount.success", target.getDisplayName(), vehicle.getDisplayName()), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++        return Command.SINGLE_SUCCESS; // Canvas - region threading
+     }
+ 
+-    // Folia start - region threading
+-    private static int dismount(final CommandSourceStack source, final Entity targetOld) throws CommandSyntaxException {
+-        targetOld.getBukkitEntity().taskScheduler.schedule((Entity target) -> {
+-            try {
+-                // Folia end - region threading
+-        Entity vehicle = target.getVehicle();
+-        if (vehicle == null) {
+-            throw ERROR_NOT_RIDING.create(target.getDisplayName());
+-        }
++    // Canvas start - region threading
++    private static int dismount(final CommandSourceStack source, final Entity target) throws CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(target)
++            .executes((Entity entityTarget) -> {
++                Entity vehicle = entityTarget.getVehicle();
++                if (vehicle == null) {
++                    throw ERROR_NOT_RIDING.create(entityTarget.getDisplayName());
++                }
+ 
+-        target.stopRiding();
+-        source.sendSuccess(() -> Component.translatable("commands.ride.dismount.success", target.getDisplayName(), vehicle.getDisplayName()), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        }, null, 1L);
+-        return 0;
+-        // Folia end - region threading
++                entityTarget.stopRiding();
++                source.sendSuccess(() -> Component.translatable("commands.ride.dismount.success", target.getDisplayName(), vehicle.getDisplayName()), true);
++                return (_) -> null;
++            })
++            .noCompletion()
++            .start(source);
++        return Command.SINGLE_SUCCESS;
++    // Canvas end - region threading
+     }
+ }
 diff --git a/net/minecraft/server/commands/SaveAllCommand.java b/net/minecraft/server/commands/SaveAllCommand.java
-index 299991905c24a7018f8ac60d0c16e56fa43cd710..73fdd05b5fdf9b0fc4bcee7d2148bf38c27dd28d 100644
+index 299991905c24a7018f8ac60d0c16e56fa43cd710..abbb8f14a1acc05a647d6a18c23a3cc75bae72e8 100644
 --- a/net/minecraft/server/commands/SaveAllCommand.java
 +++ b/net/minecraft/server/commands/SaveAllCommand.java
-@@ -24,12 +24,48 @@ public class SaveAllCommand {
+@@ -24,12 +24,49 @@ public class SaveAllCommand {
      private static int saveAll(final CommandSourceStack source, final boolean flush) throws CommandSyntaxException {
          source.sendSuccess(() -> Component.translatable("commands.save.saving"), false);
          MinecraftServer server = source.getServer();
@@ -2498,6 +4267,7 @@ index 299991905c24a7018f8ac60d0c16e56fa43cd710..73fdd05b5fdf9b0fc4bcee7d2148bf38
 +
 +        // scoreboards
 +        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
++            // TODO - run full autosave
 +            MinecraftServer.getServer().getScoreboard().storeToSaveDataIfDirty(
 +                MinecraftServer.getServer().getDataStorage().computeIfAbsent(net.minecraft.world.scores.ScoreboardSaveData.TYPE)
 +            );
@@ -2511,242 +4281,339 @@ index 299991905c24a7018f8ac60d0c16e56fa43cd710..73fdd05b5fdf9b0fc4bcee7d2148bf38
      }
  }
 diff --git a/net/minecraft/server/commands/ScoreboardCommand.java b/net/minecraft/server/commands/ScoreboardCommand.java
-index 1e8f4cb55851b89ee2272917fd440e2f8749442f..d492975eeb5a8f4daaab871646365b3e53552ad5 100644
+index 1e8f4cb55851b89ee2272917fd440e2f8749442f..16e1e4572f22992609f9561c711c315c72548b39 100644
 --- a/net/minecraft/server/commands/ScoreboardCommand.java
 +++ b/net/minecraft/server/commands/ScoreboardCommand.java
-@@ -465,17 +465,38 @@ public class ScoreboardCommand {
-         int result = 0;
+@@ -462,19 +462,65 @@ public class ScoreboardCommand {
+         final Objective sourceObjective
+     ) throws CommandSyntaxException {
+         Scoreboard scoreboard = source.getServer().getScoreboard();
+-        int result = 0;
++    // Canvas start - region threading
  
++        final List<net.minecraft.world.entity.Entity> filtered = new java.util.ArrayList<>();
          for (ScoreHolder target : targets) {
 -            ScoreAccess score = scoreboard.getOrCreatePlayerScore(target, targetObjective);
-+            // Canvas start - region threading
- 
+-
 -            for (ScoreHolder from : sources) {
 -                ScoreAccess sourceScore = scoreboard.getOrCreatePlayerScore(from, sourceObjective);
 -                operation.apply(score, sourceScore);
-+            // both the target and source should be on the same region and share
-+            // the same region to be valid for applying operations
-+
-+            // this must be an existing entity
 +            if (!(target instanceof net.minecraft.world.entity.Entity entity)) {
-+                source.sendFailure(Component.literal("Target score holder must be an existing entity, found " + target.getScoreboardName()));
-+                continue;
++                throw TARGET_MUST_BE_ENTITY.create(target.getScoreboardName());
              }
- 
--            result += score.get();
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((targetEntity) -> {
-+                final ScoreAccess score = scoreboard.getOrCreatePlayerScore(targetEntity, targetObjective);
++            filtered.add(entity);
++        }
++
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(filtered)
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                ScoreAccess score = scoreboard.getOrCreatePlayerScore(entity, targetObjective);
 +
 +                for (ScoreHolder from : sources) {
-+                    // Canvas start - region threading
-+                    if (!(from instanceof net.minecraft.world.entity.Entity sourceEntity) || !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(sourceEntity)) {
-+                        source.sendFailure(Component.literal("Source entity not in same region, skipping"));
-+                        continue;
++
++                    // we must ensure the following:
++                    // - the source and target are entities
++                    // - they are both in the same region
++
++                    if (!(from instanceof net.minecraft.world.entity.Entity sourceEntity)) {
++                        throw new SimpleCommandExceptionType(Component.literal("Holder source \"" + from.getScoreboardName() + "\" must be an entity")).create();
 +                    }
++
++                    if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(sourceEntity)) {
++                        throw io.canvasmc.canvas.command.execution.AbstractCommandExecution.CANNOT_DO_X_CROSS_REGION.create("perform score operation");
++                    }
++
++                    // we passed the checks, now we can apply
++
 +                    ScoreAccess sourceScore = scoreboard.getOrCreatePlayerScore(sourceEntity, sourceObjective);
-+                    try {
-+                        operation.apply(score, sourceScore);
-+                    } catch (CommandSyntaxException cse) {
-+                        source.sendFailure(Component.literal(cse.getMessage()));
-+                    }
++                    operation.apply(score, sourceScore);
 +                }
-+            });
-+            // Canvas end - region threading
-         }
  
--        if (targets.size() == 1) {
-+        if (false && targets.size() == 1) { // Canvas - region threading - "result" is no longer accurate
+-            result += score.get();
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(score.get());
++            })
++            .onComplete((result, processed, css) -> performOperationCallback(result, processed.stream().map(ScoreHolder.class::cast).toList(), targetObjective, css))
++            .start(source);
++        return 1;
++    }
++
++    private static final com.mojang.brigadier.exceptions.DynamicCommandExceptionType TARGET_MUST_BE_ENTITY = new com.mojang.brigadier.exceptions.DynamicCommandExceptionType(
++        name -> Component.literal("Holder target \"" + name + "\" must be an entity")
++    );
++    private static final java.util.function.Function<net.minecraft.world.scores.ScoreHolder, net.minecraft.world.entity.Entity> SCORE_HOLDER2ENTITY = (name) -> {
++        if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
++            throw new UnsupportedOperationException(TARGET_MUST_BE_ENTITY.create(name.getScoreboardName()).getMessage());
+         }
++        return entity;
++    };
+ 
++    private static int performOperationCallback(
++        final int result,
++        final Collection<ScoreHolder> targets,
++        final Objective targetObjective,
++        final CommandSourceStack source
++    ) {
++    // Canvas end - region threading
+         if (targets.size() == 1) {
              int finalResult = result;
              source.sendSuccess(
-                 () -> Component.translatable(
-@@ -501,41 +522,40 @@ public class ScoreboardCommand {
+@@ -501,16 +547,36 @@ public class ScoreboardCommand {
          }
  
          Scoreboard scoreboard = source.getServer().getScoreboard();
 -        int count = 0;
-+        // Canvas - region threading
++    // Canvas start - region threading
++        final List<net.minecraft.world.entity.Entity> filtered = new java.util.ArrayList<>();
  
          for (ScoreHolder name : names) {
 -            ScoreAccess score = scoreboard.getOrCreatePlayerScore(name, objective);
 -            if (score.locked()) {
 -                score.unlock();
 -                count++;
-+            // Canvas start - region threading
 +            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
++                throw TARGET_MUST_BE_ENTITY.create(name.getScoreboardName());
              }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((scoreHolder) -> {
-+                ScoreAccess score = scoreboard.getOrCreatePlayerScore(scoreHolder, objective);
++            filtered.add(entity);
+         }
+ 
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(filtered)
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                ScoreAccess score = scoreboard.getOrCreatePlayerScore(entity, objective);
 +                if (score.locked()) {
 +                    score.unlock();
++                    return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
 +                }
-+            });
-+            // Canvas end - region threading
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((count, processed, css) -> enableTriggerCallback(count, processed.stream().map(ScoreHolder.class::cast).toList(), css, objective))
++            .start(source);
++        return 1;
++    }
++
++    private static int enableTriggerCallback(
++        final int count, final Collection<ScoreHolder> names, final CommandSourceStack source, final Objective objective
++    ) throws CommandSyntaxException {
++    // Canvas end - region threading
++
+         if (count == 0) {
+             throw ERROR_TRIGGER_ALREADY_ENABLED.create();
          }
-+        // Canvas start - region threading
-+        source.sendSuccess(
-+            () -> Component.translatable("commands.scoreboard.players.enable.success.multiple", objective.getFormattedDisplayName(), names.size()), true
-+        );
-+        // Canvas end - region threading
- 
--        if (count == 0) {
--            throw ERROR_TRIGGER_ALREADY_ENABLED.create();
--        }
--
--        if (names.size() == 1) {
--            source.sendSuccess(
--                () -> Component.translatable(
--                    "commands.scoreboard.players.enable.success.single", objective.getFormattedDisplayName(), getFirstTargetName(names)
--                ),
--                true
--            );
--        } else {
--            source.sendSuccess(
--                () -> Component.translatable("commands.scoreboard.players.enable.success.multiple", objective.getFormattedDisplayName(), names.size()), true
--            );
--        }
--
--        return count;
-+        return 0; // Canvas - region threading
+@@ -531,13 +597,22 @@ public class ScoreboardCommand {
+         return count;
      }
  
-     private static int resetScores(final CommandSourceStack source, final Collection<ScoreHolder> names) {
+-    private static int resetScores(final CommandSourceStack source, final Collection<ScoreHolder> names) {
++    // Canvas start - region threading
++    private static int resetScores(final CommandSourceStack source, final Collection<ScoreHolder> names) throws CommandSyntaxException {
          Scoreboard scoreboard = source.getServer().getScoreboard();
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<net.minecraft.world.entity.Entity>())
++            .with(names.stream().map(SCORE_HOLDER2ENTITY))
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                scoreboard.resetAllPlayerScores(entity);
++                return (list) -> list.add(entity);
++            })
++            .onComplete((filtered, _, css) -> resetScoresCallback(filtered.castAllTo(ScoreHolder.class).copyOf(), css))
++            .start(source);
++        return 1;
++    }
  
-         for (ScoreHolder name : names) {
+-        for (ScoreHolder name : names) {
 -            scoreboard.resetAllPlayerScores(name);
-+            // Canvas start - region threading
-+            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
-+            }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute(scoreboard::resetAllPlayerScores);
-+            // Canvas end - region threading
-         }
- 
+-        }
+-
++    private static int resetScoresCallback(final Collection<ScoreHolder> names, final CommandSourceStack source) {
++    // Canvas end - region threading
          if (names.size() == 1) {
-@@ -551,7 +571,13 @@ public class ScoreboardCommand {
-         Scoreboard scoreboard = source.getServer().getScoreboard();
+             source.sendSuccess(() -> Component.translatable("commands.scoreboard.players.reset.all.single", getFirstTargetName(names)), true);
+         } else {
+@@ -547,13 +622,22 @@ public class ScoreboardCommand {
+         return names.size();
+     }
  
-         for (ScoreHolder name : names) {
+-    private static int resetScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective) {
++    // Canvas start - region threading
++    private static int resetScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective) throws CommandSyntaxException {
+         Scoreboard scoreboard = source.getServer().getScoreboard();
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<net.minecraft.world.entity.Entity>())
++            .with(names.stream().map(SCORE_HOLDER2ENTITY))
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                scoreboard.resetSinglePlayerScore(entity, objective);
++                return (list) -> list.add(entity);
++            })
++            .onComplete((filtered, _, css) -> resetScoreCallback(css, filtered.castAllTo(ScoreHolder.class).copyOf(), objective))
++            .start(source);
++        return 1;
++    }
+ 
+-        for (ScoreHolder name : names) {
 -            scoreboard.resetSinglePlayerScore(name, objective);
-+            // Canvas start - region threading
-+            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
-+            }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((scoreHolder) ->
-+                scoreboard.resetSinglePlayerScore(scoreHolder, objective));
-+            // Canvas end - region threading
-         }
- 
+-        }
+-
++    private static int resetScoreCallback(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective) {
++    // Canvas end - region threading
          if (names.size() == 1) {
-@@ -574,7 +600,13 @@ public class ScoreboardCommand {
-         Scoreboard scoreboard = source.getServer().getScoreboard();
+             source.sendSuccess(
+                 () -> Component.translatable(
+@@ -570,13 +654,24 @@ public class ScoreboardCommand {
+         return names.size();
+     }
  
-         for (ScoreHolder name : names) {
+-    private static int setScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value) {
++    // Canvas start - region threading
++    private static int setScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value) throws CommandSyntaxException {
+         Scoreboard scoreboard = source.getServer().getScoreboard();
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<net.minecraft.world.entity.Entity>())
++            .with(names.stream().map(SCORE_HOLDER2ENTITY))
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                scoreboard.getOrCreatePlayerScore(entity, objective).set(value);
++                return (list) -> list.add(entity);
++            })
++            .onComplete((filtered, _, css) -> setScoreCallback(css, filtered.castAllTo(ScoreHolder.class).copyOf(), objective, value))
++            .start(source);
++        return 1;
++    }
+ 
+-        for (ScoreHolder name : names) {
 -            scoreboard.getOrCreatePlayerScore(name, objective).set(value);
-+            // Canvas start - region threading
-+            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
-+            }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((scoreHolder) ->
-+                scoreboard.getOrCreatePlayerScore(scoreHolder, objective).set(value));
-+            // Canvas end - region threading
-         }
- 
+-        }
+-
++    private static int setScoreCallback(
++        final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value
++    ) {
++    // Canvas end - region threading
          if (names.size() == 1) {
-@@ -600,7 +632,13 @@ public class ScoreboardCommand {
-         Scoreboard scoreboard = source.getServer().getScoreboard();
+             source.sendSuccess(
+                 () -> Component.translatable(
+@@ -596,13 +691,24 @@ public class ScoreboardCommand {
  
-         for (ScoreHolder name : names) {
+     private static int setScoreDisplay(
+         final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final @Nullable Component display
+-    ) {
++    ) throws CommandSyntaxException { // Canvas - region threading
+         Scoreboard scoreboard = source.getServer().getScoreboard();
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(names.stream().map(SCORE_HOLDER2ENTITY))
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                scoreboard.getOrCreatePlayerScore(entity, objective).display(display);
++                return (_) -> null;
++            })
++            .onComplete((_, processed, css) -> setScoreDisplayCallback(css, processed.stream().map(ScoreHolder.class::cast).toList(), objective, display))
++            .start(source);
++        return 1;
++    }
+ 
+-        for (ScoreHolder name : names) {
 -            scoreboard.getOrCreatePlayerScore(name, objective).display(display);
-+            // Canvas start - region threading
-+            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
-+            }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((scoreHolder) ->
-+                scoreboard.getOrCreatePlayerScore(scoreHolder, objective).display(display));
-+            // Canvas end - region threading
-         }
- 
+-        }
+-
++    private static int setScoreDisplayCallback(
++        final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final @Nullable Component display
++    ) {
++    // Canvas end - region threading
          if (display == null) {
-@@ -644,7 +682,13 @@ public class ScoreboardCommand {
+             if (names.size() == 1) {
+                 source.sendSuccess(
+@@ -640,13 +746,24 @@ public class ScoreboardCommand {
+ 
+     private static int setScoreNumberFormat(
+         final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final @Nullable NumberFormat numberFormat
+-    ) {
++    ) throws CommandSyntaxException { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(names.stream().map(SCORE_HOLDER2ENTITY))
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                scoreboard.getOrCreatePlayerScore(entity, objective).numberFormatOverride(numberFormat);
++                return (_) -> null;
++            })
++            .onComplete((_, filtered, css) -> setScoreNumberFormatCallback(css, filtered.stream().map(ScoreHolder.class::cast).toList(), objective, numberFormat))
++            .start(source);
++        return 1;
++    }
  
-         for (ScoreHolder name : names) {
+-        for (ScoreHolder name : names) {
 -            scoreboard.getOrCreatePlayerScore(name, objective).numberFormatOverride(numberFormat);
-+            // Canvas start - region threading
-+            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
-+            }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((scoreHolder) ->
-+                scoreboard.getOrCreatePlayerScore(scoreHolder, objective).numberFormatOverride(numberFormat));
-+            // Canvas end - region threading
-         }
- 
+-        }
+-
++    private static int setScoreNumberFormatCallback(
++        final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final @Nullable NumberFormat numberFormat
++    ) {
++    // Canvas end - region threading
          if (numberFormat == null) {
-@@ -687,20 +731,18 @@ public class ScoreboardCommand {
-         int result = 0;
+             if (names.size() == 1) {
+                 source.sendSuccess(
+@@ -682,16 +799,25 @@ public class ScoreboardCommand {
+         return names.size();
+     }
  
-         for (ScoreHolder name : names) {
+-    private static int addScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value) {
++    // Canvas start - region threading
++    private static int addScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value) throws CommandSyntaxException {
+         Scoreboard scoreboard = source.getServer().getScoreboard();
+-        int result = 0;
+-
+-        for (ScoreHolder name : names) {
 -            ScoreAccess score = scoreboard.getOrCreatePlayerScore(name, objective);
 -            score.set(score.get() + value);
 -            result += score.get();
-+            // Canvas start - region threading
-+            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
-+            }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((scoreHolder) -> {
-+                ScoreAccess score = scoreboard.getOrCreatePlayerScore(scoreHolder, objective);
+-        }
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(names.stream().map(SCORE_HOLDER2ENTITY))
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                ScoreAccess score = scoreboard.getOrCreatePlayerScore(entity, objective);
 +                score.set(score.get() + value);
-+            });
-+            // Canvas end - region threading
-         }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(score.get());
++            })
++            .onComplete((result, filtered, css) -> addScoreCallback(result, css, filtered.stream().map(ScoreHolder.class::cast).toList(), objective, value))
++            .start(source);
++        return 1;
++    }
  
--        if (names.size() == 1) {
--            int finalResult = result;
--            source.sendSuccess(
--                () -> Component.translatable(
--                    "commands.scoreboard.players.add.success.single", value, objective.getFormattedDisplayName(), getFirstTargetName(names), finalResult
--                ),
--                true
--            );
--        } else {
-+        { // Canvas - region threading
++    private static int addScoreCallback(
++        final int result, final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value
++    ) {
++    // Canvas end - region threading
+         if (names.size() == 1) {
+             int finalResult = result;
              source.sendSuccess(
-                 () -> Component.translatable("commands.scoreboard.players.add.success.multiple", value, objective.getFormattedDisplayName(), names.size()),
-                 true
-@@ -715,20 +757,18 @@ public class ScoreboardCommand {
-         int result = 0;
+@@ -710,16 +836,25 @@ public class ScoreboardCommand {
+         return result;
+     }
  
-         for (ScoreHolder name : names) {
+-    private static int removeScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value) {
++    // Canvas start - region threading
++    private static int removeScore(final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value) throws CommandSyntaxException {
+         Scoreboard scoreboard = source.getServer().getScoreboard();
+-        int result = 0;
+-
+-        for (ScoreHolder name : names) {
 -            ScoreAccess score = scoreboard.getOrCreatePlayerScore(name, objective);
 -            score.set(score.get() - value);
 -            result += score.get();
-+            // Canvas start - region threading
-+            if (!(name instanceof net.minecraft.world.entity.Entity entity)) {
-+                throw new UnsupportedOperationException("Score holder must be an entity");
-+            }
-+            entity.getBukkitEntity().taskScheduler.scheduleOrExecute((scoreHolder) -> {
-+                ScoreAccess score = scoreboard.getOrCreatePlayerScore(scoreHolder, objective);
+-        }
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(names.stream().map(SCORE_HOLDER2ENTITY))
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                ScoreAccess score = scoreboard.getOrCreatePlayerScore(entity, objective);
 +                score.set(score.get() - value);
-+            });
-+            // Canvas end - region threading
-         }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.addInt(score.get());
++            })
++            .onComplete((result, filtered, css) -> removeScoreCallback(result, css, filtered.stream().map(ScoreHolder.class::cast).toList(), objective, value))
++            .start(source);
++        return 1;
++    }
  
--        if (names.size() == 1) {
--            int finalResult = result;
--            source.sendSuccess(
--                () -> Component.translatable(
--                    "commands.scoreboard.players.remove.success.single", value, objective.getFormattedDisplayName(), getFirstTargetName(names), finalResult
--                ),
--                true
--            );
--        } else {
-+        { // Canvas - region threading
++    private static int removeScoreCallback(
++        final int result, final CommandSourceStack source, final Collection<ScoreHolder> names, final Objective objective, final int value
++    ) {
++    // Canvas end - region threading
+         if (names.size() == 1) {
+             int finalResult = result;
              source.sendSuccess(
-                 () -> Component.translatable("commands.scoreboard.players.remove.success.multiple", value, objective.getFormattedDisplayName(), names.size()),
-                 true
-@@ -755,12 +795,18 @@ public class ScoreboardCommand {
+@@ -755,12 +890,18 @@ public class ScoreboardCommand {
      }
  
      private static int listTrackedPlayerScores(final CommandSourceStack source, final ScoreHolder entity) {
@@ -2768,7 +4635,7 @@ index 1e8f4cb55851b89ee2272917fd440e2f8749442f..d492975eeb5a8f4daaab871646365b3e
              );
              Object2IntMaps.fastForEach(
                  scores,
-@@ -773,10 +819,17 @@ public class ScoreboardCommand {
+@@ -773,10 +914,14 @@ public class ScoreboardCommand {
              );
          }
  
@@ -2780,174 +4647,271 @@ index 1e8f4cb55851b89ee2272917fd440e2f8749442f..d492975eeb5a8f4daaab871646365b3e
      }
  
      private static int clearDisplaySlot(final CommandSourceStack source, final DisplaySlot slot) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
          if (scoreboard.getDisplayObjective(slot) == null) {
              throw ERROR_DISPLAY_SLOT_ALREADY_EMPTY.create();
-@@ -784,10 +837,20 @@ public class ScoreboardCommand {
+@@ -784,10 +929,12 @@ public class ScoreboardCommand {
  
          scoreboard.setDisplayObjective(slot, null);
          source.sendSuccess(() -> Component.translatable("commands.scoreboard.objectives.display.cleared", slot.getSerializedName()), true);
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
          return 0;
      }
  
      private static int setDisplaySlot(final CommandSourceStack source, final DisplaySlot slot, final Objective objective) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
          if (scoreboard.getDisplayObjective(slot) == objective) {
              throw ERROR_DISPLAY_SLOT_ALREADY_SET.create();
-@@ -797,10 +860,17 @@ public class ScoreboardCommand {
+@@ -797,10 +944,12 @@ public class ScoreboardCommand {
          source.sendSuccess(
              () -> Component.translatable("commands.scoreboard.objectives.display.set", slot.getSerializedName(), objective.getDisplayName()), true
          );
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
          return 0;
      }
  
      private static int setDisplayName(final CommandSourceStack source, final Objective objective, final Component displayName) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (!objective.getDisplayName().equals(displayName)) {
              objective.setDisplayName(displayName);
              source.sendSuccess(
-@@ -808,11 +878,13 @@ public class ScoreboardCommand {
+@@ -808,11 +957,13 @@ public class ScoreboardCommand {
                  true
              );
          }
-+        }); // Canvas - region threading
++        }, source); // Canvas - region threading
  
          return 0;
      }
  
      private static int setDisplayAutoUpdate(final CommandSourceStack source, final Objective objective, final boolean displayAutoUpdate) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (objective.displayAutoUpdate() != displayAutoUpdate) {
              objective.setDisplayAutoUpdate(displayAutoUpdate);
              if (displayAutoUpdate) {
-@@ -831,38 +903,51 @@ public class ScoreboardCommand {
+@@ -831,38 +982,48 @@ public class ScoreboardCommand {
                  );
              }
          }
-+        }); // Canvas - region threading
++        }, source); // Canvas - region threading
  
          return 0;
      }
  
      private static int setObjectiveFormat(final CommandSourceStack source, final Objective objective, final @Nullable NumberFormat numberFormat) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          objective.setNumberFormat(numberFormat);
          if (numberFormat != null) {
              source.sendSuccess(() -> Component.translatable("commands.scoreboard.objectives.modify.objectiveFormat.set", objective.getName()), true);
          } else {
              source.sendSuccess(() -> Component.translatable("commands.scoreboard.objectives.modify.objectiveFormat.clear", objective.getName()), true);
          }
-+        }); // Canvas - region threading
++        }, source); // Canvas - region threading
  
          return 0;
      }
  
      private static int setRenderType(final CommandSourceStack source, final Objective objective, final ObjectiveCriteria.RenderType renderType) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (objective.getRenderType() != renderType) {
              objective.setRenderType(renderType);
              source.sendSuccess(() -> Component.translatable("commands.scoreboard.objectives.modify.rendertype", objective.getFormattedDisplayName()), true);
          }
-+        }); // Canvas - region threading
++        }, source); // Canvas - region threading
  
          return 0;
      }
  
      private static int removeObjective(final CommandSourceStack source, final Objective objective) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
          scoreboard.removeObjective(objective);
          source.sendSuccess(() -> Component.translatable("commands.scoreboard.objectives.remove.success", objective.getFormattedDisplayName()), true);
 -        return scoreboard.getObjectives().size();
 +        // Canvas start - region threading
-+        });
-+        return 0;
++        }, source);
++        return 1;
 +        // Canvas end - region threading
      }
  
      private static int addObjective(final CommandSourceStack source, final String name, final ObjectiveCriteria criteria, final Component displayName) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
          if (scoreboard.getObjective(name) != null) {
              throw ERROR_OBJECTIVE_ALREADY_EXISTS.create();
-@@ -871,7 +956,14 @@ public class ScoreboardCommand {
+@@ -871,7 +1032,10 @@ public class ScoreboardCommand {
          scoreboard.addObjective(name, criteria, displayName, criteria.getDefaultRenderType(), false, null);
          Objective objective = scoreboard.getObjective(name);
          source.sendSuccess(() -> Component.translatable("commands.scoreboard.objectives.add.success", objective.getFormattedDisplayName()), true);
 -        return scoreboard.getObjectives().size();
-+        return; // Canvas - region threading
 +        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
++        }, source);
++        return 1;
 +        // Canvas end - region threading
      }
  
      private static int listObjectives(final CommandSourceStack source) {
+diff --git a/net/minecraft/server/commands/SetBlockCommand.java b/net/minecraft/server/commands/SetBlockCommand.java
+index ec789ef9bebab2743647d2e73d6a6e810e0d7a43..15aaa85fd7c935942acf868f9e5003a6f3177179 100644
+--- a/net/minecraft/server/commands/SetBlockCommand.java
++++ b/net/minecraft/server/commands/SetBlockCommand.java
+@@ -98,12 +98,7 @@ public class SetBlockCommand {
+         );
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
++    // Canvas - region threading
+     private static int setBlock(
+         final CommandSourceStack source,
+         final BlockPos pos,
+@@ -113,11 +108,7 @@ public class SetBlockCommand {
+         final boolean strict
+     ) throws CommandSyntaxException {
+         ServerLevel level = source.getLevel();
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
+-                level, pos.getX() >> 4, pos.getZ() >> 4, () -> {
+-                    try {
+-                        // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> { // Canvas - region threading
+         if (level.isDebug()) {
+             throw ERROR_FAILED.create();
+         }
+@@ -145,14 +136,8 @@ public class SetBlockCommand {
+         }
+ 
+         source.sendSuccess(() -> Component.translatable("commands.setblock.success", pos.getX(), pos.getY(), pos.getZ()), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-                    } catch (CommandSyntaxException ex) {
+-                        sendMessage(source, ex);
+-                    }
+-                });
+         return Command.SINGLE_SUCCESS;
+-        // Folia end - region threading
++        }, pos, level, source); // Canvas - region threading
+     }
+ 
+     public enum Mode {
+diff --git a/net/minecraft/server/commands/SetSpawnCommand.java b/net/minecraft/server/commands/SetSpawnCommand.java
+index 2dfc4242e7d11b1a66fcdb60f31b5b61279438b1..4296975226e9d3cc36ef466f9b515598f52781ec 100644
+--- a/net/minecraft/server/commands/SetSpawnCommand.java
++++ b/net/minecraft/server/commands/SetSpawnCommand.java
+@@ -68,24 +68,41 @@ public class SetSpawnCommand {
+         );
+     }
+ 
+-    private static int setSpawn(final CommandSourceStack source, final Collection<ServerPlayer> targets, final BlockPos pos, final Coordinates rotation) {
++    private static int setSpawn(final CommandSourceStack source, final Collection<ServerPlayer> targets, final BlockPos pos, final Coordinates rotation) throws com.mojang.brigadier.exceptions.CommandSyntaxException { // Canvas - region threading
+         ResourceKey<Level> dimension = source.getLevel().dimension();
+         Vec2 rotationVector = rotation.getRotation(source);
+         float yaw = Mth.wrapDegrees(rotationVector.y);
+         float pitch = Mth.clamp(rotationVector.x, -90.0F, 90.0F);
+ 
+-        final Collection<ServerPlayer> actualTargets = new java.util.ArrayList<>(); // Paper - Add PlayerSetSpawnEvent
+-        for (ServerPlayer target : targets) {
+-            // Paper start - Add PlayerSetSpawnEvent
+-            // Folia start - region threading
+-            target.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer newTarget) -> {
+-                newTarget.setRespawnPosition(new ServerPlayer.RespawnConfig(LevelData.RespawnData.of(dimension, pos, yaw, pitch), true), false, com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.COMMAND);
+-            });
+-            if (true) { // Folia end - region threading
+-                actualTargets.add(target);
+-            }
+-            // Paper end - Add PlayerSetSpawnEvent
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<io.canvasmc.canvas.util.CollectingList<ServerPlayer>, ServerPlayer>
++                _abstract(new io.canvasmc.canvas.util.CollectingList<>())
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                // Paper start - Add PlayerSetSpawnEvent
++                boolean pass = entityPlayer.setRespawnPosition(
++                    new ServerPlayer.RespawnConfig(LevelData.RespawnData.of(dimension, pos, yaw, pitch), true),
++                    false,
++                    com.destroystokyo.paper.event.player.PlayerSetSpawnEvent.Cause.COMMAND
++                );
++                // Paper end - Add PlayerSetSpawnEvent
++                return (list) -> pass ? list.add(entityPlayer) : list;
++            })
++            .onComplete((actualTargets, _, css) -> setSpawnCallback(actualTargets.copyOf(), pos, rotation, dimension, css, yaw, pitch))
++            .start(source);
++        return 1;
++    }
++
++    private static int setSpawnCallback(
++        final Collection<ServerPlayer> actualTargets,
++        final BlockPos pos,
++        final Coordinates rotation,
++        final ResourceKey<Level> dimension,
++        final CommandSourceStack source,
++        final float yaw,
++        final float pitch
++    ) {
++    // Canvas end - region threading
+         // Paper start - Add PlayerSetSpawnEvent
+         if (actualTargets.isEmpty()) {
+             return 0;
+diff --git a/net/minecraft/server/commands/SetWorldSpawnCommand.java b/net/minecraft/server/commands/SetWorldSpawnCommand.java
+index 2ec59a43af72a40dcacda4d3bff11b19fc21fd69..c98dd1d32519f1b575ce68160a032da86309df7f 100644
+--- a/net/minecraft/server/commands/SetWorldSpawnCommand.java
++++ b/net/minecraft/server/commands/SetWorldSpawnCommand.java
+@@ -32,6 +32,7 @@ public class SetWorldSpawnCommand {
+     }
+ 
+     private static int setSpawn(final CommandSourceStack source, final BlockPos pos, final Coordinates rotation) {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         ServerLevel level = source.getLevel();
+         Vec2 rotationVector = rotation.getRotation(source);
+         float yaw = rotationVector.y;
+@@ -50,6 +51,6 @@ public class SetWorldSpawnCommand {
+             ),
+             true
+         );
+-        return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
+     }
+ }
 diff --git a/net/minecraft/server/commands/SpectateCommand.java b/net/minecraft/server/commands/SpectateCommand.java
-index 3cb3b93851ccbbb8879fc871954da30a12dd54a4..39cba393723b0910011eee12abd45f33f2723a3b 100644
+index 3cb3b93851ccbbb8879fc871954da30a12dd54a4..7f901b5650dbfce454196e268fdeb9d01eee776d 100644
 --- a/net/minecraft/server/commands/SpectateCommand.java
 +++ b/net/minecraft/server/commands/SpectateCommand.java
-@@ -38,7 +38,17 @@ public class SpectateCommand {
+@@ -38,7 +38,12 @@ public class SpectateCommand {
          );
      }
  
 -    private static int spectate(final CommandSourceStack source, final @Nullable Entity target, final ServerPlayer player) throws CommandSyntaxException {
 +    // Canvas start - region threading
-+    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
-+        src.sendFailure((Component)ex.getRawMessage());
-+    }
++    private static int spectate(final CommandSourceStack source, final @Nullable Entity target, final ServerPlayer spectator) throws CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(spectator)
++            .executes((ServerPlayer player) -> {
 +    // Canvas end - region threading
-+
-+    private static int spectate(final CommandSourceStack source, final @Nullable Entity target, final ServerPlayer spectator) throws CommandSyntaxException { // Folia - region threading
-+        // Canvas start - region threading
-+        spectator.getBukkitEntity().taskScheduler.scheduleOrExecute((ServerPlayer player) -> {
-+            try {
-+        // Canvas end - region threading
          if (player == target) {
              throw ERROR_SELF.create();
          }
-@@ -58,6 +68,13 @@ public class SpectateCommand {
+@@ -58,6 +63,12 @@ public class SpectateCommand {
              source.sendSuccess(() -> Component.translatable("commands.spectate.success.stopped"), false);
          }
  
 +        // Canvas start - region threading
-+        return;
-+            } catch (CommandSyntaxException ex) {
-+                sendMessage(source, ex);
-+            }
-+        });
++                return (_) -> null;
++            })
++            .noCompletion()
++            .start(source);
 +        // Canvas end - region threading
          return Command.SINGLE_SUCCESS;
      }
  }
 diff --git a/net/minecraft/server/commands/SpreadPlayersCommand.java b/net/minecraft/server/commands/SpreadPlayersCommand.java
-index f6f7d738ceecab197607a2017616b03bac8b4de7..de1d824bff34b05d4dcbd790076fe9106392ee7f 100644
+index f6f7d738ceecab197607a2017616b03bac8b4de7..4e6d31fcab17534fa12f85ae2922c595e6823805 100644
 --- a/net/minecraft/server/commands/SpreadPlayersCommand.java
 +++ b/net/minecraft/server/commands/SpreadPlayersCommand.java
 @@ -32,6 +32,45 @@ import net.minecraft.world.phys.Vec2;
@@ -2996,7 +4960,7 @@ index f6f7d738ceecab197607a2017616b03bac8b4de7..de1d824bff34b05d4dcbd790076fe910
      private static final int MAX_ITERATION_COUNT = 10000;
      private static final Dynamic4CommandExceptionType ERROR_FAILED_TO_SPREAD_TEAMS = new Dynamic4CommandExceptionType(
          (count, x, z, recommended) -> Component.translatableEscape("commands.spreadplayers.failed.teams", count, x, z, recommended)
-@@ -119,11 +158,32 @@ public class SpreadPlayersCommand {
+@@ -119,33 +158,216 @@ public class SpreadPlayersCommand {
          double minZ = center.y - maxRange;
          double maxX = center.x + maxRange;
          double maxZ = center.y + maxRange;
@@ -3005,6 +4969,17 @@ index f6f7d738ceecab197607a2017616b03bac8b4de7..de1d824bff34b05d4dcbd790076fe910
 -        );
 -        spreadPositions(center, spreadDistance, level, random, minX, minZ, maxX, maxZ, maxHeight, positions, respectTeams);
 -        double distance = setPlayerPositions(entities, level, positions, maxHeight, respectTeams);
+-        source.sendSuccess(
+-            () -> Component.translatable(
+-                "commands.spreadplayers.success." + (respectTeams ? "teams" : "entities"),
+-                positions.length,
+-                center.x,
+-                center.y,
+-                String.format(Locale.ROOT, "%.2f", distance)
+-            ),
+-            true
+-        );
+-        return positions.length;
 +        // Canvas start - region threading
 +        EXECUTOR.queue(() -> {
 +            RandomSource fasterRandom = io.canvasmc.canvas.GlobalConfiguration.createFastRandom();
@@ -3029,20 +5004,24 @@ index f6f7d738ceecab197607a2017616b03bac8b4de7..de1d824bff34b05d4dcbd790076fe910
 +                source.sendFailure(Component.literal(ex.getMessage()));
 +            } catch (Throwable t) {
 +                net.minecraft.server.MinecraftServer.LOGGER.error("An error occurred while spreading players asynchronously", t);
++                source.sendFailure(Component.literal("An error occurred while trying to spread players. Check console"));
++            } finally {
++                double distance = canvas$teleportEntities(entities, level, positions, maxHeight, respectTeams);
++                source.sendSuccess(
++                    () -> Component.translatable(
++                        "commands.spreadplayers.success." + (respectTeams ? "teams" : "entities"),
++                        positions.length,
++                        center.x,
++                        center.y,
++                        String.format(Locale.ROOT, "%.2f", distance)
++                    ),
++                    true
++                );
 +            }
-+        double distance = canvas$teleportEntities(entities, level, positions, maxHeight, respectTeams);
-         source.sendSuccess(
-             () -> Component.translatable(
-                 "commands.spreadplayers.success." + (respectTeams ? "teams" : "entities"),
-@@ -134,18 +194,178 @@ public class SpreadPlayersCommand {
-             ),
-             true
-         );
--        return positions.length;
 +        });
 +        return entities.size(); // original is 'positions.length'
 +        // Canvas end - region threading
-     }
++    }
 +    // Canvas start - region threading
 +
 +    private static void canvas$spreadRegionThreading(
@@ -3143,8 +5122,8 @@ index f6f7d738ceecab197607a2017616b03bac8b4de7..de1d824bff34b05d4dcbd790076fe910
 +                );
 +            }
 +        }
-+    }
-+
+     }
+ 
 +    private static double canvas$teleportEntities(
 +        Collection<? extends Entity> entities, ServerLevel world, SpreadPlayersCommand.Position[] positions, int maxY, boolean respectTeams
 +    ) {
@@ -3200,7 +5179,7 @@ index f6f7d738ceecab197607a2017616b03bac8b4de7..de1d824bff34b05d4dcbd790076fe910
 +        return entities.size() < 2 ? 0.0 : totalMinDistance / entities.size();
 +    }
 +    // Canvas end - region threading
- 
++
      private static int getNumberOfTeams(final Collection<? extends Entity> players) {
          Set<Team> teams = Sets.newHashSet();
  
@@ -3218,8 +5197,267 @@ index f6f7d738ceecab197607a2017616b03bac8b4de7..de1d824bff34b05d4dcbd790076fe910
          }
  
          return teams.size();
+diff --git a/net/minecraft/server/commands/StopSoundCommand.java b/net/minecraft/server/commands/StopSoundCommand.java
+index 288a78caf7e537ee1a417f674d2568edf83d588e..dbad09c333da677d66e9bd19512ce6b4d9e03408 100644
+--- a/net/minecraft/server/commands/StopSoundCommand.java
++++ b/net/minecraft/server/commands/StopSoundCommand.java
+@@ -46,13 +46,23 @@ public class StopSoundCommand {
+ 
+     private static int stopSound(
+         final CommandSourceStack source, final Collection<ServerPlayer> targets, final @Nullable SoundSource soundSource, final @Nullable Identifier sound
+-    ) {
++    ) throws com.mojang.brigadier.exceptions.CommandSyntaxException { // Canvas - region threading
+         ClientboundStopSoundPacket packet = new ClientboundStopSoundPacket(sound, soundSource);
+ 
+-        for (ServerPlayer player : targets) {
+-            player.connection.send(packet);
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.send(packet);
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> stopSoundCallback(css, selected, soundSource, sound))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int stopSoundCallback(final CommandSourceStack source, final Collection<? extends ServerPlayer> targets, final @Nullable SoundSource soundSource, final @Nullable Identifier sound) {
++    // Canvas end - region threading
+         if (soundSource != null) {
+             if (sound != null) {
+                 source.sendSuccess(
+diff --git a/net/minecraft/server/commands/StopwatchCommand.java b/net/minecraft/server/commands/StopwatchCommand.java
+index 03bc08a21ea6fcedcfa6e61bb83604083a5c263e..0c01d5436305d640999925587057fcb13b78e665 100644
+--- a/net/minecraft/server/commands/StopwatchCommand.java
++++ b/net/minecraft/server/commands/StopwatchCommand.java
+@@ -69,6 +69,7 @@ public class StopwatchCommand {
+     }
+ 
+     private static int createStopwatch(final CommandSourceStack source, final Identifier id) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         MinecraftServer server = source.getServer();
+         Stopwatches stopwatches = server.getStopwatches();
+         Stopwatch now = new Stopwatch(Stopwatches.currentTime());
+@@ -78,9 +79,11 @@ public class StopwatchCommand {
+ 
+         source.sendSuccess(() -> Component.translatable("commands.stopwatch.create.success", Component.translationArg(id)), true);
+         return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int queryStopwatch(final CommandSourceStack source, final Identifier id, final double scale) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         MinecraftServer server = source.getServer();
+         Stopwatches stopwatches = server.getStopwatches();
+         Stopwatch stopwatch = stopwatches.get(id);
+@@ -92,9 +95,11 @@ public class StopwatchCommand {
+         double elapsedSeconds = stopwatch.elapsedSeconds(currentTime);
+         source.sendSuccess(() -> Component.translatable("commands.stopwatch.query", Component.translationArg(id), elapsedSeconds), true);
+         return (int)(elapsedSeconds * scale);
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int restartStopwatch(final CommandSourceStack source, final Identifier id) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         MinecraftServer server = source.getServer();
+         Stopwatches stopwatches = server.getStopwatches();
+         if (!stopwatches.update(id, stopwatch -> new Stopwatch(Stopwatches.currentTime()))) {
+@@ -103,9 +108,11 @@ public class StopwatchCommand {
+ 
+         source.sendSuccess(() -> Component.translatable("commands.stopwatch.restart.success", Component.translationArg(id)), true);
+         return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int removeStopwatch(final CommandSourceStack source, final Identifier id) throws CommandSyntaxException {
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         MinecraftServer server = source.getServer();
+         Stopwatches stopwatches = server.getStopwatches();
+         if (!stopwatches.remove(id)) {
+@@ -114,5 +121,6 @@ public class StopwatchCommand {
+ 
+         source.sendSuccess(() -> Component.translatable("commands.stopwatch.remove.success", Component.translationArg(id)), true);
+         return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
+     }
+ }
+diff --git a/net/minecraft/server/commands/SummonCommand.java b/net/minecraft/server/commands/SummonCommand.java
+index 14b3adcf74b644f05199680db1efd4af27e19c8f..84d7fcde9604274feeac0b13cff54f9217efa70e 100644
+--- a/net/minecraft/server/commands/SummonCommand.java
++++ b/net/minecraft/server/commands/SummonCommand.java
+@@ -98,15 +98,12 @@ public class SummonCommand {
+             throw ERROR_FAILED.create();
+         }
+ 
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
+-                level, entity.chunkPosition().x(), entity.chunkPosition().z(), () -> {
+-                    // Folia end - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeAtPos(() -> { // Canvas - region threading
+         if (finalize && entity instanceof Mob mob) {
+             mob.finalizeSpawn(source.getLevel(), source.getLevel().getCurrentDifficultyAt(entity.blockPosition()), EntitySpawnReason.COMMAND, null);
+         }
+         level.tryAddFreshEntityWithPassengers(entity, org.bukkit.event.entity.CreatureSpawnEvent.SpawnReason.COMMAND); // Folia - region threading
+-        }); // Folia - region threading
++        }, pos, level, source); // Canvas - region threading - tryAddFreshEntityWithPassengers has handling in EntityLookup for duplicate UUIDs, this is fine
+ 
+         if (false) { // CraftBukkit - pass a spawn reason of "COMMAND" // Folia - region threading
+             throw ERROR_DUPLICATE_UUID.create();
+diff --git a/net/minecraft/server/commands/SwingCommand.java b/net/minecraft/server/commands/SwingCommand.java
+index 82f38edebe847ff138bbf5ffb98b7c881b50ad50..277d571730ea912167310bcebf392a1d32557744 100644
+--- a/net/minecraft/server/commands/SwingCommand.java
++++ b/net/minecraft/server/commands/SwingCommand.java
+@@ -38,15 +38,23 @@ public class SwingCommand {
+     }
+ 
+     private static int swing(final CommandSourceStack source, final Collection<? extends Entity> targets, final InteractionHand hand) throws CommandSyntaxException {
+-        int livingEntitiesCount = 0;
+-
+-        for (Entity entity : targets) {
+-            if (entity instanceof LivingEntity livingEntity) {
+-                livingEntity.swing(hand, true);
+-                livingEntitiesCount++;
+-            }
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._int()
++            .with(targets)
++            .executes((Entity entity) -> {
++                if (entity instanceof LivingEntity livingEntity) {
++                    livingEntity.swing(hand, true);
++                    return io.canvasmc.canvas.command.execution.ExecutionCallbacks.incrementInt();
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((livingEntitiesCount, selected, css) -> swingCallback(livingEntitiesCount, css, selected))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int swingCallback(final int livingEntitiesCount, final CommandSourceStack source, final Collection<? extends Entity> targets) throws CommandSyntaxException {
++    // Canvas end - region threading
+         if (livingEntitiesCount == 0) {
+             throw ERROR_NO_LIVING_ENTITY.create();
+         }
+diff --git a/net/minecraft/server/commands/TagCommand.java b/net/minecraft/server/commands/TagCommand.java
+index 97dbff6de2ba316724d19c5822ae83518eb72b9b..43dd6b0141bda5291820369abb38c6fb83b0ab48 100644
+--- a/net/minecraft/server/commands/TagCommand.java
++++ b/net/minecraft/server/commands/TagCommand.java
+@@ -58,15 +58,29 @@ public class TagCommand {
+     }
+ 
+     private static int addTag(final CommandSourceStack source, final Collection<? extends Entity> targets, final String name) throws CommandSyntaxException {
+-        int count = 0;
+-
+-        for (Entity entity : targets) {
+-            if (entity.addTag(name)) {
+-                count++;
+-            }
+-        }
++    // Canvas start - region threading
++
++        // again, with this command, if 1 entity passes then the feedback says they all pass...
++        // that's stupid! so we fixy :)
++
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<Entity>())
++            .with(targets)
++            .executes((Entity entity) -> {
++                if (entity.addTag(name)) {
++                    return (list) -> list.add(entity);
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((passed, _, css) -> addCallback(css, passed.copyOf(), name))
++            .start(source);
++        return 1;
++    }
+ 
+-        if (count == 0) {
++    private static int addCallback(
++        final CommandSourceStack source, final Collection<? extends Entity> targets, final String name
++    ) throws CommandSyntaxException {
++        if (targets.isEmpty()) {
++    // Canvas end - region threading
+             throw ERROR_ADD_FAILED.create();
+         }
+ 
+@@ -76,19 +90,33 @@ public class TagCommand {
+             source.sendSuccess(() -> Component.translatable("commands.tag.add.success.multiple", name, targets.size()), true);
+         }
+ 
+-        return count;
++        return targets.size(); // Canvas - region threading
+     }
+ 
+     private static int removeTag(final CommandSourceStack source, final Collection<? extends Entity> targets, final String name) throws CommandSyntaxException {
+-        int count = 0;
+-
+-        for (Entity entity : targets) {
+-            if (entity.removeTag(name)) {
+-                count++;
+-            }
+-        }
++    // Canvas start - region threading
++
++        // again, with this command, if 1 entity passes then the feedback says they all pass...
++        // that's stupid! so we fixy :)
++
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<Entity>())
++            .with(targets)
++            .executes((Entity entity) -> {
++                if (entity.removeTag(name)) {
++                    return (list) -> list.add(entity);
++                }
++                return io.canvasmc.canvas.command.execution.ExecutionCallbacks.nothing();
++            })
++            .onComplete((passed, _, css) -> removeCallback(css, passed.copyOf(), name))
++            .start(source);
++        return 1;
++    }
+ 
+-        if (count == 0) {
++    private static int removeCallback(
++        final CommandSourceStack source, final Collection<? extends Entity> targets, final String name
++    ) throws CommandSyntaxException {
++        if (targets.isEmpty()) {
++    // Canvas end - region threading
+             throw ERROR_REMOVE_FAILED.create();
+         }
+ 
+@@ -98,16 +126,21 @@ public class TagCommand {
+             source.sendSuccess(() -> Component.translatable("commands.tag.remove.success.multiple", name, targets.size()), true);
+         }
+ 
+-        return count;
++        return targets.size(); // Canvas - region threading
+     }
+ 
+-    private static int listTags(final CommandSourceStack source, final Collection<? extends Entity> targets) {
+-        Set<String> tags = Sets.newHashSet();
+-
+-        for (Entity entity : targets) {
+-            tags.addAll(entity.entityTags());
+-        }
++    // Canvas start - region threading
++    private static int listTags(final CommandSourceStack source, final Collection<? extends Entity> targets) throws CommandSyntaxException {
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._abstract(new io.canvasmc.canvas.util.CollectingList<String>())
++            .with(targets)
++            .executes((Entity entity) -> (list) -> list.addAll(entity.entityTags()))
++            .onComplete((tags, selected, css) -> listCallback(tags.copyOf(), css, selected))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int listCallback(final Collection<String> tags, final CommandSourceStack source, final Collection<? extends Entity> targets) {
++    // Canvas end - region threading
+         if (targets.size() == 1) {
+             Entity entity = targets.iterator().next();
+             if (tags.isEmpty()) {
 diff --git a/net/minecraft/server/commands/TeamCommand.java b/net/minecraft/server/commands/TeamCommand.java
-index b9c04e559db8352def5f6d73a5f7532e7cce9e0e..bf7fa2280e1548d2836b8c513d8319f768ffd15e 100644
+index b9c04e559db8352def5f6d73a5f7532e7cce9e0e..a997703bd413518b17721e45d435c55344bf0e17 100644
 --- a/net/minecraft/server/commands/TeamCommand.java
 +++ b/net/minecraft/server/commands/TeamCommand.java
 @@ -90,10 +90,7 @@ public class TeamCommand {
@@ -3234,309 +5472,260 @@ index b9c04e559db8352def5f6d73a5f7532e7cce9e0e..bf7fa2280e1548d2836b8c513d8319f7
                  .then(
                      Commands.literal("join")
                          .then(
-@@ -277,7 +274,16 @@ public class TeamCommand {
+@@ -273,13 +270,36 @@ public class TeamCommand {
+         return members.iterator().next().getFeedbackDisplayName();
+     }
+ 
+-    private static int leaveTeam(final CommandSourceStack source, final Collection<ScoreHolder> members) {
++    private static int leaveTeam(final CommandSourceStack source, final Collection<ScoreHolder> members) throws CommandSyntaxException { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
  
++    // Canvas start - region threading
++        final java.util.List<net.minecraft.world.entity.Entity> entities = new java.util.ArrayList<>();
++        final java.util.List<ScoreHolder> returnForFeedback = new java.util.concurrent.CopyOnWriteArrayList<>();
          for (ScoreHolder member : members) {
 -            scoreboard.removePlayerFromTeam(member.getScoreboardName());
-+            // Canvas start - region threading
 +            if (member instanceof net.minecraft.world.entity.Entity entity) {
-+                entity.getBukkitEntity().taskScheduler.scheduleOrExecute((serverEntity) ->
-+                    scoreboard.removePlayerFromTeam(serverEntity.getScoreboardName())
-+                );
++                entities.add(entity);
 +            }
-+            else {
-+                scoreboard.removePlayerFromTeam(member.getScoreboardName());
++            else if (scoreboard.removePlayerFromTeam(member.getScoreboardName())) {
++                returnForFeedback.add(member);
 +            }
-+            // Canvas end - region threading
          }
  
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(entities)
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                if (scoreboard.removePlayerFromTeam(entity.getScoreboardName())) {
++                    returnForFeedback.add(entity);
++                }
++                return (_) -> null;
++            })
++            .onComplete((_,_, css) -> leaveCallback(css, returnForFeedback))
++            .start(source);
++        return 1;
++    }
++
++    private static int leaveCallback(final CommandSourceStack source, final Collection<ScoreHolder> members) {
++    // Canvas end - region threading
          if (members.size() == 1) {
-@@ -293,7 +299,17 @@ public class TeamCommand {
+             source.sendSuccess(() -> Component.translatable("commands.team.leave.success.single", getFirstMemberName(members)), true);
+         } else {
+@@ -289,13 +309,36 @@ public class TeamCommand {
+         return members.size();
+     }
+ 
+-    private static int joinTeam(final CommandSourceStack source, final PlayerTeam team, final Collection<ScoreHolder> members) {
++    private static int joinTeam(final CommandSourceStack source, final PlayerTeam team, final Collection<ScoreHolder> members) throws CommandSyntaxException { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
  
++    // Canvas start - region threading
++        final java.util.List<net.minecraft.world.entity.Entity> entities = new java.util.ArrayList<>();
++        final java.util.List<ScoreHolder> returnForFeedback = new java.util.concurrent.CopyOnWriteArrayList<>();
          for (ScoreHolder member : members) {
 -            scoreboard.addPlayerToTeam(member.getScoreboardName(), team);
-+            // Canvas start - region threading
 +            if (member instanceof net.minecraft.world.entity.Entity entity) {
-+                entity.getBukkitEntity().taskScheduler.scheduleOrExecute((serverEntity) ->
-+                    scoreboard.addPlayerToTeam(serverEntity.getScoreboardName(), team)
-+                );
-+                continue;
++                entities.add(entity);
 +            }
-+            else {
-+                scoreboard.addPlayerToTeam(member.getScoreboardName(), team);
++            else if (scoreboard.addPlayerToTeam(member.getScoreboardName(), team)) {
++                returnForFeedback.add(member);
 +            }
-+            // Canvas end - region threading
          }
  
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution._void()
++            .with(entities)
++            .executes((net.minecraft.world.entity.Entity entity) -> {
++                if (scoreboard.addPlayerToTeam(entity.getScoreboardName(), team)) {
++                    returnForFeedback.add(entity);
++                }
++                return (_) -> null;
++            })
++            .onComplete((_,_, css) -> joinCallback(css, returnForFeedback, team))
++            .start(source);
++        return 1;
++    }
++
++    private static int joinCallback(final CommandSourceStack source, final Collection<ScoreHolder> members, final PlayerTeam team) {
++    // Canvas end - region threading
          if (members.size() == 1) {
-@@ -308,6 +324,10 @@ public class TeamCommand {
+             source.sendSuccess(
+                 () -> Component.translatable("commands.team.join.success.single", getFirstMemberName(members), team.getFormattedDisplayName()), true
+@@ -308,6 +351,7 @@ public class TeamCommand {
      }
  
      private static int setNameTagVisibility(final CommandSourceStack source, final PlayerTeam team, final Team.Visibility visibility) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (team.getNameTagVisibility() == visibility) {
              throw ERROR_TEAM_NAMETAG_VISIBLITY_UNCHANGED.create();
          }
-@@ -316,10 +336,20 @@ public class TeamCommand {
+@@ -316,10 +360,11 @@ public class TeamCommand {
          source.sendSuccess(
              () -> Component.translatable("commands.team.option.nametagVisibility.success", team.getFormattedDisplayName(), visibility.getDisplayName()), true
          );
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
-         return 0;
+-        return 0;
++        }, source); // Canvas - region threading
      }
  
      private static int setDeathMessageVisibility(final CommandSourceStack source, final PlayerTeam team, final Team.Visibility visibility) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (team.getDeathMessageVisibility() == visibility) {
              throw ERROR_TEAM_DEATH_MESSAGE_VISIBLITY_UNCHANGED.create();
          }
-@@ -329,10 +359,20 @@ public class TeamCommand {
+@@ -329,10 +374,11 @@ public class TeamCommand {
              () -> Component.translatable("commands.team.option.deathMessageVisibility.success", team.getFormattedDisplayName(), visibility.getDisplayName()),
              true
          );
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
-         return 0;
+-        return 0;
++        }, source); // Canvas - region threading
      }
  
      private static int setCollision(final CommandSourceStack source, final PlayerTeam team, final Team.CollisionRule collision) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (team.getCollisionRule() == collision) {
              throw ERROR_TEAM_COLLISION_UNCHANGED.create();
          }
-@@ -341,10 +381,20 @@ public class TeamCommand {
+@@ -341,10 +387,11 @@ public class TeamCommand {
          source.sendSuccess(
              () -> Component.translatable("commands.team.option.collisionRule.success", team.getFormattedDisplayName(), collision.getDisplayName()), true
          );
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
-         return 0;
+-        return 0;
++        }, source); // Canvas - region threading
      }
  
      private static int setFriendlySight(final CommandSourceStack source, final PlayerTeam team, final boolean allowed) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (team.canSeeFriendlyInvisibles() == allowed) {
              if (allowed) {
                  throw ERROR_TEAM_ALREADY_FRIENDLYINVISIBLES_ENABLED.create();
-@@ -357,11 +407,22 @@ public class TeamCommand {
-                 () -> Component.translatable("commands.team.option.seeFriendlyInvisibles." + (allowed ? "enabled" : "disabled"), team.getFormattedDisplayName()),
-                 true
+@@ -359,9 +406,11 @@ public class TeamCommand {
              );
--            return 0;
-+            return; // Canvas - region threading
+             return 0;
          }
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
      }
  
      private static int setFriendlyFire(final CommandSourceStack source, final PlayerTeam team, final boolean allowed) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (team.isAllowFriendlyFire() == allowed) {
              if (allowed) {
                  throw ERROR_TEAM_ALREADY_FRIENDLYFIRE_ENABLED.create();
-@@ -373,21 +434,42 @@ public class TeamCommand {
-             source.sendSuccess(
-                 () -> Component.translatable("commands.team.option.friendlyfire." + (allowed ? "enabled" : "disabled"), team.getFormattedDisplayName()), true
+@@ -375,19 +424,22 @@ public class TeamCommand {
              );
--            return 0;
-+            return; // Canvas - region threading
+             return 0;
          }
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
      }
  
      private static int setDisplayName(final CommandSourceStack source, final PlayerTeam team, final Component displayName) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          if (team.getDisplayName().equals(displayName)) {
              throw ERROR_TEAM_ALREADY_NAME.create();
          }
  
          team.setDisplayName(displayName);
          source.sendSuccess(() -> Component.translatable("commands.team.option.name.success", team.getFormattedDisplayName()), true);
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
-         return 0;
+-        return 0;
++        }, source); // Canvas - region threading
      }
  
      private static int setColor(final CommandSourceStack source, final PlayerTeam team, final TeamColor color) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Optional<TeamColor> currentColor = team.getColor();
          if (currentColor.isPresent() && currentColor.get().equals(color)) {
              throw ERROR_TEAM_ALREADY_COLOR.create();
-@@ -395,10 +477,20 @@ public class TeamCommand {
+@@ -395,10 +447,11 @@ public class TeamCommand {
  
          team.setColor(Optional.of(color));
          source.sendSuccess(() -> Component.translatable("commands.team.option.color.success", team.getFormattedDisplayName(), color.getSerializedName()), true);
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
-         return 0;
+-        return 0;
++        }, source); // Canvas - region threading
      }
  
      private static int clearColor(final CommandSourceStack source, final PlayerTeam team) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Optional<TeamColor> currentColor = team.getColor();
          if (currentColor.isEmpty()) {
              throw ERROR_TEAM_ALREADY_COLOR.create();
-@@ -406,6 +498,12 @@ public class TeamCommand {
+@@ -406,7 +459,7 @@ public class TeamCommand {
  
          team.setColor(Optional.empty());
          source.sendSuccess(() -> Component.translatable("commands.team.option.color.clear.success", team.getFormattedDisplayName()), true);
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        // Canvas end - region threading
-         return 0;
+-        return 0;
++        }, source); // Canvas - region threading
      }
  
-@@ -425,10 +523,14 @@ public class TeamCommand {
+     private static int emptyTeam(final CommandSourceStack source, final PlayerTeam team) throws CommandSyntaxException {
+@@ -425,10 +478,11 @@ public class TeamCommand {
      }
  
      private static int deleteTeam(final CommandSourceStack source, final PlayerTeam team) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
          scoreboard.removePlayerTeam(team);
          source.sendSuccess(() -> Component.translatable("commands.team.remove.success", team.getFormattedDisplayName()), true);
 -        return scoreboard.getPlayerTeams().size();
-+        // Canvas start - region threading
-+        });
-+        return 0;
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
      }
  
      private static int createTeam(final CommandSourceStack source, final String name) throws CommandSyntaxException {
-@@ -436,6 +538,10 @@ public class TeamCommand {
+@@ -436,6 +490,7 @@ public class TeamCommand {
      }
  
      private static int createTeam(final CommandSourceStack source, final String name, final Component displayName) throws CommandSyntaxException {
-+        // Canvas start - region threading
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
-+            try {
-+        // Canvas end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Scoreboard scoreboard = source.getServer().getScoreboard();
          if (scoreboard.getPlayerTeam(name) != null) {
              throw ERROR_TEAM_ALREADY_EXISTS.create();
-@@ -444,10 +550,18 @@ public class TeamCommand {
+@@ -444,10 +499,11 @@ public class TeamCommand {
          PlayerTeam team = scoreboard.addPlayerTeam(name);
          team.setDisplayName(displayName);
          source.sendSuccess(() -> Component.translatable("commands.team.add.success", team.getFormattedDisplayName()), true);
 -        return scoreboard.getPlayerTeams().size();
-+        return; // Canvas - region threading
-+        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
      }
  
      private static int listMembers(final CommandSourceStack source, final PlayerTeam team) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Collection<String> members = team.getPlayers();
          if (members.isEmpty()) {
              source.sendSuccess(() -> Component.translatable("commands.team.list.members.empty", team.getFormattedDisplayName()), false);
-@@ -459,11 +573,14 @@ public class TeamCommand {
+@@ -459,11 +515,11 @@ public class TeamCommand {
                  false
              );
          }
 -
 -        return members.size();
-+        // Canvas start - region threading
-+        });
-+        return 0;
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
      }
  
      private static int listTeams(final CommandSourceStack source) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          Collection<PlayerTeam> teams = source.getServer().getScoreboard().getPlayerTeams();
          if (teams.isEmpty()) {
              source.sendSuccess(() -> Component.translatable("commands.team.list.teams.empty"), false);
-@@ -475,19 +592,25 @@ public class TeamCommand {
+@@ -475,19 +531,20 @@ public class TeamCommand {
                  false
              );
          }
 -
 -        return teams.size();
-+        // Canvas start - region threading
-+        });
-+        return 0;
-+        // Canvas end - region threading
++        }, source); // Canvas - region threading
      }
  
      private static int setPrefix(final CommandSourceStack source, final PlayerTeam team, final Component prefix) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          team.setPlayerPrefix(prefix);
          source.sendSuccess(() -> Component.translatable("commands.team.option.prefix.success", prefix), false);
-+        }); // Canvas - region threading
-         return Command.SINGLE_SUCCESS;
+-        return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
      }
  
      private static int setSuffix(final CommandSourceStack source, final PlayerTeam team, final Component suffix) {
-+        io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> { // Canvas - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
          team.setPlayerSuffix(suffix);
          source.sendSuccess(() -> Component.translatable("commands.team.option.suffix.success", suffix), false);
-+        }); // Canvas - region threading
-         return Command.SINGLE_SUCCESS;
+-        return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
      }
  }
 diff --git a/net/minecraft/server/commands/TeleportCommand.java b/net/minecraft/server/commands/TeleportCommand.java
@@ -3572,8 +5761,257 @@ index 369be2ad59cf05c76a44b4b00bec18d1c564688a..e4d2cb8417d638d32c9de75e290e54db
              return;
          }
          // Folia end - region threading
+diff --git a/net/minecraft/server/commands/TimeCommand.java b/net/minecraft/server/commands/TimeCommand.java
+index 174c3a671c3cfd276efc08add9d9dc59f0bd655b..bb34d1ccdda4d7640003e9ebfa6f4f4b57aba225 100644
+--- a/net/minecraft/server/commands/TimeCommand.java
++++ b/net/minecraft/server/commands/TimeCommand.java
+@@ -116,12 +116,7 @@ public class TimeCommand {
+             );
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
++    // Canvas - region threading
+     private static CompletableFuture<Suggestions> suggestTimeMarkers(
+         final CommandSourceStack source, final SuggestionsBuilder builder, final Holder<WorldClock> clock
+     ) {
+@@ -149,11 +144,10 @@ public class TimeCommand {
+ 
+     private static int queryTime(final CommandSourceStack source, final Holder<WorldClock> clock) {
+         ServerClockManager clockManager = source.getLevel().clockManager(); // Paper - per-world time
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         long totalTicks = clockManager.getTotalTicks(clock);
+         source.sendSuccess(() -> Component.translatable("commands.time.query.absolute", clock.getRegisteredName(), totalTicks), false);
+-        }); // Folia - region threading
+-        return 0; // Folia - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int queryTimelineTicks(final CommandSourceStack source, final Holder<WorldClock> clock, final Holder<Timeline> timeline) throws CommandSyntaxException {
+@@ -162,11 +156,10 @@ public class TimeCommand {
+         }
+ 
+         ServerClockManager clockManager = source.getLevel().clockManager(); // Paper - per-world time
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         long currentTicks = timeline.value().getCurrentTicks(clockManager);
+         source.sendSuccess(() -> Component.translatable("commands.time.query.timeline", timeline.getRegisteredName(), currentTicks), false);
+-        }); // Folia - region threading
+-        return 0; // Folia - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int queryTimelineRepetitions(final CommandSourceStack source, final Holder<WorldClock> clock, final Holder<Timeline> timeline) throws CommandSyntaxException {
+@@ -175,17 +168,16 @@ public class TimeCommand {
+         }
+ 
+         ServerClockManager clockManager = source.getLevel().clockManager(); // Paper - per-world time
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         long repetitions = timeline.value().getPeriodCount(clockManager);
+         source.sendSuccess(() -> Component.translatable("commands.time.query.timeline.repetitions", timeline.getRegisteredName(), repetitions), false);
+-        }); // Folia - region threading
+-        return 0; // Folia - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     // Paper start - per-world time
+     private static int setTotalTicks(final CommandSourceStack source, final Holder<WorldClock> clock, final int totalTicks) {
+         ServerClockManager clockManager = source.getLevel().clockManager();
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         long currentTotalTicks = clockManager.getTotalTicks(clock);
+         org.bukkit.event.world.ClockTimeSkipEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.createTimeSkipEvent(source, totalTicks - currentTotalTicks);
+         final long newTotalTicks;
+@@ -196,28 +188,23 @@ public class TimeCommand {
+             newTotalTicks = totalTicks; // just pass it through
+         }
+         source.sendSuccess(() -> Component.translatable("commands.time.set.absolute", clock.getRegisteredName(), newTotalTicks), true);
+-        }); // Folia - region threading
+-        return 0; // Folia - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int addTime(final CommandSourceStack source, final Holder<WorldClock> clock, final int time) {
+         ServerClockManager clockManager = source.getLevel().clockManager();
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         org.bukkit.event.world.ClockTimeSkipEvent event = org.bukkit.craftbukkit.event.CraftEventFactory.createTimeSkipEvent(source, time);
+         if (event.callEvent()) {
+             clockManager.addTicks(clock, event.getSkipAmount());
+         }
+         long totalTicks = clockManager.getTotalTicks(clock);
+         source.sendSuccess(() -> Component.translatable("commands.time.set.absolute", clock.getRegisteredName(), totalTicks), true);
+-        }); // Folia - region threading
+-        return 0; // Folia - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setTimeToTimeMarker(final CommandSourceStack source, final Holder<WorldClock> clock, final ResourceKey<ClockTimeMarker> timeMarkerId) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         // Paper start - per-world time
+         ServerClockManager clockManager = source.getLevel().clockManager();
+         java.util.OptionalLong targetTime = clockManager.getTotalTicksToTimeMarker(clock, timeMarkerId);
+@@ -234,30 +221,21 @@ public class TimeCommand {
+         }
+         // Paper end - per-world time
+         source.sendSuccess(() -> Component.translatable("commands.time.set.time_marker", clock.getRegisteredName(), timeMarkerId.identifier().toString()), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 0;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setPaused(final CommandSourceStack source, final Holder<WorldClock> clock, final boolean paused) {
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         source.getLevel().clockManager().setPaused(clock, paused); // Paper - per-world time
+         source.sendSuccess(() -> Component.translatable(paused ? "commands.time.pause" : "commands.time.resume", clock.getRegisteredName()), true);
+-        }); // Folia - region threading
+-        return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setRate(final CommandSourceStack source, final Holder<WorldClock> clock, final float rate) {
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         source.getLevel().clockManager().setRate(clock, rate); // Paper - per-world time
+         source.sendSuccess(() -> Component.translatable("commands.time.rate", clock.getRegisteredName(), rate), true);
+-        }); // Folia - region threading
+-        return Command.SINGLE_SUCCESS;
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int wrapTime(final long ticks) {
+diff --git a/net/minecraft/server/commands/TitleCommand.java b/net/minecraft/server/commands/TitleCommand.java
+index ecf9f5cc7fd23570c1c7f7f267643dccb79e62ba..ac422e969399918d1084b90bcdae66089f01e709 100644
+--- a/net/minecraft/server/commands/TitleCommand.java
++++ b/net/minecraft/server/commands/TitleCommand.java
+@@ -101,13 +101,23 @@ public class TitleCommand {
+         );
+     }
+ 
+-    private static int clearTitle(final CommandSourceStack source, final Collection<ServerPlayer> targets) {
++    private static int clearTitle(final CommandSourceStack source, final Collection<ServerPlayer> targets) throws CommandSyntaxException { // Canvas - region threading
+         ClientboundClearTitlesPacket packet = new ClientboundClearTitlesPacket(false);
+ 
+-        for (ServerPlayer player : targets) {
+-            player.connection.send(packet);
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.send(packet);
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> clearCallback(css, selected))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int clearCallback(final CommandSourceStack source, final Collection<? extends ServerPlayer> targets) {
++    // Canvas end - region threading
+         if (targets.size() == 1) {
+             source.sendSuccess(() -> Component.translatable("commands.title.cleared.single", targets.iterator().next().getDisplayName()), true);
+         } else {
+@@ -117,13 +127,23 @@ public class TitleCommand {
+         return targets.size();
+     }
+ 
+-    private static int resetTitle(final CommandSourceStack source, final Collection<ServerPlayer> targets) {
++    private static int resetTitle(final CommandSourceStack source, final Collection<ServerPlayer> targets) throws CommandSyntaxException { // Canvas - region threading
+         ClientboundClearTitlesPacket packet = new ClientboundClearTitlesPacket(true);
+ 
+-        for (ServerPlayer player : targets) {
+-            player.connection.send(packet);
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.send(packet);
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> resetCallback(css, selected))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int resetCallback(final CommandSourceStack source, final Collection<? extends ServerPlayer> targets) {
++    // Canvas end - region threading
+         if (targets.size() == 1) {
+             source.sendSuccess(() -> Component.translatable("commands.title.reset.single", targets.iterator().next().getDisplayName()), true);
+         } else {
+@@ -140,11 +160,20 @@ public class TitleCommand {
+         final String type,
+         final Function<Component, Packet<?>> factory
+     ) throws CommandSyntaxException {
+-        for (ServerPlayer player : targets) {
+-            player.connection
+-                .send(factory.apply(ComponentUtils.resolve(ResolutionContext.builder().withSource(source).withEntityOverride(player).build(), title)));
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.send(factory.apply(ComponentUtils.resolve(ResolutionContext.builder().withSource(source).withEntityOverride(entityPlayer).build(), title)));
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> showCallback(css, selected, type))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int showCallback(final CommandSourceStack source, final Collection<? extends ServerPlayer> targets, final String type) {
++    // Canvas end - region threading
+         if (targets.size() == 1) {
+             source.sendSuccess(() -> Component.translatable("commands.title.show." + type + ".single", targets.iterator().next().getDisplayName()), true);
+         } else {
+@@ -154,13 +183,23 @@ public class TitleCommand {
+         return targets.size();
+     }
+ 
+-    private static int setTimes(final CommandSourceStack source, final Collection<ServerPlayer> targets, final int fadeIn, final int stay, final int fadeOut) {
++    private static int setTimes(final CommandSourceStack source, final Collection<ServerPlayer> targets, final int fadeIn, final int stay, final int fadeOut) throws CommandSyntaxException { // Canvas - region threading
+         ClientboundSetTitlesAnimationPacket packet = new ClientboundSetTitlesAnimationPacket(fadeIn, stay, fadeOut);
+ 
+-        for (ServerPlayer player : targets) {
+-            player.connection.send(packet);
+-        }
++    // Canvas start - region threading
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(targets)
++            .executes((ServerPlayer entityPlayer) -> {
++                entityPlayer.connection.send(packet);
++                return (_) -> null;
++            })
++            .onComplete((_, selected, css) -> setCallback(css, selected))
++            .start(source);
++        return 1;
++    }
+ 
++    private static int setCallback(final CommandSourceStack source, final Collection<? extends ServerPlayer> targets) {
++    // Canvas end - region threading
+         if (targets.size() == 1) {
+             source.sendSuccess(() -> Component.translatable("commands.title.times.single", targets.iterator().next().getDisplayName()), true);
+         } else {
 diff --git a/net/minecraft/server/commands/TriggerCommand.java b/net/minecraft/server/commands/TriggerCommand.java
-index 088b7b91154546fc9c020cab5cefbb4b89762ac8..9d5f76ff2892fd38a21397698a986027774f5832 100644
+index 088b7b91154546fc9c020cab5cefbb4b89762ac8..a753d5276c40f1b37f4726e01e5bd973a757634b 100644
 --- a/net/minecraft/server/commands/TriggerCommand.java
 +++ b/net/minecraft/server/commands/TriggerCommand.java
 @@ -89,24 +89,54 @@ public class TriggerCommand {
@@ -3581,62 +6019,321 @@ index 088b7b91154546fc9c020cab5cefbb4b89762ac8..9d5f76ff2892fd38a21397698a986027
  
      private static int addValue(final CommandSourceStack source, final ServerPlayer player, final Objective objective, final int amount) throws CommandSyntaxException {
 -        ScoreAccess score = getScore(source.getServer().getScoreboard(), player, objective);
-+        // Canvas start - region threading
-+        player.getBukkitEntity().taskScheduler.scheduleOrExecute((entityPlayer) -> {
-+            try {
-+        ScoreAccess score = getScore(source.getServer().getScoreboard(), entityPlayer, objective);
-+        // Canvas end - region threading
-         int newValue = score.add(amount);
-         source.sendSuccess(() -> Component.translatable("commands.trigger.add.success", objective.getFormattedDisplayName(), amount), true);
+-        int newValue = score.add(amount);
+-        source.sendSuccess(() -> Component.translatable("commands.trigger.add.success", objective.getFormattedDisplayName(), amount), true);
 -        return newValue;
 +        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(player)
++            .executes((ServerPlayer entityPlayer) -> {
++                ScoreAccess score = getScore(source.getServer().getScoreboard(), entityPlayer, objective);
++                score.add(amount);
++                source.sendSuccess(() -> Component.translatable("commands.trigger.add.success", objective.getFormattedDisplayName(), amount), true);
++                return (_) -> null;
++            })
++            // no point in a completion statement, it's simple af we don't need it
++            .noCompletion()
++            .start(source);
++        return 1;
 +        // Canvas end - region threading
      }
  
      private static int setValue(final CommandSourceStack source, final ServerPlayer player, final Objective objective, final int amount) throws CommandSyntaxException {
 -        ScoreAccess score = getScore(source.getServer().getScoreboard(), player, objective);
-+        // Canvas start - region threading
-+        player.getBukkitEntity().taskScheduler.scheduleOrExecute((entityPlayer) -> {
-+            try {
-+        ScoreAccess score = getScore(source.getServer().getScoreboard(), entityPlayer, objective);
-+        // Canvas end - region threading
-         score.set(amount);
-         source.sendSuccess(() -> Component.translatable("commands.trigger.set.success", objective.getFormattedDisplayName(), amount), true);
+-        score.set(amount);
+-        source.sendSuccess(() -> Component.translatable("commands.trigger.set.success", objective.getFormattedDisplayName(), amount), true);
 -        return amount;
 +        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(player)
++            .executes((ServerPlayer entityPlayer) -> {
++                ScoreAccess score = getScore(source.getServer().getScoreboard(), entityPlayer, objective);
++                score.set(amount);
++                source.sendSuccess(() -> Component.translatable("commands.trigger.set.success", objective.getFormattedDisplayName(), amount), true);
++                return (_) -> null;
++            })
++            // no point in a completion statement, it's simple af we don't need it
++            .noCompletion()
++            .start(source);
++        return 1;
 +        // Canvas end - region threading
      }
  
      private static int simpleTrigger(final CommandSourceStack source, final ServerPlayer player, final Objective objective) throws CommandSyntaxException {
 -        ScoreAccess score = getScore(source.getServer().getScoreboard(), player, objective);
-+        // Canvas start - region threading
-+        player.getBukkitEntity().taskScheduler.scheduleOrExecute((entityPlayer) -> {
-+            try {
-+        ScoreAccess score = getScore(source.getServer().getScoreboard(), entityPlayer, objective);
-+        // Canvas end - region threading
-         int newValue = score.add(1);
-         source.sendSuccess(() -> Component.translatable("commands.trigger.simple.success", objective.getFormattedDisplayName()), true);
+-        int newValue = score.add(1);
+-        source.sendSuccess(() -> Component.translatable("commands.trigger.simple.success", objective.getFormattedDisplayName()), true);
 -        return newValue;
 +        // Canvas start - region threading
-+            } catch (CommandSyntaxException cse) {
-+                source.sendFailure(Component.literal(cse.getMessage()));
-+            }
-+        });
-+        return 0;
++        io.canvasmc.canvas.command.execution.AbstractCommandExecution.<ServerPlayer>_void()
++            .with(player)
++            .executes((ServerPlayer entityPlayer) -> {
++                ScoreAccess score = getScore(source.getServer().getScoreboard(), entityPlayer, objective);
++                score.add(1);
++                source.sendSuccess(() -> Component.translatable("commands.trigger.simple.success", objective.getFormattedDisplayName()), true);
++                return (_) -> null;
++            })
++            // no point in a completion statement, it's simple af we don't need it
++            .noCompletion()
++            .start(source);
++        return 1;
 +        // Canvas end - region threading
      }
  
      private static ScoreAccess getScore(final Scoreboard scoreboard, final ScoreHolder scoreHolder, final Objective objective) throws CommandSyntaxException {
+diff --git a/net/minecraft/server/commands/WaypointCommand.java b/net/minecraft/server/commands/WaypointCommand.java
+index 1a826c3d697ab01a84a4b182d4185b1001b8d0fa..022cb3cb2855055a342fcbb31e4a75c6a81f78f0 100644
+--- a/net/minecraft/server/commands/WaypointCommand.java
++++ b/net/minecraft/server/commands/WaypointCommand.java
+@@ -97,38 +97,44 @@ public class WaypointCommand {
+     }
+ 
+     private static int setWaypointStyle(final CommandSourceStack source, final WaypointTransmitter waypoint, final ResourceKey<WaypointStyleAsset> style) {
+-        mutateIcon(source, waypoint, icon -> icon.style = style);
++        regionThreadingIconMutation(source, waypoint, icon -> icon.style = style, () -> { // Canvas - region threading
+         source.sendSuccess(() -> Component.translatable("commands.waypoint.modify.style"), false);
++        }); // Canvas - region threading
+         return 0;
+     }
+ 
+     private static int setWaypointColor(final CommandSourceStack source, final WaypointTransmitter waypoint, final TeamColor color) {
+-        mutateIcon(source, waypoint, icon -> icon.color = Optional.of(color.rgb()));
++        regionThreadingIconMutation(source, waypoint, icon -> icon.color = Optional.of(color.rgb()), () -> { // Canvas - region threading
+         source.sendSuccess(
+             () -> Component.translatable("commands.waypoint.modify.color", Component.literal(color.getSerializedName()).withColor(color.textColor())), false
+         );
++        }); // Canvas - region threading
+         return 0;
+     }
+ 
+     private static int setWaypointColor(final CommandSourceStack source, final WaypointTransmitter waypoint, final Integer color) {
+-        mutateIcon(source, waypoint, icon -> icon.color = Optional.of(color));
++        regionThreadingIconMutation(source, waypoint, icon -> icon.color = Optional.of(color), () -> { // Canvas - region threading
+         source.sendSuccess(
+             () -> Component.translatable(
+                 "commands.waypoint.modify.color", Component.literal(HexFormat.of().withUpperCase().toHexDigits(ARGB.color(0, color), 6)).withColor(color)
+             ),
+             false
+         );
++        }); // Canvas - region threading
+         return 0;
+     }
+ 
+     private static int resetWaypointColor(final CommandSourceStack source, final WaypointTransmitter waypoint) {
+-        mutateIcon(source, waypoint, icon -> icon.color = Optional.empty());
++        regionThreadingIconMutation(source, waypoint, icon -> icon.color = Optional.empty(), () -> { // Canvas - region threading
+         source.sendSuccess(() -> Component.translatable("commands.waypoint.modify.color.reset"), false);
++        }); // Canvas - region threading
+         return 0;
+     }
+ 
+     private static int listWaypoints(final CommandSourceStack source) {
+         ServerLevel level = source.getLevel();
++        // Canvas - note: transmitters function is safe in our waypoint rewrite, it snapshots
++        //                the current data so this is safe to execute anywhere in parallel
+         Set<WaypointTransmitter> waypoints = level.getWaypointManager().transmitters();
+         String dimension = level.dimension().identifier().toString();
+         if (waypoints.isEmpty()) {
+@@ -164,6 +170,25 @@ public class WaypointCommand {
+             return waypoints.size();
+         }
+     }
++    // Canvas start - region threading
++
++    private static void regionThreadingIconMutation(final CommandSourceStack source, final WaypointTransmitter waypoint, final Consumer<Waypoint.Icon> iconConsumer, final Runnable callback) {
++        if (waypoint instanceof LivingEntity livingEntity) {
++            // schedule this to the entity in question
++            livingEntity.getBukkitEntity().taskScheduler.scheduleOrExecute((LivingEntity targetEntity) -> {
++                mutateIcon(source, targetEntity, iconConsumer);
++                callback.run();
++            });
++        }
++        else {
++            // no fucking clue what this is, just schedule to global
++            io.papermc.paper.threadedregions.RegionizedServer.getInstance().scheduleToOrExecute(() -> {
++                mutateIcon(source, waypoint, iconConsumer);
++                callback.run();
++            });
++        }
++    }
++    // Canvas end - region threading
+ 
+     private static void mutateIcon(final CommandSourceStack source, final WaypointTransmitter waypoint, final Consumer<Waypoint.Icon> iconConsumer) {
+         ServerLevel level = (waypoint instanceof LivingEntity livingEntity) ? (ServerLevel) livingEntity.level() : source.getLevel(); // Paper - MC-300685 use level of waypoint if it's a living entity for broadcast
+diff --git a/net/minecraft/server/commands/WorldBorderCommand.java b/net/minecraft/server/commands/WorldBorderCommand.java
+index 5b998967b38800101d0b78ca5b6414c2fcf6921b..9a8bbf3ad5c4a3e690ccbab4ee31249241665577 100644
+--- a/net/minecraft/server/commands/WorldBorderCommand.java
++++ b/net/minecraft/server/commands/WorldBorderCommand.java
+@@ -126,17 +126,8 @@ public class WorldBorderCommand {
+         );
+     }
+ 
+-    // Folia start - region threading
+-    private static void sendMessage(CommandSourceStack src, CommandSyntaxException ex) {
+-        src.sendFailure((Component)ex.getRawMessage());
+-    }
+-    // Folia end - region threading
+-
+     private static int setDamageBuffer(final CommandSourceStack source, final float distance) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         WorldBorder border = source.getLevel().getWorldBorder();
+         if (border.getSafeZone() == distance) {
+             throw ERROR_SAME_DAMAGE_BUFFER.create();
+@@ -144,21 +135,11 @@ public class WorldBorderCommand {
+ 
+         border.setSafeZone(distance);
+         source.sendSuccess(() -> Component.translatable("commands.worldborder.damage.buffer.success", String.format(Locale.ROOT, "%.2f", distance)), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 1;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setDamageAmount(final CommandSourceStack source, final float damagePerBlock) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         WorldBorder border = source.getLevel().getWorldBorder();
+         if (border.getDamagePerBlock() == damagePerBlock) {
+             throw ERROR_SAME_DAMAGE_AMOUNT.create();
+@@ -166,21 +147,11 @@ public class WorldBorderCommand {
+ 
+         border.setDamagePerBlock(damagePerBlock);
+         source.sendSuccess(() -> Component.translatable("commands.worldborder.damage.amount.success", String.format(Locale.ROOT, "%.2f", damagePerBlock)), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 1;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setWarningTime(final CommandSourceStack source, final int ticks) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         WorldBorder border = source.getLevel().getWorldBorder();
+         if (border.getWarningTime() == ticks) {
+             throw ERROR_SAME_WARNING_TIME.create();
+@@ -188,21 +159,11 @@ public class WorldBorderCommand {
+ 
+         border.setWarningTime(ticks);
+         source.sendSuccess(() -> Component.translatable("commands.worldborder.warning.time.success", formatTicksToSeconds(ticks)), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 1;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setWarningDistance(final CommandSourceStack source, final int distance) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         WorldBorder border = source.getLevel().getWorldBorder();
+         if (border.getWarningBlocks() == distance) {
+             throw ERROR_SAME_WARNING_DISTANCE.create();
+@@ -210,34 +171,18 @@ public class WorldBorderCommand {
+ 
+         border.setWarningBlocks(distance);
+         source.sendSuccess(() -> Component.translatable("commands.worldborder.warning.distance.success", distance), true);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 1;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int getSize(final CommandSourceStack source) {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         double size = source.getLevel().getWorldBorder().getSize();
+         source.sendSuccess(() -> Component.translatable("commands.worldborder.get", String.format(Locale.ROOT, "%.0f", size)), false);
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-        });
+-        return 1;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setCenter(final CommandSourceStack source, final Vec2 center) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         WorldBorder border = source.getLevel().getWorldBorder();
+         if (border.getCenterX() == center.x && border.getCenterZ() == center.y) {
+             throw ERROR_SAME_CENTER.create();
+@@ -253,20 +198,11 @@ public class WorldBorderCommand {
+         } else {
+             throw ERROR_TOO_FAR_OUT.create();
+         }
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 1;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static int setSize(final CommandSourceStack source, final double distance, final long ticks) throws CommandSyntaxException {
+-        // Folia start - region threading
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> {
+-            try {
+-                // Folia end - region threading
++        return io.canvasmc.canvas.command.execution.AbstractCommandExecution.executeOnGlobal(() -> { // Canvas - region threading
+         ServerLevel level = source.getLevel();
+         WorldBorder border = level.getWorldBorder();
+         double current = border.getSize();
+@@ -294,15 +230,7 @@ public class WorldBorderCommand {
+             border.setSize(distance);
+             source.sendSuccess(() -> Component.translatable("commands.worldborder.set.immediate", formattedDistance), true);
+         }
+-
+-        return; // Folia - region threading
+-        // Folia start - region threading
+-            } catch (CommandSyntaxException ex) {
+-                sendMessage(source, ex);
+-            }
+-        });
+-        return 1;
+-        // Folia end - region threading
++        }, source); // Canvas - region threading
+     }
+ 
+     private static String formatTicksToSeconds(final long ticks) {
 diff --git a/net/minecraft/server/commands/data/BlockDataAccessor.java b/net/minecraft/server/commands/data/BlockDataAccessor.java
 index 1b0ad9375986fe35795fc75f8eecfecaacc0cc13..5e4a4e0c6247f6417cd5c0570876348aaa5fe233 100644
 --- a/net/minecraft/server/commands/data/BlockDataAccessor.java
@@ -3704,7 +6401,7 @@ index 8eed353e878d3c2bede58ed526c4bc065fe7db90..fa225169136b1e74bd666325bfe76d51
 +    // Canvas end - region threading
  }
 diff --git a/net/minecraft/server/commands/data/DataCommands.java b/net/minecraft/server/commands/data/DataCommands.java
-index 024606d6784a7ddcf253052920ff0102867c9a14..5751ee8d8b6eda908a7176542bd06eaf5e6004c5 100644
+index 024606d6784a7ddcf253052920ff0102867c9a14..14e7804a5ddda444b88e2ebd69d7bfb10a992f08 100644
 --- a/net/minecraft/server/commands/data/DataCommands.java
 +++ b/net/minecraft/server/commands/data/DataCommands.java
 @@ -54,7 +54,7 @@ public class DataCommands {
@@ -3729,7 +6426,7 @@ index 024606d6784a7ddcf253052920ff0102867c9a14..5751ee8d8b6eda908a7176542bd06eaf
 +
 +    // TODO - bring back global storage data accessor?
 +
-+    private static void handleAction(final io.canvasmc.canvas.util.CommandFunction<net.minecraft.server.commands.data.DataAccessor> iAction, final DataAccessor accessor, final CommandSourceStack sourceStack) throws CommandSyntaxException {
++    private static void handleAction(final io.canvasmc.canvas.util.command.CommandFunction<net.minecraft.server.commands.data.DataAccessor> iAction, final DataAccessor accessor, final CommandSourceStack sourceStack) throws CommandSyntaxException {
 +        if (io.papermc.paper.threadedregions.RegionizedServer.isGlobalTickThread()) {
 +            // just schedule to the instance in question
 +            accessor.scheduleOrExecute((da) -> {
@@ -4936,6 +7633,57 @@ index b455050c16946f54fc1d9893173777e39baf4290..5ee7759034404b37df09a368a9cc87f5
 +        // Canvas - region threading
      }
  }
+diff --git a/net/minecraft/world/Stopwatches.java b/net/minecraft/world/Stopwatches.java
+index 4fda3efe9eb24bdb1828078b3c296c497bd211d3..1ca622a587ac55ae893ff78b83ea87725062f171 100644
+--- a/net/minecraft/world/Stopwatches.java
++++ b/net/minecraft/world/Stopwatches.java
+@@ -21,12 +21,13 @@ public class Stopwatches extends SavedData {
+     public static final SavedDataType<Stopwatches> TYPE = new SavedDataType<>(
+         Identifier.withDefaultNamespace("stopwatches"), Stopwatches::new, CODEC, DataFixTypes.SAVED_DATA_STOPWATCHES
+     );
+-    private final Map<Identifier, Stopwatch> stopwatches = new Object2ObjectOpenHashMap<>();
++    private final Map<Identifier, Stopwatch> stopwatches = new ca.spottedleaf.concurrentutil.map.SWMRHashTable<>(); // Canvas - region threading
+ 
+     private Stopwatches() {
+     }
+ 
+     private static Stopwatches unpack(final Map<Identifier, Long> stopwatches) {
++        io.canvasmc.canvas.util.TickGuard.ensureGlobalOrStartup("Cannot unpack stopwatches async"); // Canvas - region threading
+         Stopwatches result = new Stopwatches();
+         long currentTime = currentTime();
+         stopwatches.forEach((id, accumulatedElapsedTime) -> result.stopwatches.put(id, new Stopwatch(currentTime, accumulatedElapsedTime)));
+@@ -34,6 +35,7 @@ public class Stopwatches extends SavedData {
+     }
+ 
+     private Map<Identifier, Long> pack() {
++        io.canvasmc.canvas.util.TickGuard.ensureGlobalOrStartup("Cannot pack stopwatches async"); // Canvas - region threading
+         long currentTime = currentTime();
+         Map<Identifier, Long> result = new TreeMap<>();
+         this.stopwatches.forEach((id, stopwatch) -> result.put(id, stopwatch.elapsedMilliseconds(currentTime)));
+@@ -45,6 +47,7 @@ public class Stopwatches extends SavedData {
+     }
+ 
+     public boolean add(final Identifier id, final Stopwatch stopwatch) {
++        io.papermc.paper.threadedregions.RegionizedServer.ensureGlobalTickThread("Cannot add stopwatch async"); // Canvas - region threading
+         if (this.stopwatches.putIfAbsent(id, stopwatch) == null) {
+             this.setDirty();
+             return true;
+@@ -54,6 +57,7 @@ public class Stopwatches extends SavedData {
+     }
+ 
+     public boolean update(final Identifier id, final UnaryOperator<Stopwatch> update) {
++        io.papermc.paper.threadedregions.RegionizedServer.ensureGlobalTickThread("Cannot update stopwatch async"); // Canvas - region threading
+         if (this.stopwatches.computeIfPresent(id, (key, value) -> update.apply(value)) != null) {
+             this.setDirty();
+             return true;
+@@ -63,6 +67,7 @@ public class Stopwatches extends SavedData {
+     }
+ 
+     public boolean remove(final Identifier id) {
++        io.papermc.paper.threadedregions.RegionizedServer.ensureGlobalTickThread("Cannot remove stopwatch async"); // Canvas - region threading
+         boolean removed = this.stopwatches.remove(id) != null;
+         if (removed) {
+             this.setDirty();
 diff --git a/net/minecraft/world/entity/Entity.java b/net/minecraft/world/entity/Entity.java
 index 945b2f76ec47448c462df95ba64271eaf2567af1..5e34cf071e2ea33d4cbd733209029a6d62eb367a 100644
 --- a/net/minecraft/world/entity/Entity.java

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
@@ -54,11 +54,11 @@ public class AbstractCommandExecution<R, E extends Entity> {
     }
 
     public static int executeAtPosWithRadius(final @NonNull CommandIntSupplier action, final @NonNull Vec3 pos, final int radius, final Level level, final CommandSourceStack css) {
-        return executeAtPosWithRadius(action, new BlockPos((int) pos.x, (int) pos.y, (int) pos.z), radius, level, css);
+        return executeAtPosWithRadius(action, BlockPos.containing(pos), radius, level, css);
     }
 
     public static int executeAtPosWithRadius(final CommandRunnable action, final @NonNull Vec3 pos, final int radius, final Level level, final CommandSourceStack css) {
-        return executeAtPosWithRadius(action, new BlockPos((int) pos.x, (int) pos.y, (int) pos.z), radius, level, css);
+        return executeAtPosWithRadius(action, BlockPos.containing(pos), radius, level, css);
     }
 
     public static int executeAtPosWithRadius(final CommandRunnable action, final @NonNull BlockPos pos, final int radius, final @NonNull Level level, final CommandSourceStack css) {
@@ -81,26 +81,26 @@ public class AbstractCommandExecution<R, E extends Entity> {
         return Command.SINGLE_SUCCESS;
     }
 
-    public static int executeAtPos(final CommandRunnable action, final @NonNull BlockPos pos, final Level level, final CommandSourceStack css) {
-        return executeAtPos(action, new Vec3(pos), level, css);
-    }
-
-    public static int executeAtPos(final CommandIntSupplier action, final @NonNull BlockPos pos, final Level level, final CommandSourceStack css) {
-        return executeAtPos(action, new Vec3(pos), level, css);
-    }
-
     public static int executeAtPos(final CommandRunnable action, final @NonNull Vec3 pos, final Level level, final CommandSourceStack css) {
+        return executeAtPos(action, BlockPos.containing(pos), level, css);
+    }
+
+    public static int executeAtPos(final CommandIntSupplier action, final @NonNull Vec3 pos, final Level level, final CommandSourceStack css) {
+        return executeAtPos(action, BlockPos.containing(pos), level, css);
+    }
+
+    public static int executeAtPos(final CommandRunnable action, final @NonNull BlockPos pos, final Level level, final CommandSourceStack css) {
         return executeAtPos(() -> {
             action.act();
             return Command.SINGLE_SUCCESS;
         }, pos, level, css);
     }
 
-    public static int executeAtPos(final CommandIntSupplier action, final @NonNull Vec3 pos, final Level level, final CommandSourceStack css) {
+    public static int executeAtPos(final CommandIntSupplier action, final @NonNull BlockPos pos, final Level level, final CommandSourceStack css) {
         RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
             (ServerLevel) level,
-            ((int) pos.x) >> 4,
-            ((int) pos.z) >> 4,
+            pos.getX() >> 4,
+            pos.getZ() >> 4,
             () -> {
                 try {
                     action.act();

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
@@ -1,0 +1,273 @@
+package io.canvasmc.canvas.command.execution;
+
+import ca.spottedleaf.concurrentutil.util.Priority;
+import ca.spottedleaf.moonrise.common.util.TickThread;
+import com.mojang.brigadier.Command;
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
+import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
+import io.canvasmc.canvas.util.CanonicalReference;
+import io.canvasmc.canvas.util.LockedReference;
+import io.canvasmc.canvas.util.command.AbstractCommandFunction;
+import io.canvasmc.canvas.util.command.CommandIntSupplier;
+import io.canvasmc.canvas.util.command.CommandRunnable;
+import io.canvasmc.canvas.util.command.TriCommandFunction;
+import io.papermc.paper.threadedregions.RegionizedServer;
+import java.util.Collection;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.Consumer;
+import java.util.function.Function;
+import java.util.stream.Stream;
+import net.minecraft.commands.CommandSourceStack;
+import net.minecraft.core.BlockPos;
+import net.minecraft.network.chat.Component;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.level.Level;
+import net.minecraft.world.phys.Vec3;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.NonNull;
+
+public class AbstractCommandExecution<R, E extends Entity> {
+
+    protected static final DynamicCommandExceptionType INVALID_EXECUTION = new DynamicCommandExceptionType(
+        type -> Component.literal("Invalid execution arguments provided. Forgot to provide \"" + type + "\" argument")
+    );
+    protected static final DynamicCommandExceptionType ALREADY_PROVIDED = new DynamicCommandExceptionType(
+        type -> Component.literal("Already provided \"" + type + "\" argument to execution constructor")
+    );
+
+    public static final DynamicCommandExceptionType CANNOT_DO_X_CROSS_REGION = new DynamicCommandExceptionType(
+        action -> Component.literal("Cannot " + action + " cross-region")
+    );
+
+    final LockedReference<R> dataInstance;
+    final CanonicalReference<TriCommandFunction<R, List<? extends E>, CommandSourceStack>> complete;
+    final CanonicalReference<AbstractCommandFunction<E, Function<R, R>>> commandAction;
+    final CanonicalReference<List<? extends E>> targets;
+
+    AbstractCommandExecution(final R dataInstance) {
+        this.dataInstance = new LockedReference<>(dataInstance);
+        this.complete = new CanonicalReference<>();
+        this.commandAction = new CanonicalReference<>();
+        this.targets = new CanonicalReference<>();
+    }
+
+    public static int executeAtPosWithRadius(final @NonNull CommandIntSupplier action, final @NonNull Vec3 pos, final int radius, final Level level, final CommandSourceStack css) {
+        return executeAtPosWithRadius(action, new BlockPos((int) pos.x, (int) pos.y, (int) pos.z), radius, level, css);
+    }
+
+    public static int executeAtPosWithRadius(final CommandRunnable action, final @NonNull Vec3 pos, final int radius, final Level level, final CommandSourceStack css) {
+        return executeAtPosWithRadius(action, new BlockPos((int) pos.x, (int) pos.y, (int) pos.z), radius, level, css);
+    }
+
+    public static int executeAtPosWithRadius(final CommandRunnable action, final @NonNull BlockPos pos, final int radius, final @NonNull Level level, final CommandSourceStack css) {
+        return executeAtPosWithRadius(() -> {
+            action.act();
+            return Command.SINGLE_SUCCESS;
+        }, pos, radius, level, css);
+    }
+
+    public static int executeAtPosWithRadius(final @NonNull CommandIntSupplier action, final @NonNull BlockPos pos, final int radius, final @NonNull Level level, final CommandSourceStack css) {
+        level.canvas$loadOrRunAtChunksAsync(
+            pos, radius, Priority.NORMAL, () -> {
+                try {
+                    action.act();
+                } catch (final CommandSyntaxException cse) {
+                    css.sendFailure(Component.literal(cse.getMessage()));
+                }
+            }
+        );
+        return Command.SINGLE_SUCCESS;
+    }
+
+    public static int executeAtPos(final CommandRunnable action, final @NonNull BlockPos pos, final Level level, final CommandSourceStack css) {
+        return executeAtPos(action, new Vec3(pos), level, css);
+    }
+
+    public static int executeAtPos(final CommandIntSupplier action, final @NonNull BlockPos pos, final Level level, final CommandSourceStack css) {
+        return executeAtPos(action, new Vec3(pos), level, css);
+    }
+
+    public static int executeAtPos(final CommandRunnable action, final @NonNull Vec3 pos, final Level level, final CommandSourceStack css) {
+        return executeAtPos(() -> {
+            action.act();
+            return Command.SINGLE_SUCCESS;
+        }, pos, level, css);
+    }
+
+    public static int executeAtPos(final CommandIntSupplier action, final @NonNull Vec3 pos, final Level level, final CommandSourceStack css) {
+        RegionizedServer.getInstance().taskQueue.queueOrExecuteTickTask(
+            (ServerLevel) level,
+            ((int) pos.x) >> 4,
+            ((int) pos.z) >> 4,
+            () -> {
+                try {
+                    action.act();
+                } catch (final CommandSyntaxException cse) {
+                    css.sendFailure(Component.literal(cse.getMessage()));
+                }
+            }
+        );
+        return Command.SINGLE_SUCCESS;
+    }
+
+    public static int executeOnGlobal(final CommandRunnable action, final CommandSourceStack css) {
+        return executeOnGlobal(() -> {
+            action.act();
+            return Command.SINGLE_SUCCESS;
+        }, css);
+    }
+
+    public static int executeOnGlobal(final CommandIntSupplier action, final CommandSourceStack css) {
+        RegionizedServer.getInstance().scheduleToOrExecute(() -> {
+            try {
+                action.act();
+            } catch (final CommandSyntaxException cse) {
+                css.sendFailure(Component.literal(cse.getMessage()));
+            }
+        });
+        return Command.SINGLE_SUCCESS;
+    }
+
+    @Contract("_ -> new")
+    public static <R, E extends Entity> @NonNull AbstractCommandExecution<R, E> _abstract(final R _default) {
+        return new AbstractCommandExecution<>(_default);
+    }
+
+    @Contract("_ -> new")
+    public static <E extends Entity> @NonNull AbstractCommandExecution<Boolean, E> _boolean(final boolean _default) {
+        return _abstract(_default);
+    }
+
+    @Contract(" -> new")
+    public static <E extends Entity> @NonNull AbstractCommandExecution<Void, E> _void() {
+        return _abstract(null);
+    }
+
+    @Contract(" -> new")
+    public static <E extends Entity> @NonNull AbstractCommandExecution<Integer, E> _int() {
+        return _abstract(0);
+    }
+
+    @Contract(" -> new")
+    public static <E extends Entity> @NonNull AbstractCommandExecution<Long, E> _long() {
+        return _abstract(0L);
+    }
+
+    @Contract(" -> new")
+    public static <E extends Entity> @NonNull AbstractCommandExecution<Double, E> _double() {
+        return _abstract(0.0D);
+    }
+
+    @Contract(" -> new")
+    public static <E extends Entity> @NonNull AbstractCommandExecution<Float, E> _float() {
+        return _abstract(0.0F);
+    }
+
+    public AbstractCommandExecution<R, E> noCompletion() throws CommandSyntaxException {
+        return onComplete((_, _, _) -> Command.SINGLE_SUCCESS);
+    }
+
+    public AbstractCommandExecution<R, E> onComplete(final TriCommandFunction<R, List<? extends E>, CommandSourceStack> complete) throws CommandSyntaxException {
+        if (this.complete.isSet()) {
+            throw ALREADY_PROVIDED.create("on complete");
+        }
+        this.complete.setValue(complete);
+        return this;
+    }
+
+    public AbstractCommandExecution<R, E> executes(final AbstractCommandFunction<E, Function<R, R>> action) throws CommandSyntaxException {
+        if (this.commandAction.isSet()) {
+            throw ALREADY_PROVIDED.create("command action");
+        }
+        this.commandAction.setValue(action);
+        return this;
+    }
+
+    public AbstractCommandExecution<R, E> with(final E singular) throws CommandSyntaxException {
+        return with(List.of(singular));
+    }
+
+    public AbstractCommandExecution<R, E> with(final @NonNull Stream<? extends E> targetsStream) throws CommandSyntaxException {
+        return with(targetsStream.toList());
+    }
+
+    public AbstractCommandExecution<R, E> with(final Collection<? extends E> targets) throws CommandSyntaxException {
+        if (this.targets.isSet()) {
+            throw ALREADY_PROVIDED.create("targets");
+        }
+        // stream to list so we copy it so it's immutable
+        this.targets.setValue(targets.stream().toList());
+        return this;
+    }
+
+    public void start(final CommandSourceStack sourceStack) throws CommandSyntaxException {
+        if (!this.complete.isSet()) {
+            throw INVALID_EXECUTION.create("on complete");
+        }
+        if (!this.commandAction.isSet()) {
+            throw INVALID_EXECUTION.create("on complete");
+        }
+        if (!this.targets.isSet()) {
+            throw INVALID_EXECUTION.create("on complete");
+        }
+
+        final List<? extends E> targets = this.targets.value();
+        final AtomicInteger count = new AtomicInteger(targets.size());
+
+        final Consumer<E> action = (entity) -> {
+            try {
+                final Function<R, R> dataModifier = this.commandAction.value().act(entity);
+                this.dataInstance.swapValue(dataModifier::apply);
+                if (count.decrementAndGet() == 0) {
+                    // we reached the end!
+                    this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
+                }
+            } catch (final CommandSyntaxException cse) {
+                sourceStack.sendFailure(Component.literal(cse.getMessage()));
+                if (count.decrementAndGet() == 0) {
+                    // we reached the end! unfortunately we failed though
+                    try {
+                        this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
+                    } catch (final CommandSyntaxException cse1) {
+                        sourceStack.sendFailure(Component.literal(cse1.getMessage()));
+                    }
+                }
+            }
+        };
+
+        // handle the special case where a command could give 0 valid targets
+        if (count.get() == 0) {
+            try {
+                this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
+            } catch (final CommandSyntaxException cse1) {
+                sourceStack.sendFailure(Component.literal(cse1.getMessage()));
+            }
+            return;
+        }
+
+        // iterate over all targets now and schedule or execute
+        for (final E selected : targets) {
+            if (TickThread.isTickThreadFor(selected)) {
+                action.accept(selected);
+            }
+            else {
+                selected.getBukkitEntity().taskScheduler.schedule(
+                    action, (_) -> {
+                        // entity is retired, so we just decrement
+                        // with no action being executed
+                        if (count.decrementAndGet() == 0) {
+                            try {
+                                this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
+                            } catch (final CommandSyntaxException cse1) {
+                                sourceStack.sendFailure(Component.literal(cse1.getMessage()));
+                            }
+                        }
+                    }, 1L
+                );
+            }
+        }
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
@@ -5,7 +5,6 @@ import ca.spottedleaf.moonrise.common.util.TickThread;
 import com.mojang.brigadier.Command;
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 import com.mojang.brigadier.exceptions.DynamicCommandExceptionType;
-import com.mojang.brigadier.exceptions.SimpleCommandExceptionType;
 import io.canvasmc.canvas.util.CanonicalReference;
 import io.canvasmc.canvas.util.LockedReference;
 import io.canvasmc.canvas.util.command.AbstractCommandFunction;

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
@@ -265,16 +265,17 @@ public class AbstractCommandExecution<R, E extends Entity> {
                 final Function<R, R> dataModifier = this.commandAction.value().act(entity);
                 this.dataInstance.swapValue(dataModifier::apply);
             } catch (final Throwable uncaught) {
+                hasFailed.set(true);
                 // if syntax exception, we should tell the source
                 if (uncaught instanceof CommandSyntaxException cse) {
                     sourceStack.sendFailure(Component.literal(cse.getMessage()));
+                    return;
                 }
 
                 // realistically, this should kill the server if not a CSE...in theory
                 // but only if this was scheduled. if it wasn't this will do nothing so we
                 // need to set "has failed" anyway or else this may continue
 
-                hasFailed.set(true);
                 throw new RuntimeException("Uncaught exception when executing ACE constructed command", uncaught);
             } finally {
                 if (count.decrementAndGet() == 0 && !hasFailed.get()) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
@@ -234,19 +234,23 @@ public class AbstractCommandExecution<R, E extends Entity> {
                 action.accept(selected);
             }
             else {
-                selected.getBukkitEntity().taskScheduler.schedule(
-                    action, (_) -> {
-                        // entity is retired, so we just decrement
-                        // with no action being executed
-                        if (count.decrementAndGet() == 0) {
-                            try {
-                                this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
-                            } catch (final CommandSyntaxException cse1) {
-                                sourceStack.sendFailure(Component.literal(cse1.getMessage()));
-                            }
+                final Consumer<Entity> retired = (_) -> {
+                    // entity is retired, so we just decrement
+                    // with no action being executed
+                    if (count.decrementAndGet() == 0) {
+                        try {
+                            this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
+                        } catch (final CommandSyntaxException cse1) {
+                            sourceStack.sendFailure(Component.literal(cse1.getMessage()));
                         }
-                    }, 1L
-                );
+                    }
+                };
+                if (!selected.getBukkitEntity().taskScheduler.schedule(
+                    action, retired, 1L
+                )) {
+                    // entity is retired already
+                    retired.accept(selected);
+                }
             }
         }
     }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
@@ -211,7 +211,7 @@ public class AbstractCommandExecution<R, E extends Entity> {
             throw INVALID_EXECUTION.create("on complete");
         }
         if (!this.targets.isSet()) {
-            throw INVALID_EXECUTION.create("on complete");
+            throw INVALID_EXECUTION.create("targets");
         }
 
         final List<? extends E> targets = this.targets.value();

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/AbstractCommandExecution.java
@@ -14,6 +14,7 @@ import io.canvasmc.canvas.util.command.TriCommandFunction;
 import io.papermc.paper.threadedregions.RegionizedServer;
 import java.util.Collection;
 import java.util.List;
+import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -215,27 +216,7 @@ public class AbstractCommandExecution<R, E extends Entity> {
 
         final List<? extends E> targets = this.targets.value();
         final AtomicInteger count = new AtomicInteger(targets.size());
-
-        final Consumer<E> action = (entity) -> {
-            try {
-                final Function<R, R> dataModifier = this.commandAction.value().act(entity);
-                this.dataInstance.swapValue(dataModifier::apply);
-                if (count.decrementAndGet() == 0) {
-                    // we reached the end!
-                    this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
-                }
-            } catch (final CommandSyntaxException cse) {
-                sourceStack.sendFailure(Component.literal(cse.getMessage()));
-                if (count.decrementAndGet() == 0) {
-                    // we reached the end! unfortunately we failed though
-                    try {
-                        this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
-                    } catch (final CommandSyntaxException cse1) {
-                        sourceStack.sendFailure(Component.literal(cse1.getMessage()));
-                    }
-                }
-            }
-        };
+        final Consumer<E> action = constructAction(sourceStack, count, targets);
 
         // handle the special case where a command could give 0 valid targets
         if (count.get() == 0) {
@@ -268,5 +249,42 @@ public class AbstractCommandExecution<R, E extends Entity> {
                 );
             }
         }
+    }
+
+    private @NonNull Consumer<E> constructAction(final CommandSourceStack sourceStack, final AtomicInteger count, final List<? extends E> targets) {
+        final AtomicBoolean hasFailed = new AtomicBoolean(false);
+
+        return (entity) -> {
+
+            // if we failed, don't do anything
+            if (hasFailed.get()) {
+                return;
+            }
+
+            try {
+                final Function<R, R> dataModifier = this.commandAction.value().act(entity);
+                this.dataInstance.swapValue(dataModifier::apply);
+            } catch (final Throwable uncaught) {
+                // if syntax exception, we should tell the source
+                if (uncaught instanceof CommandSyntaxException cse) {
+                    sourceStack.sendFailure(Component.literal(cse.getMessage()));
+                }
+
+                // realistically, this should kill the server if not a CSE...in theory
+                // but only if this was scheduled. if it wasn't this will do nothing so we
+                // need to set "has failed" anyway or else this may continue
+
+                hasFailed.set(true);
+                throw new RuntimeException("Uncaught exception when executing ACE constructed command", uncaught);
+            } finally {
+                if (count.decrementAndGet() == 0 && !hasFailed.get()) {
+                    try {
+                        this.complete.value().act(this.dataInstance.getValue(), targets, sourceStack);
+                    } catch (final CommandSyntaxException cse1) {
+                        sourceStack.sendFailure(Component.literal(cse1.getMessage()));
+                    }
+                }
+            }
+        };
     }
 }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/ExecutionCallbacks.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/command/execution/ExecutionCallbacks.java
@@ -1,0 +1,208 @@
+package io.canvasmc.canvas.command.execution;
+
+import java.util.function.Function;
+import org.jetbrains.annotations.Contract;
+import org.jspecify.annotations.NonNull;
+
+@SuppressWarnings("unused")
+public interface ExecutionCallbacks {
+
+    @Contract(pure = true)
+    @NonNull
+    static <A extends Number, B extends Number> Function<NumericPair<A, B>, NumericPair<A, B>> mapPairFirst(
+        Function<A, ? extends Number> fa
+    ) {
+        return pair -> pair.mapFirst(fa);
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static <A extends Number, B extends Number> Function<NumericPair<A, B>, NumericPair<A, B>> mapPairSecond(
+        Function<B, ? extends Number> fb
+    ) {
+        return pair -> pair.mapSecond(fb);
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static <A extends Number, B extends Number> Function<NumericPair<A, B>, NumericPair<A, B>> mapPairBoth(
+        Function<A, ? extends Number> fa, Function<B, ? extends Number> fb
+    ) {
+        return pair -> pair.mapBoth(fa, fb);
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static <A, B> Function<A, B> nothing() {
+        //noinspection unchecked
+        return (a) -> (B) a;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Integer, Integer> incrementInt() {
+        return (a) -> a + 1;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Integer, Integer> decrement() {
+        return (a) -> a - 1;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Integer, Integer> addInt(final int amount) {
+        return (a) -> a + amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Integer, Integer> subtractInt(final int amount) {
+        return (a) -> a - amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Integer, Integer> multiplyInt(final int amount) {
+        return (a) -> a * amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Integer, Integer> divideInt(final int amount) {
+        return (a) -> a / amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Long, Long> incrementLong() {
+        return (a) -> a + 1L;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Long, Long> decrementLong() {
+        return (a) -> a - 1L;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Long, Long> addLong(final long amount) {
+        return (a) -> a + amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Long, Long> subtractLong(final long amount) {
+        return (a) -> a - amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Long, Long> multiplyLong(final long amount) {
+        return (a) -> a * amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Long, Long> divideLong(final long amount) {
+        return (a) -> a / amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Float, Float> incrementFloat() {
+        return (a) -> a + 1.0F;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Float, Float> decrementFloat() {
+        return (a) -> a - 1.0F;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Float, Float> addFloat(final float amount) {
+        return (a) -> a + amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Float, Float> subtractFloat(final float amount) {
+        return (a) -> a - amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Float, Float> multiplyFloat(final float amount) {
+        return (a) -> a * amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Float, Float> divideFloat(final float amount) {
+        return (a) -> a / amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Double, Double> incrementDouble() {
+        return (a) -> a + 1.0D;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Double, Double> decrementDouble() {
+        return (a) -> a - 1.0D;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Double, Double> addDouble(final double amount) {
+        return (a) -> a + amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Double, Double> subtractDouble(final double amount) {
+        return (a) -> a - amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Double, Double> multiplyDouble(final double amount) {
+        return (a) -> a * amount;
+    }
+
+    @Contract(pure = true)
+    @NonNull
+    static Function<Double, Double> divideDouble(final double amount) {
+        return (a) -> a / amount;
+    }
+
+    record NumericPair<A extends Number, B extends Number>(A first, B second) {
+
+        @Contract("_, _ -> new")
+        public static <A extends Number, B extends Number> @NonNull NumericPair<A, B> of(A first, B second) {
+            return new NumericPair<>(first, second);
+        }
+
+        @Contract("_ -> new")
+        @SuppressWarnings("unchecked")
+        public @NonNull NumericPair<A, B> mapFirst(@NonNull Function<A, ? extends Number> f) {
+            return new NumericPair<>((A) f.apply(this.first), this.second);
+        }
+
+        @Contract("_ -> new")
+        @SuppressWarnings("unchecked")
+        public @NonNull NumericPair<A, B> mapSecond(@NonNull Function<B, ? extends Number> f) {
+            return new NumericPair<>(this.first, (B) f.apply(this.second));
+        }
+
+        public @NonNull NumericPair<A, B> mapBoth(Function<A, ? extends Number> fa, Function<B, ? extends Number> fb) {
+            return mapFirst(fa).mapSecond(fb);
+        }
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/CollectingList.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/CollectingList.java
@@ -1,0 +1,87 @@
+package io.canvasmc.canvas.util;
+
+import it.unimi.dsi.fastutil.objects.ObjectArrayList;
+import java.util.Collection;
+import java.util.Comparator;
+import java.util.Iterator;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * A list that returns itself for methods that modify the backing set
+ *
+ * @param <T>
+ *     the type
+ *
+ * @author dueris
+ */
+public class CollectingList<T> {
+    private final ObjectArrayList<T> backing = new ObjectArrayList<>();
+
+    public int size() {
+        return this.backing.size();
+    }
+
+    public boolean isEmpty() {
+        return this.backing.isEmpty();
+    }
+
+    public @NonNull Iterator<T> iterator() {
+        return this.backing.iterator();
+    }
+
+    public Collection<T> copyOf() {
+        return new ObjectArrayList<>(this.backing);
+    }
+
+    public <N> CollectingList<N> castAllTo(@NonNull Class<N> nClass) {
+        return new CollectingList<N>().addAll(this.backing.stream().map(nClass::cast).toList());
+    }
+
+    public CollectingList<T> addAllNotPresent(final @NonNull Collection<T> tCollection) {
+        for (final T t : tCollection) {
+            if (this.backing.contains(t)) {
+                continue;
+            }
+            this.backing.add(t);
+        }
+        return this;
+    }
+
+    public CollectingList<T> addAll(final Collection<T> tCollection) {
+        this.backing.addAll(tCollection);
+        return this;
+    }
+
+    public CollectingList<T> add(final T t) {
+        this.backing.add(t);
+        return this;
+    }
+
+    public CollectingList<T> remove(final T t) {
+        this.backing.remove(t);
+        return this;
+    }
+
+    public CollectingList<T> sort(@Nullable final Comparator<? super T> c) {
+        this.backing.sort(c);
+        return this;
+    }
+
+    public CollectingList<T> clear() {
+        this.backing.clear();
+        return this;
+    }
+
+    public T get(final int index) {
+        return this.backing.get(index);
+    }
+
+    public T getFirst() {
+        return this.backing.getFirst();
+    }
+
+    public T getLast() {
+        return this.backing.getLast();
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/TickGuard.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/TickGuard.java
@@ -4,6 +4,7 @@ import ca.spottedleaf.moonrise.common.util.EntityUtil;
 import ca.spottedleaf.moonrise.common.util.TickThread;
 import ca.spottedleaf.moonrise.common.util.WorldUtil;
 import io.canvasmc.canvas.GlobalConfiguration;
+import io.papermc.paper.threadedregions.RegionShutdownThread;
 import io.papermc.paper.threadedregions.RegionizedServer;
 import io.papermc.paper.threadedregions.TickRegions;
 import net.minecraft.core.BlockPos;
@@ -52,7 +53,12 @@ public class TickGuard {
         }
     }
 
+    // TODO - move this to Util when https://github.com/PaperMC/Paper/pull/13924 is merged
     public static void ensureGlobalOrStartup(final String reason) {
+        if (RegionShutdownThread.isShutdownThread()) {
+            // just pass, the shutdown thread owns all
+            return;
+        }
         if (TickRegions.started) {
             RegionizedServer.ensureGlobalTickThread(reason);
         }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/command/AbstractCommandFunction.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/command/AbstractCommandFunction.java
@@ -1,0 +1,8 @@
+package io.canvasmc.canvas.util.command;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+@FunctionalInterface
+public interface AbstractCommandFunction<A, B> {
+    B act(final A t) throws CommandSyntaxException;
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/command/CommandFunction.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/command/CommandFunction.java
@@ -1,4 +1,4 @@
-package io.canvasmc.canvas.util;
+package io.canvasmc.canvas.util.command;
 
 import com.mojang.brigadier.exceptions.CommandSyntaxException;
 

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/command/CommandIntSupplier.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/command/CommandIntSupplier.java
@@ -1,0 +1,8 @@
+package io.canvasmc.canvas.util.command;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+@FunctionalInterface
+public interface CommandIntSupplier {
+    int act() throws CommandSyntaxException;
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/command/CommandRunnable.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/command/CommandRunnable.java
@@ -1,0 +1,8 @@
+package io.canvasmc.canvas.util.command;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+@FunctionalInterface
+public interface CommandRunnable {
+    void act() throws CommandSyntaxException;
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/command/TriCommandFunction.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/command/TriCommandFunction.java
@@ -1,0 +1,8 @@
+package io.canvasmc.canvas.util.command;
+
+import com.mojang.brigadier.exceptions.CommandSyntaxException;
+
+@FunctionalInterface
+public interface TriCommandFunction<A, B, C> {
+    int act(final A a, B b, C c) throws CommandSyntaxException;
+}


### PR DESCRIPTION
## Overview

Both Folia and Canvas are known for cutting corners when in terms of restoring Vanilla commands to work with region threading. This often leads to issues or minor bugs or assumptions being made in command execution that lead to oddities. For example:

- Folia restores the `clear` command, which clears the inventory contents of the specified target player entities. Normally the command feedback(in English) is `Removed %s item(s) from player %s` for singular targets, and `Removed %s item(s) from %s players` for multiple targets. Folia breaks this feedback by always returning the first argument(the amount of items removed), as the same amount of entities in the target selection. This means, in Folia, if I had my inventory full of items stacked to 64, and I run the `clear` command on only myself, instead of returning `2304` items, Folia would provide feedback of `1` item being cleared. While minor, this sort of issue is present in numerous kinds of commands throughout Folia's patches.

There are also numerous cases where there is frankly, improper threading alltogether from commands restored by Folia. For example, the `swing` command is enabled in Folia while not doing any scheduling of any kind to the target(s) in question, which can lead to race conditions if the target is in a different region, given the `LivingEntity#swing` function is not thread-safe.

While these issues are minor and probably not going to be encountered all that often, these issues are yet *still present* and plentiful. The changes made in this PR aim to fix all of these issues found in the restored Vanilla commands by Canvas and Folia, since there simply lacked a system required to make these commands more closely aligned before. Both Canvas and Folia have altered functionality, and altered feedback responses, and more, to try and make commands work, but this PR brings these commands a bit closer to Vanilla, and fixes these issues, without an ugly af diff.

## The ACE API

The API in question is called the `AbstractCommandExecution` API(referred to later in this PR as "ACE"). The ACE API essentially allows defining targets, an executor, and a completion callback with abstract responses defined by the type `R` and `E extends Entity`. `R` defines the type of return the execution requires for the callback, and `E` defines the type of entity in question, like for if players specifically are required.

When constructing a new ACE instance, you are required to specify a singular `E` instance, a `Stream` of `E` instances, or a `Collection` of `E` instances. These define the entity targets that will be iterated over and scheduled to. You are also required to provide an executor, which is a functional interface that defines the logic for what happens on each entity in the target list and then what to do with the `R` data. The `R` data has synchronized mutation, meaning that when you provide the function to modify the `R` data, it will be held under locks, so no concurrency handling is required if working with a data type that is not thread-safe. The executor provides an `E` target instance, and is guaranteed that the code executed in the executor is on the owning thread of the target instance provided. An example(the `damage` command) is shown below:

```java
executes((Entity target) -> (_) -> target.hurtServer(stack.getLevel(), source, amount))
```

As you can see in the example, the executor requires returning a function that mutates the `R` data, since the `R` data is the data returned to the callback. The `hurtServer` function returns a `boolean` whether it failed to damage the entity or not, which is handled in the completion callback. The completion callback is provided the final `R` value, after being mutated across all entities in the target list, and is provided the `CommandSourceStack`, and the target list. It is worth noting that the completion callback has no guarantee of being on the owning context of the command source, so there should be no mutations to any entities at all at this point, and it should just be returning feedback of the command. The `damage` command completion callback is shown below:

```java
onComplete((passed, targets, css) -> {
    if (!passed) {
        throw ERROR_INVULNERABLE.create();
    }
    css.sendSuccess(() -> Component.translatable("commands.damage.success", amount, targets.getFirst().getDisplayName()), true);
    return Command.SINGLE_SUCCESS;
})
```

As you can see, the first variable passed is the `R` value, whether it passed or not. The second variable passed is the target list, and the third argument is the command source instance. In the `damage` command, note that the completion only checks the passed value and returns the feedback of the command *only*. It is also worth noting that the `return Command.SINGLE_SUCCESS` is simply there to simplify diff, since often times this API wraps existing Vanilla code, so we require returning an integer in response to mimic the same method descriptor as the previous enclosing method(since all commands require an integer return value). The full `damage` command reimplementation is shown below:

```java
io.canvasmc.canvas.command.execution.AbstractCommandExecution._boolean(false)
     .with(selected)
     .executes((Entity target) -> (_) -> target.hurtServer(stack.getLevel(), source, amount))
     .onComplete((passed, targets, css) -> {
         if (!passed) {
             throw ERROR_INVULNERABLE.create();
         }
         css.sendSuccess(() -> Component.translatable("commands.damage.success", amount, targets.getFirst().getDisplayName()), true);
         return Command.SINGLE_SUCCESS;
     })
     .start(stack);
```

Note, the `damage` command takes a singular target instance.

As you can see, the `damage` command takes a target, `selected`, and on the owning context of the target, it executes the `hurtServer` function and applies a mutation to the `R` value, setting it to the return value of the function, then passing it into the completion callback. The completion callback is always executed on the thread/region of the final executing entity in the target set. Ordering is not guaranteed, so no mutations should be done in the completion callback context.

Note the `start` function, which verifies the ACE definition and schedules everything, takes a `CommandSourceStack` instance, which is used to handle failures, exceptions, and be passed into the completion callback.

This system allows us to more closely align with Vanilla mechanics and behavior and more. This system also allowed this PR to fix a large sum of issues found in Folia and Canvas' restorations of certain commands.

## For reviewers

You may have to compare the diff in the source against the Folia source code and Paper source code, since some commands were fully reverted to the Paper equivalent before being re-regionized with this system.

## Extras

It was found during the creation of this PR that the stopwatches system is not properly regionized in Folia, and was recklessly enabled by Folia in [25w41a](https://minecraft.wiki/w/Java_Edition_25w41a), or `1.21.11` with no actual changes to this system to make it safe. This PR makes this system run very similarly to the scoreboards rewrite, requiring that all mutations are made on the **global tick**, while guaranteeing that all read operations are safe from any thread. Alongside this, autosave of this global data was redone to be a lot safer and better, only autosaving specific types of saved data, rather than **all** saved data, which may or may not be safe to save async.

## Side notes

All commands need extreme testing before merging. I did testing on my own to make sure they worked, however I maybe missed something or didn't test all the way. The modified commands should be tested in-game from multiple region contexts and in many scenarios to try and ensure that the changes made in this PR are safe for production.