### PR TITLE
Fix ActivityArrayMap#hashCode violating the Map hashCode contract

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/map/ActivityArrayMap.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/map/ActivityArrayMap.java
@@ -200,7 +200,11 @@ public final class ActivityArrayMap<V> implements Map<Activity, V> {
     public int hashCode() {
         int hash = 0;
         for (int i = 0; i < size; i++) {
-            hash += Objects.hashCode(k[i]) ^ Objects.hashCode(v[i]);
+            // Map.hashCode is the sum of entry hashes, where an entry hash is
+            // key.hashCode() ^ value.hashCode(). The key is the Activity, not its
+            // raw registry id, so hash the Activity to stay consistent with equals()
+            // (which compares against arbitrary Activity-keyed maps).
+            hash += BuiltInRegistries.ACTIVITY.byIdOrThrow(k[i]).hashCode() ^ Objects.hashCode(v[i]);
         }
         return hash;
     }


### PR DESCRIPTION
### Problem
`ActivityArrayMap#hashCode()` derives each entry's key hash from the raw activity registry id:

```java
hash += Objects.hashCode(k[i]) ^ Objects.hashCode(v[i]); // k[i] is the int id
```

The `Map` contract defines a map's hash as the sum of its entries' hashes, and an entry hash as `key.hashCode() ^ value.hashCode()`. The key here is an `Activity`, and `Activity#hashCode()` returns `name.hashCode()`, not the id.

Since `equals()` accepts any `Map` and compares by `Activity` keys, an `ActivityArrayMap` can be equal to an ordinary `Map<Activity, V>` (e.g. a `HashMap`) holding the same entries while returning a different `hashCode()`, which breaks the `Object` equals/hashCode contract.

The two key hashes are unrelated (id vs `name.hashCode()`):

| activity | id (used now) | Activity.hashCode() (correct) |
|----------|---------------|-------------------------------|
| core | 0 | 3059615 |
| idle | 1 | 3227604 |
| work | 2 | 3655441 |

### Fix
Hash the `Activity` itself — looked up from the id the same way `entrySet()` already reconstructs keys — so `hashCode()` stays consistent with `equals()`.

### Testing
`./gradlew :canvas-server:compileJava` builds cleanly. The change only touches the hash computation: a single map's behaviour is unchanged, and its hash is now correct when compared against other `Map` implementations.