### PR TITLE
Add old pearl saved data migration, so saved-data parsing doesnt fail…

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
@@ -4,6 +4,11 @@ import io.papermc.paper.world.migration.WorldMigrationContext;
 import java.io.IOException;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.util.ArrayList;
+import net.minecraft.nbt.CompoundTag;
+import net.minecraft.nbt.NbtAccounter;
+import net.minecraft.nbt.NbtIo;
+import net.minecraft.nbt.Tag;
 import net.minecraft.world.level.storage.LevelResource;
 
 public class PearlsMigration implements Migration {
@@ -12,20 +17,38 @@ public class PearlsMigration implements Migration {
 
     @Override
     public void conduct(final WorldMigrationContext context) {
-        // old data just needs to be moved to the new data folder, honestly not that bad tbh
         try {
             final Path newPath = resolveNewPath(context);
             // create directories first or else we throw
             Files.createDirectories(newPath.getParent());
 
-            // now move
-            Files.move(
-                OLD_PATH,
-                newPath
-            );
+            final CompoundTag oldData = NbtIo.readCompressed(OLD_PATH, NbtAccounter.unlimitedHeap());
+            NbtIo.writeCompressed(migratePearlsTag(oldData), newPath);
+            Files.delete(OLD_PATH);
         } catch (final IOException ioe) {
             throw new RuntimeException("Couldn't conduct pearl migration", ioe);
         }
+    }
+
+    public static CompoundTag migratePearlsTag(final CompoundTag oldData) {
+        if (oldData.contains("data")) {
+            return oldData;
+        }
+
+        final CompoundTag wrappedData = new CompoundTag();
+        for (final String key : new ArrayList<>(oldData.keySet())) {
+            if ("DataVersion".equals(key)) {
+                continue;
+            }
+
+            final Tag value = oldData.remove(key);
+            if (value != null) {
+                wrappedData.put(key, value);
+            }
+        }
+
+        oldData.put("data", wrappedData);
+        return oldData;
     }
 
     @Override

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
@@ -78,7 +78,7 @@ public class PearlsMigration implements Migration {
 
     @Override
     public boolean hasOldData(final WorldMigrationContext context) {
-        return Files.exists(OLD_PATH) || needsMigration(resolveNewPath(context)); // pre-26.1 path or pre-release 26.2 data shape
+        return Files.exists(OLD_PATH) || needsMigration(resolveNewPath(context)); // pre-26.1 path or pre-merger 26.2 data shape
     }
 
     @Override

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
@@ -22,16 +22,25 @@ public class PearlsMigration implements Migration {
             // create directories first or else we throw
             Files.createDirectories(newPath.getParent());
 
-            final CompoundTag oldData = NbtIo.readCompressed(OLD_PATH, NbtAccounter.unlimitedHeap());
-            NbtIo.writeCompressed(migratePearlsTag(oldData), newPath);
-            Files.delete(OLD_PATH);
+            if (Files.exists(newPath)) {
+                migratePearlsFile(newPath);
+            } else {
+                final CompoundTag oldData = NbtIo.readCompressed(OLD_PATH, NbtAccounter.unlimitedHeap());
+                NbtIo.writeCompressed(migratePearlsTag(oldData), newPath);
+                Files.delete(OLD_PATH);
+            }
         } catch (final IOException ioe) {
             throw new RuntimeException("Couldn't conduct pearl migration", ioe);
         }
     }
 
+    public static void migratePearlsFile(final Path path) throws IOException {
+        final CompoundTag oldData = NbtIo.readCompressed(path, NbtAccounter.unlimitedHeap());
+        NbtIo.writeCompressed(migratePearlsTag(oldData), path);
+    }
+
     public static CompoundTag migratePearlsTag(final CompoundTag oldData) {
-        if (oldData.contains("data")) {
+        if (isModernPearlsTag(oldData)) {
             return oldData;
         }
 
@@ -51,14 +60,31 @@ public class PearlsMigration implements Migration {
         return oldData;
     }
 
+    public static boolean isModernPearlsTag(final CompoundTag tag) {
+        return tag.get("data") instanceof CompoundTag;
+    }
+
+    public static boolean needsMigration(final Path path) {
+        if (!Files.exists(path)) {
+            return false;
+        }
+
+        try {
+            return !isModernPearlsTag(NbtIo.readCompressed(path, NbtAccounter.unlimitedHeap()));
+        } catch (final IOException ioe) {
+            throw new RuntimeException("Couldn't read pearl data for migration", ioe);
+        }
+    }
+
     @Override
     public boolean hasOldData(final WorldMigrationContext context) {
-        return Files.exists(OLD_PATH); // pre-26.1 path
+        return Files.exists(OLD_PATH) || needsMigration(resolveNewPath(context)); // pre-26.1 path or pre-release 26.2 data shape
     }
 
     @Override
     public boolean hasNewData(final WorldMigrationContext context) {
-        return Files.exists(resolveNewPath(context));
+        final Path newPath = resolveNewPath(context);
+        return Files.exists(newPath) && !needsMigration(newPath);
     }
 
     private static Path resolveNewPath(final WorldMigrationContext context) {

--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/migration/PearlsMigration.java
@@ -46,7 +46,7 @@ public class PearlsMigration implements Migration {
 
         final CompoundTag wrappedData = new CompoundTag();
         for (final String key : new ArrayList<>(oldData.keySet())) {
-            if ("DataVersion".equals(key)) {
+            if (key.equals("DataVersion")) {
                 continue;
             }
 


### PR DESCRIPTION
… on pearls.dat files -> pearls go poof.

- Convert old pearl data layout during file migration
- Preserve DataVersion at the root while moving saved pearl payload under data

Tested it and the error was gone 