### PR TITLE
Update FasterRandomSource.java

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/util/FasterRandomSource.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/util/FasterRandomSource.java
@@ -86,8 +86,8 @@ public class FasterRandomSource implements BitRandomSource {
 
         @Override
         public RandomSource fromHashOf(String seed) {
-            int i = seed.hashCode();
-            return new FasterRandomSource((long) i ^ this.seed);
+            long i = (long) seed.hashCode() & 0xFFFFFFFFL;
+            return new FasterRandomSource(i ^ this.seed);
         }
 
         @Override


### PR DESCRIPTION
the fromHashOf method was making an incorrect conversion when converting strings to random numbers the hash code of the string is a 32 bit number when converting this to 64 bits the upper part was always getting the same values because of this different strings were converting into the same number and everything was generating the same in world generation with the fix this issue was resolved