### PR TITLE
Fix: region profiler state races

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/plugin/FoliaTickStatistics.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/plugin/FoliaTickStatistics.java
@@ -1,7 +1,6 @@
 package io.canvasmc.canvas.spark.plugin;
 
 import io.canvasmc.canvas.spark.profiler.RegionProfiler;
-import io.canvasmc.canvas.tick.SchedulerUtil;
 import io.papermc.paper.threadedregions.RegionizedServer;
 import io.papermc.paper.threadedregions.ThreadedRegionizer;
 import io.papermc.paper.threadedregions.TickRegionScheduler;
@@ -18,8 +17,9 @@ public class FoliaTickStatistics implements TickStatistics {
 
     private static double getTpsFor(TimeSpan span) {
         // we must include global tick, and all regions
-        if (isRunningIndependentRegion()) {
-            return getTpsFor(RegionProfiler.STATE.get().regionScheduleHandle(), span);
+        final RegionProfiler.ProfilingState profilingState = RegionProfiler.STATE.get();
+        if (profilingState != null) {
+            return getTpsFor(profilingState.regionScheduleHandle(), span);
         }
         DoubleArrayList tpsCounts = new DoubleArrayList();
         tpsCounts.add(getTpsFor(RegionizedServer.getGlobalTickData(), span));
@@ -53,10 +53,6 @@ public class FoliaTickStatistics implements TickStatistics {
         };
         if (d == null) return TickRegionScheduler.getTickRate();
         else return d;
-    }
-
-    private static boolean isRunningIndependentRegion() {
-        return SchedulerUtil.getHandle().isRunningRegionProfiler();
     }
 
     @Override

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/plugin/FoliaWorldInfoProvider.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/plugin/FoliaWorldInfoProvider.java
@@ -48,10 +48,11 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
 
     @Override
     public CountsResult pollCounts() {
-        if (RegionProfiler.isProfiling()) {
+        final RegionProfiler.ProfilingState profilingState = RegionProfiler.STATE.get();
+        if (profilingState != null) {
             // we need tile entities, chunks, entities, and players
             // if this isn't a region pinner, this is the global tick
-            if (RegionProfiler.STATE.get().handlePinner() instanceof RegionScheduleHandlePinner.RegionPinner pinner) {
+            if (profilingState.handlePinner() instanceof RegionScheduleHandlePinner.RegionPinner pinner) {
                 final ServerLevel level = pinner.level();
                 final ChunkPos target = pinner.getCenter();
 
@@ -80,7 +81,10 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
                 try {
                     // timeout 5 seconds like FoliaChunkInfo#getEntityCounts
                     return result.get(5, TimeUnit.SECONDS);
-                } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Couldn't fetch localized world data", e);
+                } catch (TimeoutException | ExecutionException e) {
                     throw new RuntimeException("Couldn't fetch localized world data", e);
                 }
             }
@@ -110,8 +114,9 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
         ChunksResult<FoliaChunkInfo> data = new ChunksResult<>();
 
         // Note: if we are ending a profiler, this will be cached, otherwise this is current
-        if (RegionProfiler.isProfiling()) {
-            if (RegionProfiler.STATE.get().handlePinner() instanceof RegionScheduleHandlePinner.RegionPinner pinner) {
+        final RegionProfiler.ProfilingState profilingState = RegionProfiler.STATE.get();
+        if (profilingState != null) {
+            if (profilingState.handlePinner() instanceof RegionScheduleHandlePinner.RegionPinner pinner) {
                 final ServerLevel level = pinner.level();
                 final ChunkPos target = pinner.getCenter();
                 final CompletableFuture<List<FoliaChunkInfo>> result = new CompletableFuture<>();
@@ -131,7 +136,10 @@ public class FoliaWorldInfoProvider implements WorldInfoProvider {
                     // timeout 5 seconds like FoliaChunkInfo#getEntityCounts
                     data.put(level.getWorld().getName(), result.get(5, TimeUnit.SECONDS));
                     return data;
-                } catch (InterruptedException | TimeoutException | ExecutionException e) {
+                } catch (InterruptedException e) {
+                    Thread.currentThread().interrupt();
+                    throw new RuntimeException("Couldn't fetch localized world data", e);
+                } catch (TimeoutException | ExecutionException e) {
                     throw new RuntimeException("Couldn't fetch localized world data", e);
                 }
             }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/RegionProfiler.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/spark/profiler/RegionProfiler.java
@@ -43,7 +43,8 @@ public class RegionProfiler {
             if (!SchedulerUtil.doesSupportRegionProfiler()) {
                 throw ERROR_NOT_SUPPORTED.create();
             }
-            if (!isProfiling()) {
+            final ProfilingState state = STATE.getAndSet(null);
+            if (state == null) {
                 // we aren't profiling, don't bother canceling
                 throw ERROR_NOT_PROFILING.create();
             }
@@ -51,7 +52,7 @@ public class RegionProfiler {
             // so we need this executed BEFORE scheduling.
             // if we unpin later it doesn't really matter
             unpinCallback.run();
-            STATE.getAndSet(null).handlePinner.unpin((_) -> {
+            state.handlePinner.unpin((_) -> {
                 // note: calling curr tick runner is safe here, since this callback is guaranteed to be run
                 //       on the schedule handle that is pinned, so we are on a tick runner
                 AffinitySchedulerThreadPool.TickThreadRunner threadRunner = ((AffinitySchedulerThreadPool) TickRegions.getScheduler().scheduler).getCurrentTickThreadRunner();

--- a/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/tick/SchedulerUtil.java
@@ -279,8 +279,9 @@ public class SchedulerUtil {
 
         @Override
         public boolean isRunningRegionProfilerOnThread(final long threadId, final String threadName) {
-            if (isRunningRegionProfiler()) {
-                AffinitySchedulerThreadPool.TickThreadRunner threadRunner = RegionProfiler.STATE.get().threadRunner();
+            final RegionProfiler.ProfilingState state = RegionProfiler.STATE.get();
+            if (state != null) {
+                AffinitySchedulerThreadPool.TickThreadRunner threadRunner = state.threadRunner();
                 return threadRunner.getRunnerThread().getName().equalsIgnoreCase(threadName);
             }
             return false;
@@ -303,8 +304,9 @@ public class SchedulerUtil {
 
         @Override
         public void onRegionMerge(final TickRegions.TickRegionData from, final TickRegions.TickRegionData to, final ServerLevel level) {
-            if (!isRunningRegionProfiler()) return;
-            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = RegionProfiler.STATE.get().threadRunner();
+            final RegionProfiler.ProfilingState state = RegionProfiler.STATE.get();
+            if (state == null) return;
+            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = state.threadRunner();
             if (!threadRunner.isLinkedTo(from.tickHandle)) return;
             tryTransferPinningState(from.tickHandle, to.tickHandle);
         }
@@ -314,10 +316,11 @@ public class SchedulerUtil {
         //       because the global tick can't call split
         @Override
         public void onRegionSplit(final TickRegions.TickRegionData from, final Long2ReferenceOpenHashMap<ThreadedRegionizer.ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData>> into, final ServerLevel level) {
-            if (!isRunningRegionProfiler()) return;
-            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = RegionProfiler.STATE.get().threadRunner();
+            final RegionProfiler.ProfilingState state = RegionProfiler.STATE.get();
+            if (state == null) return;
+            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = state.threadRunner();
             if (!threadRunner.isLinkedTo(from.tickHandle)) return;
-            ChunkPos center = ((RegionScheduleHandlePinner.RegionPinner) RegionProfiler.STATE.get().handlePinner()).getCenter();
+            ChunkPos center = ((RegionScheduleHandlePinner.RegionPinner) state.handlePinner()).getCenter();
             tryTransferPinningState(from.tickHandle, into.get(center.longKey()).getData().tickHandle);
         }
 
@@ -334,8 +337,9 @@ public class SchedulerUtil {
 
         private void tryDestroyLink(final ThreadedRegionizer.@NonNull ThreadedRegion<TickRegions.TickRegionData, TickRegions.TickRegionSectionData> region) {
             final TickRegions.TickRegionData data = region.getData();
-            if (!isRunningRegionProfiler()) return;
-            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = RegionProfiler.STATE.get().threadRunner();
+            final RegionProfiler.ProfilingState state = RegionProfiler.STATE.get();
+            if (state == null) return;
+            AffinitySchedulerThreadPool.TickThreadRunner threadRunner = state.threadRunner();
             if (data.tickHandle.state != null && threadRunner.isLinkedTo(data.tickHandle)) {
                 threadRunner.unlink();
             }


### PR DESCRIPTION
Fixes a few race-prone `RegionProfiler.STATE` accesses by keeping a local snapshot before using it.

Also preserves interrupt status in the Folia world info polling waits.

Testing:
- `git diff --check`
- Compile/apply patches were attempted, but local setup failed before reaching these changes.