### PR TITLE
Fix MC-261810

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FireworkRocketEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FireworkRocketEntity.java.patch
@@ -1,5 +1,29 @@
 --- a/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
 +++ b/net/minecraft/world/entity/projectile/FireworkRocketEntity.java
+@@ -126,6 +_,23 @@
+         super.inactiveTick();
+     }
+     // Paper end - EAR 2
++    // Canvas start - MC-261810
++
++    @Override
++    protected void onBelowWorld() {
++        if (
++            io.canvasmc.canvas.GlobalConfiguration.getInstance().vanillaFixes.mc261810 &&
++            this.attachedToEntity != null &&
++            ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this.attachedToEntity)
++        ) {
++            // we shouldn't discard the entity if the attached entity is still
++            // in the same tick region and we are below the void, otherwise the
++            // firework gets discarded and the boost stops like 1 tick in
++            return;
++        }
++        super.onBelowWorld();
++    }
++    // Canvas end - MC-261810
+ 
+     @Override
+     public void tick() {
 @@ -147,7 +_,7 @@
  
              if (this.attachedToEntity != null) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -452,6 +452,7 @@ public class GlobalConfiguration extends Part {
                 );
         }
 
+        public boolean mc261810 = false;
         public boolean mc298464 = false;
         public boolean mc223153 = false;
         public boolean mc200418 = false;


### PR DESCRIPTION
https://bugs.mojang.com/browse/MC/issues/MC-261810

When in the void, rockets get discarded during the rocket entity tick, thus making it so that rockets are practically ineffective if in the void with an elytra(in the void meaning you are taking damage).

This fixes it by not allowing the rocket entity to be discarded when in the void if attached to an entity in the same region.