### PR TITLE
Fix TimeSpan#inPast/inFuture throwing on week/month/year units

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/TimeSpan.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/TimeSpan.java
@@ -121,12 +121,12 @@ public class TimeSpan {
 
     public Instant inPast() {
         final Instant now = Instant.now();
-        return now.minus(count, chronoUnit);
+        return now.minus(chronoUnit.getDuration().multipliedBy(count));
     }
 
     public Instant inFuture() {
         final Instant now = Instant.now();
-        return now.plus(count, chronoUnit);
+        return now.plus(chronoUnit.getDuration().multipliedBy(count));
     }
 
     @Override


### PR DESCRIPTION
`TimeSpan` accepts week/month/year units (`w`, `mo`, `y`, ...), but `inPast()`/`inFuture()` were calling `Instant.minus(count, chronoUnit)` / `Instant.plus(...)`. `Instant` only supports temporal units up to `DAYS`, so `WEEKS`, `MONTHS` and `YEARS` throw `UnsupportedTemporalTypeException`.

This matters because the log cleaner calls `inPast()` with the user-configurable `logs.cleaner-time-span`. The default `30d` is fine, but a perfectly normal value like `2w`, `1mo` or `1y` makes the server throw during config load at startup:

```
java.time.temporal.UnsupportedTemporalTypeException: Unsupported unit: Weeks
```

I fixed it by using the unit's duration (`chronoUnit.getDuration().multipliedBy(count)`) with `Instant.minus/plus(Duration)`, which works for every `ChronoUnit` and is exactly what `asNanoSpan()` already does.

How I tested it: I built the server the normal way (`./gradlew applyAllPatches` then `./gradlew :canvas-server:runDevServer`), set `logs.enable-log-cleaner: true` and `logs.cleaner-time-span: "2w"`, and dropped an old file into `logs/`.

- Before the change the server crashes during config load with `UnsupportedTemporalTypeException: Unsupported unit: Weeks` and never finishes startup.
- After the change it logs `Log cleaner removed 1 old log files`, deletes the stale log (keeps `latest.log`) and reaches `Done!` normally.

I also checked `2w`/`1mo`/`1y` straight against `TimeSpan`: they throw before the change and return the expected instants after it.
