### PR TITLE
Features: Each region could have its own weather.

### DIFF
--- a/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/RegionalWeatherSnapshot.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/RegionalWeatherSnapshot.java
@@ -1,0 +1,12 @@
+package io.canvasmc.canvas.world.weather;
+
+public record RegionalWeatherSnapshot(
+    long regionId,
+    boolean raining,
+    boolean thundering,
+    int clearTime,
+    int rainTime,
+    int thunderTime,
+    float rainLevel,
+    float thunderLevel
+) {}

--- a/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/RegionalWeatherSnapshot.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/RegionalWeatherSnapshot.java
@@ -1,5 +1,21 @@
 package io.canvasmc.canvas.world.weather;
 
+/**
+ * Immutable snapshot of a region's weather at the time of the call.
+ *
+ * <p>Returned by {@link WeatherController#getRegionalWeather(org.bukkit.World, int, int)}.
+ * It is a plain copy and does not reflect changes made after it was taken.</p>
+ *
+ * @param regionId     unique id of the ticking region
+ * @param raining      whether the region is currently raining
+ * @param thundering   whether the region is currently thundering
+ * @param clearTime    remaining ticks of clear weather before the cycle may change
+ * @param rainTime     remaining ticks of rain
+ * @param thunderTime  remaining ticks of thunder
+ * @param rainLevel    current rain intensity, in {@code [0..1]}; fades progressively
+ *                     toward its target unless set instantly
+ * @param thunderLevel current thunder intensity, in {@code [0..1]}
+ */
 public record RegionalWeatherSnapshot(
     long regionId,
     boolean raining,
@@ -9,4 +25,5 @@ public record RegionalWeatherSnapshot(
     int thunderTime,
     float rainLevel,
     float thunderLevel
-) {}
+) {
+}

--- a/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherController.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherController.java
@@ -2,23 +2,75 @@ package io.canvasmc.canvas.world.weather;
 
 import org.bukkit.Location;
 import org.bukkit.World;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * API to read and change the weather of individual ticking regions,
+ * when per-region weather is enabled.
+ *
+ * <p>Must be called from the tick thread owning the targeted region.</p>
+ */
+@NullMarked
 public interface WeatherController {
 
+    /**
+     * Sets the weather of the region owning the given chunk.
+     *
+     * @param world         the world containing the region
+     * @param chunkX        chunk X coordinate used to locate the region
+     * @param chunkZ        chunk Z coordinate used to locate the region
+     * @param type          target weather ({@code CLEAR}, {@code RAIN} or {@code THUNDER})
+     * @param durationTicks how long to hold this weather, in ticks; a value {@code <= 0}
+     *                      lets the current weather cycle continue naturally
+     * @param instantLevels if {@code true}, applies the rain/thunder intensities
+     *                      immediately instead of fading progressively
+     * @throws IllegalStateException if not called from the region's tick thread
+     */
     void setRegionalWeather(World world, int chunkX, int chunkZ, WeatherType type, int durationTicks, boolean instantLevels);
 
+    /**
+     * Sets the weather of the region owning the given location.
+     *
+     * @param loc           the location whose chunk determines the region
+     * @param type          target weather ({@code CLEAR}, {@code RAIN} or {@code THUNDER})
+     * @param durationTicks how long to hold this weather, in ticks; a value {@code <= 0}
+     *                      lets the current weather cycle continue naturally
+     * @param instantLevels if {@code true}, applies the rain/thunder intensities
+     *                      immediately instead of fading progressively
+     * @throws IllegalStateException if not called from the region's tick thread
+     * @see #setRegionalWeather(World, int, int, WeatherType, int, boolean)
+     */
     default void setRegionalWeather(Location loc, WeatherType type, int durationTicks, boolean instantLevels) {
-        final int cx = loc.getBlockX() >> 4;
-        final int cz = loc.getBlockZ() >> 4;
-        setRegionalWeather(loc.getWorld(), cx, cz, type, durationTicks, instantLevels);
+        final int chunkX = loc.getBlockX() >> 4;
+        final int chunkZ = loc.getBlockZ() >> 4;
+        setRegionalWeather(loc.getWorld(), chunkX, chunkZ, type, durationTicks, instantLevels);
     }
 
+    /**
+     * Returns a snapshot of the weather of the region owning the given chunk.
+     *
+     * @param world  the world containing the region
+     * @param chunkX chunk X coordinate used to locate the region
+     * @param chunkZ chunk Z coordinate used to locate the region
+     * @return the current weather state of the region, or {@code null} if
+     * per-region weather is disabled for this world
+     * @throws IllegalStateException if not called from the region's tick thread
+     */
     @Nullable RegionalWeatherSnapshot getRegionalWeather(World world, int chunkX, int chunkZ);
 
+    /**
+     * Returns a snapshot of the weather of the region owning the given location.
+     *
+     * @param loc the location whose chunk determines the region
+     * @return the current weather state of the region, or {@code null} if
+     * per-region weather is disabled for this world
+     * @throws IllegalStateException if not called from the region's tick thread
+     * @see #getRegionalWeather(World, int, int)
+     */
     default @Nullable RegionalWeatherSnapshot getRegionalWeather(Location loc) {
-        final int cx = loc.getBlockX() >> 4;
-        final int cz = loc.getBlockZ() >> 4;
-        return getRegionalWeather(loc.getWorld(), cx, cz);
+        final int chunkX = loc.getBlockX() >> 4;
+        final int chunkZ = loc.getBlockZ() >> 4;
+        return getRegionalWeather(loc.getWorld(), chunkX, chunkZ);
     }
 }

--- a/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherController.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherController.java
@@ -1,0 +1,24 @@
+package io.canvasmc.canvas.world.weather;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.jspecify.annotations.Nullable;
+
+public interface WeatherController {
+
+    void setRegionalWeather(World world, int chunkX, int chunkZ, WeatherType type, int durationTicks, boolean instantLevels);
+
+    default void setRegionalWeather(Location loc, WeatherType type, int durationTicks, boolean instantLevels) {
+        final int cx = loc.getBlockX() >> 4;
+        final int cz = loc.getBlockZ() >> 4;
+        setRegionalWeather(loc.getWorld(), cx, cz, type, durationTicks, instantLevels);
+    }
+
+    @Nullable RegionalWeatherSnapshot getRegionalWeather(World world, int chunkX, int chunkZ);
+
+    default @Nullable RegionalWeatherSnapshot getRegionalWeather(Location loc) {
+        final int cx = loc.getBlockX() >> 4;
+        final int cz = loc.getBlockZ() >> 4;
+        return getRegionalWeather(loc.getWorld(), cx, cz);
+    }
+}

--- a/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherType.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherType.java
@@ -1,0 +1,7 @@
+package io.canvasmc.canvas.world.weather;
+
+public enum WeatherType {
+    CLEAR,
+    RAIN,
+    THUNDER
+}

--- a/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherType.java
+++ b/canvas-api/src/main/java/io/canvasmc/canvas/world/weather/WeatherType.java
@@ -1,7 +1,23 @@
 package io.canvasmc.canvas.world.weather;
 
+/**
+ * Target weather states usable with
+ * {@link WeatherController#setRegionalWeather(org.bukkit.World, int, int, WeatherType, int, boolean)}.
+ */
 public enum WeatherType {
+
+    /**
+     * No precipitation: rain and thunder stop, intensity levels fade to {@code 0}.
+     */
     CLEAR,
+
+    /**
+     * Rain without thunder.
+     */
     RAIN,
+
+    /**
+     * Thunderstorm. Implies rain: both rain and thunder levels are raised.
+     */
     THUNDER
 }

--- a/canvas-server/minecraft-patches/features/0001-Purpur-Alternative-Keepalive.patch
+++ b/canvas-server/minecraft-patches/features/0001-Purpur-Alternative-Keepalive.patch
@@ -7,7 +7,7 @@ This code is from PurpurMC/Purpur, licensed under MIT, initially ported from 26.
 https://github.com/PurpurMC/Purpur/blob/ver/26.1.2/purpur-server/minecraft-patches/sources/net/minecraft/server/network/ServerCommonPacketListenerImpl.java.patch
 
 diff --git a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
-index ee94cd5a0f6e06f6fa7511ec9413bea318b9d218..5b6a3062886a73f0f6250b07d37cb1c2b3ff2609 100644
+index bdf74f927a4ec420d98b3f3b5a51ed2df5fc5776..e9fc4bc8cadd35cb85702dac286e4f88457d206f 100644
 --- a/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 +++ b/net/minecraft/server/network/ServerCommonPacketListenerImpl.java
 @@ -39,10 +39,11 @@ public abstract class ServerCommonPacketListenerImpl implements ServerCommonPack

--- a/canvas-server/minecraft-patches/features/0003-Each-region-could-have-its-own-weather.patch
+++ b/canvas-server/minecraft-patches/features/0003-Each-region-could-have-its-own-weather.patch
@@ -5,14 +5,14 @@ Subject: [PATCH] Each region could have its own weather
 
 
 diff --git a/io/papermc/paper/threadedregions/RegionizedWorldData.java b/io/papermc/paper/threadedregions/RegionizedWorldData.java
-index d0a319856e641f06d92ea61a1a55ee8782781090..081aeb1345a838346673aa77756c83a6ee02c013 100644
+index d0a319856e641f06d92ea61a1a55ee8782781090..9d9e6385b80c0bdece524464b79c1ac22919ed4a 100644
 --- a/io/papermc/paper/threadedregions/RegionizedWorldData.java
 +++ b/io/papermc/paper/threadedregions/RegionizedWorldData.java
-@@ -161,6 +161,36 @@ public final class RegionizedWorldData {
+@@ -161,6 +161,37 @@ public final class RegionizedWorldData {
              into.phantomSpawnerNextTick = Math.max(from.phantomSpawnerNextTick, into.phantomSpawnerNextTick);
              // chunkHoldersToBroadcast
              into.chunkHoldersToBroadcast.addAll(from.chunkHoldersToBroadcast);
-+            // weather
++            // Canvas start - weather per-region
 +            if (from.world.canvasConfig().weather.perRegion) {
 +                if (from.weatherRegional != null) {
 +                    if (into.weatherRegional == null) {
@@ -42,10 +42,11 @@ index d0a319856e641f06d92ea61a1a55ee8782781090..081aeb1345a838346673aa77756c83a6
 +                    }
 +                }
 +            }
++            // Canvas end - weather per-region
          }
  
          @Override
-@@ -334,6 +364,16 @@ public final class RegionizedWorldData {
+@@ -334,6 +365,16 @@ public final class RegionizedWorldData {
                      into.chunkHoldersToBroadcast.add(chunkHolder);
                  }
              }
@@ -62,7 +63,7 @@ index d0a319856e641f06d92ea61a1a55ee8782781090..081aeb1345a838346673aa77756c83a6
          }
      };
  
-@@ -795,4 +835,48 @@ public final class RegionizedWorldData {
+@@ -795,4 +836,48 @@ public final class RegionizedWorldData {
      public int getChunkCount() {
          return this.chunks.size();
      }
@@ -99,10 +100,10 @@ index d0a319856e641f06d92ea61a1a55ee8782781090..081aeb1345a838346673aa77756c83a6
 +        dst.initialized = src.initialized;
 +    }
 +
-+    private static int weatherWeight(final RegionalWeatherState st, final ServerLevel level) {
++    private static int weatherWeight(final RegionalWeatherState weatherState, final ServerLevel level) {
 +        final var weights = level.canvasConfig().weather.weatherWeights;
-+        if (st.thundering) return weights.thunder;
-+        if (st.raining)    return weights.rain;
++        if (weatherState.thundering) return weights.thunder;
++        if (weatherState.raining)    return weights.rain;
 +        return weights.clear;
 +    }
 +
@@ -112,7 +113,7 @@ index d0a319856e641f06d92ea61a1a55ee8782781090..081aeb1345a838346673aa77756c83a6
 +    // Canvas end - weather per-region
  }
 diff --git a/net/minecraft/server/commands/WeatherCommand.java b/net/minecraft/server/commands/WeatherCommand.java
-index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896f8e9bdfc 100644
+index d0826acd4de70a7030d408faeb42903900bbbb74..ab7be92064dd70c517bbc649f2c9b8f4d02e4d77 100644
 --- a/net/minecraft/server/commands/WeatherCommand.java
 +++ b/net/minecraft/server/commands/WeatherCommand.java
 @@ -40,6 +40,12 @@ public class WeatherCommand {
@@ -148,20 +149,20 @@ index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896
 +
 +            if (player != null) {
 +                final var worldData = level.getCurrentWorldData();
-+                final var st = worldData.weatherRegional;
-+                if (st != null) {
-+                    st.initialized = true;
-+                    st.regionSeed = level.getSeed() ^ worldData.regionData.id;
++                final var weatherState = worldData.weatherRegional;
++                if (weatherState != null) {
++                    weatherState.initialized = true;
++                    weatherState.regionSeed = level.getSeed() ^ worldData.regionData.id;
 +
-+                    st.raining = false;
-+                    st.thundering = false;
++                    weatherState.raining = false;
++                    weatherState.thundering = false;
 +
-+                    st.clearTime = duration;
-+                    st.rainTime = 0;
-+                    st.thunderTime = 0;
++                    weatherState.clearTime = duration;
++                    weatherState.rainTime = 0;
++                    weatherState.thunderTime = 0;
 +
-+                    st.rainLevel = 0.0F;
-+                    st.thunderLevel = 0.0F;
++                    weatherState.rainLevel = 0.0F;
++                    weatherState.thunderLevel = 0.0F;
 +                }
 +            } else {
 +                source.getServer().setWeatherParameters(source.getLevel(), durationTime, 0, false, false); // CraftBukkit - SPIGOT-7680: per-world
@@ -189,20 +190,20 @@ index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896
 +
 +            if (player != null) {
 +                final var worldData = level.getCurrentWorldData();
-+                final var st = worldData.weatherRegional;
-+                if (st != null) {
-+                    st.initialized = true;
-+                    st.regionSeed = level.getSeed() ^ worldData.regionData.id;
++                final var weatherState = worldData.weatherRegional;
++                if (weatherState != null) {
++                    weatherState.initialized = true;
++                    weatherState.regionSeed = level.getSeed() ^ worldData.regionData.id;
 +
-+                    st.raining = true;
-+                    st.thundering = false;
++                    weatherState.raining = true;
++                    weatherState.thundering = false;
 +
-+                    st.rainTime = duration;
-+                    st.clearTime = 0;
-+                    st.thunderTime = 0;
++                    weatherState.rainTime = duration;
++                    weatherState.clearTime = 0;
++                    weatherState.thunderTime = 0;
 +
-+                    st.rainLevel = 1.0F;
-+                    st.thunderLevel = 0.0F;
++                    weatherState.rainLevel = 1.0F;
++                    weatherState.thunderLevel = 0.0F;
 +                }
 +            } else {
 +                source.getServer().setWeatherParameters(source.getLevel(), 0, durationTime, true, false); // CraftBukkit - SPIGOT-7680: per-world
@@ -231,20 +232,20 @@ index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896
 +
 +            if (player != null) {
 +                final var worldData = level.getCurrentWorldData();
-+                final var st = worldData.weatherRegional;
-+                if (st != null) {
-+                    st.initialized = true;
-+                    st.regionSeed = level.getSeed() ^ worldData.regionData.id;
++                final var weatherState = worldData.weatherRegional;
++                if (weatherState != null) {
++                    weatherState.initialized = true;
++                    weatherState.regionSeed = level.getSeed() ^ worldData.regionData.id;
 +
-+                    st.raining = true;
-+                    st.thundering = true;
++                    weatherState.raining = true;
++                    weatherState.thundering = true;
 +
-+                    st.rainTime = duration;
-+                    st.thunderTime = duration;
-+                    st.clearTime = 0;
++                    weatherState.rainTime = duration;
++                    weatherState.thunderTime = duration;
++                    weatherState.clearTime = 0;
 +
-+                    st.rainLevel = 1.0F;
-+                    st.thunderLevel = 1.0F;
++                    weatherState.rainLevel = 1.0F;
++                    weatherState.thunderLevel = 1.0F;
 +                }
 +            } else {
 +                source.getServer().setWeatherParameters(source.getLevel(), 0, durationTime, true, true); // CraftBukkit - SPIGOT-7680: per-world
@@ -262,13 +263,13 @@ index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896
 +
 +        if (level.canvasConfig().weather.perRegion && player != null) {
 +            final var worldData = level.getCurrentWorldData();
-+            final var st = worldData.weatherRegional;
++            final var weatherState = worldData.weatherRegional;
 +
-+            if (st != null && st.initialized) {
-+                if (st.thundering) {
++            if (weatherState != null && weatherState.initialized) {
++                if (weatherState.thundering) {
 +                    source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetThunder), false);
 +                    return 2;
-+                } else if (st.raining) {
++                } else if (weatherState.raining) {
 +                    source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetRain), false);
 +                    return 1;
 +                } else {
@@ -295,10 +296,10 @@ index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896
 +        if (level.canvasConfig().weather.perRegion) {
 +            final var player = source.getPlayer();
 +            if (player != null) {
-+                final int cx = player.chunkPosition().x();
-+                final int cz = player.chunkPosition().z();
++                final int chunkX = player.chunkPosition().x();
++                final int chunkZ = player.chunkPosition().z();
 +
-+                io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueChunkTask(level, cx, cz, run);
++                io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueChunkTask(level, chunkX, chunkZ, run);
 +                return;
 +            }
 +        }
@@ -307,7 +308,7 @@ index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896
 +    // Canvas end - weather per-region
  }
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
-index 62bd76bdefc87130d53b4fb78ec9e91b7f1308e5..3b366191fffdf33a14b4c0df5323e78224fde89f 100644
+index 62bd76bdefc87130d53b4fb78ec9e91b7f1308e5..54e51f10ef233674e4274c3b9be5396de670fe83 100644
 --- a/net/minecraft/server/level/ServerChunkCache.java
 +++ b/net/minecraft/server/level/ServerChunkCache.java
 @@ -559,6 +559,31 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
@@ -315,8 +316,8 @@ index 62bd76bdefc87130d53b4fb78ec9e91b7f1308e5..3b366191fffdf33a14b4c0df5323e782
          }
          // Paper end - Optional per player mob spawns
 +        if (this.level.canvasConfig().weather.perRegion) {
-+            final var st = regionizedWorldData.weatherRegional;
-+            if (st != null && st.initialized) {
++            final var weatherState = regionizedWorldData.weatherRegional;
++            if (weatherState != null && weatherState.initialized) {
 +                final boolean wasRaining = regionizedWorldData._wasRaining;
 +                final float oldRainLevel = regionizedWorldData._oldRainLevel;
 +                final float oldThunderLevel = regionizedWorldData._oldThunderLevel;
@@ -325,7 +326,7 @@ index 62bd76bdefc87130d53b4fb78ec9e91b7f1308e5..3b366191fffdf33a14b4c0df5323e782
 +                        player.tickWeather();
 +                    }
 +                }
-+                if (wasRaining != st.raining) {
++                if (wasRaining != weatherState.raining) {
 +                    for (net.minecraft.server.level.ServerPlayer player : regionizedWorldData.getLocalPlayers()) {
 +                        if (player.level() == this.level) {
 +                            player.setPlayerWeather((!wasRaining ? org.bukkit.WeatherType.DOWNFALL : org.bukkit.WeatherType.CLEAR), false);
@@ -334,7 +335,7 @@ index 62bd76bdefc87130d53b4fb78ec9e91b7f1308e5..3b366191fffdf33a14b4c0df5323e782
 +                }
 +                for (net.minecraft.server.level.ServerPlayer player : regionizedWorldData.getLocalPlayers()) {
 +                    if (player.level() == this.level) {
-+                        player.updateWeather(oldRainLevel, st.rainLevel, oldThunderLevel, st.thunderLevel);
++                        player.updateWeather(oldRainLevel, weatherState.rainLevel, oldThunderLevel, weatherState.thunderLevel);
 +                    }
 +                }
 +            }
@@ -343,7 +344,7 @@ index 62bd76bdefc87130d53b4fb78ec9e91b7f1308e5..3b366191fffdf33a14b4c0df5323e782
          boolean doMobSpawning = this.level.getGameRules().get(GameRules.SPAWN_MOBS) && !this.level.getLocalPlayers().isEmpty(); // CraftBukkit // Folia - region threading
          int tickSpeed = this.level.getGameRules().get(GameRules.RANDOM_TICK_SPEED);
 diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
-index 33971e08cfe0a9b255362e8856da1485f33fced4..8ced3b683c6d4c86237f03b481ed1a4cc70c7aff 100644
+index 33971e08cfe0a9b255362e8856da1485f33fced4..8a3d162a5feb6ef8f42c5c2bb57a75eb19cadef0 100644
 --- a/net/minecraft/server/level/ServerLevel.java
 +++ b/net/minecraft/server/level/ServerLevel.java
 @@ -854,6 +854,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
@@ -360,11 +361,11 @@ index 33971e08cfe0a9b255362e8856da1485f33fced4..8ced3b683c6d4c86237f03b481ed1a4c
              }
 +            // Canvas start - weather per-region
 +            if (region.world.canvasConfig().weather.perRegion) {
-+                final var st0 = regionizedWorldData.weatherRegional;
-+                if (st0 != null && st0.initialized) {
-+                    regionizedWorldData._wasRaining = st0.raining;
-+                    regionizedWorldData._oldThunderLevel = st0.thunderLevel;
-+                    regionizedWorldData._oldRainLevel = st0.rainLevel;
++                final var weatherState = regionizedWorldData.weatherRegional;
++                if (weatherState != null && weatherState.initialized) {
++                    regionizedWorldData._wasRaining = weatherState.raining;
++                    regionizedWorldData._oldThunderLevel = weatherState.thunderLevel;
++                    regionizedWorldData._oldRainLevel = weatherState.rainLevel;
 +                }
 +                canvas$weatherServer.tickRegion(this, regionizedWorldData);
 +            }
@@ -403,9 +404,9 @@ index 33971e08cfe0a9b255362e8856da1485f33fced4..8ced3b683c6d4c86237f03b481ed1a4c
 +    public boolean isRaining() {
 +        if (!this.canHaveWeather()) return false;
 +
-+        final var st = regionalWeatherOrNull();
-+        if (st != null) {
-+            return st.rainLevel > 0.2f;
++        final var weatherState = regionalWeatherOrNull();
++        if (weatherState != null) {
++            return weatherState.rainLevel > 0.2f;
 +        }
 +        return super.isRaining();
 +    }
@@ -414,31 +415,31 @@ index 33971e08cfe0a9b255362e8856da1485f33fced4..8ced3b683c6d4c86237f03b481ed1a4c
 +    public boolean isThundering() {
 +        if (!this.canHaveWeather()) return false;
 +
-+        final var st = regionalWeatherOrNull();
-+        if (st != null) {
-+            return (st.thunderLevel * st.rainLevel) > 0.9f;
++        final var weatherState = regionalWeatherOrNull();
++        if (weatherState != null) {
++            return (weatherState.thunderLevel * weatherState.rainLevel) > 0.9f;
 +        }
 +        return super.isThundering();
 +    }
 +
 +    public float getRainLevel(float partialTick) {
-+        final var st = regionalWeatherOrNull();
-+        if (st != null) {
-+            return net.minecraft.util.Mth.lerp(partialTick, st.oRainLevel, st.rainLevel);
++        final var weatherState = regionalWeatherOrNull();
++        if (weatherState != null) {
++            return net.minecraft.util.Mth.lerp(partialTick, weatherState.oRainLevel, weatherState.rainLevel);
 +        }
 +        return super.getRainLevel(partialTick);
 +    }
 +
 +    public float getThunderLevel(float partialTick) {
-+        final var st = regionalWeatherOrNull();
-+        if (st != null) {
-+            return net.minecraft.util.Mth.lerp(partialTick, st.oThunderLevel, st.thunderLevel);
++        final var weatherState = regionalWeatherOrNull();
++        if (weatherState != null) {
++            return net.minecraft.util.Mth.lerp(partialTick, weatherState.oThunderLevel, weatherState.thunderLevel);
 +        }
 +        return super.getThunderLevel(partialTick);
 +    }
  }
 diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
-index 9478cdf451a7a542ba34c162586d782ca12ccf5f..e003e179386d85ab05ede972860745028acfb185 100644
+index 9478cdf451a7a542ba34c162586d782ca12ccf5f..905e45245e70f47f5b4b665505175f45dabca8b7 100644
 --- a/net/minecraft/server/level/ServerPlayer.java
 +++ b/net/minecraft/server/level/ServerPlayer.java
 @@ -3772,6 +3772,60 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
@@ -450,18 +451,18 @@ index 9478cdf451a7a542ba34c162586d782ca12ccf5f..e003e179386d85ab05ede97286074502
 +    private boolean canvas$regionalWasRaining;
 +    private float canvas$regionalRainLevel;
 +    private float canvas$regionalThunderLevel;
-+    public void canvas$syncRegionalWeather(final io.papermc.paper.threadedregions.RegionizedWorldData.RegionalWeatherState st) {
++    public void canvas$syncRegionalWeather(final io.papermc.paper.threadedregions.RegionizedWorldData.RegionalWeatherState weatherState) {
 +        if (this.weatherType != null) {
 +            return;
 +        }
 +
-+        if (st == null || this.connection == null) {
++        if (weatherState == null || this.connection == null) {
 +            return;
 +        }
 +
-+        final boolean raining = st.raining;
-+        final float rainLevel = st.rainLevel;
-+        final float thunderLevel = st.thunderLevel;
++        final boolean raining = weatherState.raining;
++        final float rainLevel = weatherState.rainLevel;
++        final float thunderLevel = weatherState.thunderLevel;
 +
 +        // First sync (join / region move)
 +        if (!this.canvas$regionalWeatherInit) {

--- a/canvas-server/minecraft-patches/features/0003-Each-region-could-have-its-own-weather.patch
+++ b/canvas-server/minecraft-patches/features/0003-Each-region-could-have-its-own-weather.patch
@@ -1,8 +1,7 @@
 From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
 From: Euphyllia Bierque <bierque.euphyllia@gmail.com>
 Date: Tue, 7 Jul 2026 00:47:03 +0200
-Subject: [PATCH] feat(weather): add per-region weather system with
- configurable merge strategy
+Subject: [PATCH] Each region could have its own weather
 
 
 diff --git a/io/papermc/paper/threadedregions/RegionizedWorldData.java b/io/papermc/paper/threadedregions/RegionizedWorldData.java
@@ -110,6 +109,201 @@ index d0a319856e641f06d92ea61a1a55ee8782781090..081aeb1345a838346673aa77756c83a6
 +    public transient boolean _wasRaining;
 +    public transient float _oldRainLevel;
 +    public transient float _oldThunderLevel;
++    // Canvas end - weather per-region
+ }
+diff --git a/net/minecraft/server/commands/WeatherCommand.java b/net/minecraft/server/commands/WeatherCommand.java
+index d0826acd4de70a7030d408faeb42903900bbbb74..a98dfadc162f4a4cc712e93b27907896f8e9bdfc 100644
+--- a/net/minecraft/server/commands/WeatherCommand.java
++++ b/net/minecraft/server/commands/WeatherCommand.java
+@@ -40,6 +40,12 @@ public class WeatherCommand {
+                                 .executes(c -> setThunder(c.getSource(), IntegerArgumentType.getInteger(c, "duration")))
+                         )
+                 )
++                // Canvas start - weather per region
++                .then(
++                    Commands.literal("get")
++                        .executes(c -> getWeather(c.getSource()))
++                )
++                // Canvas end - weather per region
+         );
+     }
+ 
+@@ -48,26 +54,165 @@ public class WeatherCommand {
+     }
+ 
+     private static int setClear(final CommandSourceStack source, final int duration) {
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
+-        source.getServer().setWeatherParameters(source.getLevel(), getDuration(source, duration, ServerLevel.RAIN_DELAY), 0, false, false); // CraftBukkit - SPIGOT-7680: per-world
+-        source.sendSuccess(() -> Component.translatable("commands.weather.set.clear"), true);
+-        }); // Folia - region threading
++        // Canvas start - weather per-region
++        // io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        // source.getServer().setWeatherParameters(source.getLevel(), getDuration(source, duration, ServerLevel.RAIN_DELAY), 0, false, false); // CraftBukkit - SPIGOT-7680: per-world
++        // source.sendSuccess(() -> Component.translatable("commands.weather.set.clear"), true);
++        // }); // Folia - region threading
++        final int durationTime = getDuration(source, duration, ServerLevel.RAIN_DELAY);
++        changeWeatherInRegionOrGlobal(source, () -> {
++            final ServerLevel level = source.getLevel();
++            final var player = source.getPlayer();
++
++            if (player != null) {
++                final var worldData = level.getCurrentWorldData();
++                final var st = worldData.weatherRegional;
++                if (st != null) {
++                    st.initialized = true;
++                    st.regionSeed = level.getSeed() ^ worldData.regionData.id;
++
++                    st.raining = false;
++                    st.thundering = false;
++
++                    st.clearTime = duration;
++                    st.rainTime = 0;
++                    st.thunderTime = 0;
++
++                    st.rainLevel = 0.0F;
++                    st.thunderLevel = 0.0F;
++                }
++            } else {
++                source.getServer().setWeatherParameters(source.getLevel(), durationTime, 0, false, false); // CraftBukkit - SPIGOT-7680: per-world
++            }
++            source.sendSuccess(() -> Component.translatable("commands.weather.set.clear"), false);
++        });
++        // Canvas end - weather per-region
+         return duration;
+     }
+ 
+     private static int setRain(final CommandSourceStack source, final int duration) {
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
+-        source.getServer().setWeatherParameters(source.getLevel(), 0, getDuration(source, duration, ServerLevel.RAIN_DURATION), true, false); // CraftBukkit - SPIGOT-7680: per-world
+-        source.sendSuccess(() -> Component.translatable("commands.weather.set.rain"), true);
+-        }); // Folia - region threading
++        // Canvas start - weather per-region
++        // io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        // source.getServer().setWeatherParameters(source.getLevel(), 0, getDuration(source, duration, ServerLevel.RAIN_DURATION), true, false); // CraftBukkit - SPIGOT-7680: per-world
++        // source.sendSuccess(() -> Component.translatable("commands.weather.set.rain"), true);
++        // }); // Folia - region threading
++        final int durationTime = getDuration(source, duration, ServerLevel.RAIN_DURATION);
++        changeWeatherInRegionOrGlobal(source, () -> {
++            final ServerLevel level = source.getLevel();
++            final var player = source.getPlayer();
++
++            if (player != null) {
++                final var worldData = level.getCurrentWorldData();
++                final var st = worldData.weatherRegional;
++                if (st != null) {
++                    st.initialized = true;
++                    st.regionSeed = level.getSeed() ^ worldData.regionData.id;
++
++                    st.raining = true;
++                    st.thundering = false;
++
++                    st.rainTime = duration;
++                    st.clearTime = 0;
++                    st.thunderTime = 0;
++
++                    st.rainLevel = 1.0F;
++                    st.thunderLevel = 0.0F;
++                }
++            } else {
++                source.getServer().setWeatherParameters(source.getLevel(), 0, durationTime, true, false); // CraftBukkit - SPIGOT-7680: per-world
++            }
++
++            source.sendSuccess(() -> Component.translatable("commands.weather.set.rain"), false);
++        });
++        // Canvas end - weather per-region
+         return duration;
+     }
+ 
+     private static int setThunder(final CommandSourceStack source, final int duration) {
+-        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
+-        source.getServer().setWeatherParameters(source.getLevel(), 0, getDuration(source, duration, ServerLevel.THUNDER_DURATION), true, true); // CraftBukkit - SPIGOT-7680: per-world
+-        source.sendSuccess(() -> Component.translatable("commands.weather.set.thunder"), true);
+-        }); // Folia - region threading
++        // Canvas start - weather per-region
++        // io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(() -> { // Folia - region threading
++        // source.getServer().setWeatherParameters(source.getLevel(), 0, getDuration(source, duration, ServerLevel.THUNDER_DURATION), true, true); // CraftBukkit - SPIGOT-7680: per-world
++        // source.sendSuccess(() -> Component.translatable("commands.weather.set.thunder"), true);
++        // }); // Folia - region threading
++        final int durationTime = getDuration(source, duration, ServerLevel.THUNDER_DURATION);
++        changeWeatherInRegionOrGlobal(source, () -> {
++            final ServerLevel level = source.getLevel();
++            final var player = source.getPlayer();
++
++            if (player != null) {
++                final var worldData = level.getCurrentWorldData();
++                final var st = worldData.weatherRegional;
++                if (st != null) {
++                    st.initialized = true;
++                    st.regionSeed = level.getSeed() ^ worldData.regionData.id;
++
++                    st.raining = true;
++                    st.thundering = true;
++
++                    st.rainTime = duration;
++                    st.thunderTime = duration;
++                    st.clearTime = 0;
++
++                    st.rainLevel = 1.0F;
++                    st.thunderLevel = 1.0F;
++                }
++            } else {
++                source.getServer().setWeatherParameters(source.getLevel(), 0, durationTime, true, true); // CraftBukkit - SPIGOT-7680: per-world
++            }
++
++            source.sendSuccess(() -> Component.translatable("commands.weather.set.thunder"), false);
++        });
++        // Canvas end - weather per-region
+         return duration;
+     }
++    // Canvas start - weather per-region
++    private static int getWeather(final CommandSourceStack source) {
++        final ServerLevel level = source.getLevel();
++        final var player = source.getPlayer();
++
++        if (level.canvasConfig().weather.perRegion && player != null) {
++            final var worldData = level.getCurrentWorldData();
++            final var st = worldData.weatherRegional;
++
++            if (st != null && st.initialized) {
++                if (st.thundering) {
++                    source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetThunder), false);
++                    return 2;
++                } else if (st.raining) {
++                    source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetRain), false);
++                    return 1;
++                } else {
++                    source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetClear), false);
++                    return 0;
++                }
++            }
++        }
++
++        if (level.isThundering()) {
++            source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetThunder), false);
++            return 2;
++        } else if (level.isRaining()) {
++            source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetRain), false);
++            return 1;
++        } else {
++            source.sendSuccess(() -> Component.translatable(level.canvasConfig().weather.commandGetClear), false);
++            return 0;
++        }
++    }
++
++    private static void changeWeatherInRegionOrGlobal(CommandSourceStack source, Runnable run) {
++        final ServerLevel level = source.getLevel();
++        if (level.canvasConfig().weather.perRegion) {
++            final var player = source.getPlayer();
++            if (player != null) {
++                final int cx = player.chunkPosition().x();
++                final int cz = player.chunkPosition().z();
++
++                io.papermc.paper.threadedregions.RegionizedServer.getInstance().taskQueue.queueChunkTask(level, cx, cz, run);
++                return;
++            }
++        }
++        io.papermc.paper.threadedregions.RegionizedServer.getInstance().addTask(run);
++    }
 +    // Canvas end - weather per-region
  }
 diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java

--- a/canvas-server/minecraft-patches/features/0003-feat-weather-add-per-region-weather-system-with-conf.patch
+++ b/canvas-server/minecraft-patches/features/0003-feat-weather-add-per-region-weather-system-with-conf.patch
@@ -1,0 +1,310 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Euphyllia Bierque <bierque.euphyllia@gmail.com>
+Date: Tue, 7 Jul 2026 00:47:03 +0200
+Subject: [PATCH] feat(weather): add per-region weather system with
+ configurable merge strategy
+
+
+diff --git a/io/papermc/paper/threadedregions/RegionizedWorldData.java b/io/papermc/paper/threadedregions/RegionizedWorldData.java
+index d0a319856e641f06d92ea61a1a55ee8782781090..081aeb1345a838346673aa77756c83a6ee02c013 100644
+--- a/io/papermc/paper/threadedregions/RegionizedWorldData.java
++++ b/io/papermc/paper/threadedregions/RegionizedWorldData.java
+@@ -161,6 +161,36 @@ public final class RegionizedWorldData {
+             into.phantomSpawnerNextTick = Math.max(from.phantomSpawnerNextTick, into.phantomSpawnerNextTick);
+             // chunkHoldersToBroadcast
+             into.chunkHoldersToBroadcast.addAll(from.chunkHoldersToBroadcast);
++            // weather
++            if (from.world.canvasConfig().weather.perRegion) {
++                if (from.weatherRegional != null) {
++                    if (into.weatherRegional == null) {
++                        into.weatherRegional = new RegionalWeatherState();
++                    }
++                    final var strategy = from.world.canvasConfig().weather.mergeStrategy;
++                    if (!into.weatherRegional.initialized && from.weatherRegional.initialized) {
++                        copyWeather(from.weatherRegional, into.weatherRegional);
++                    } else if (into.weatherRegional.initialized && from.weatherRegional.initialized) {
++                        switch (strategy) {
++                            case MOST_PLAYERS -> {
++                                if (from.getPlayerCount() > into.getPlayerCount()) {
++                                    copyWeather(from.weatherRegional, into.weatherRegional);
++                                }
++                            }
++                            case MOST_CHUNKS -> {
++                                if (from.getChunkCount() > into.getChunkCount()) {
++                                    copyWeather(from.weatherRegional, into.weatherRegional);
++                                }
++                            }
++                            case WEATHER_PRIORITY -> {
++                                if (weatherWeight(from.weatherRegional, from.world) > weatherWeight(into.weatherRegional, into.world)) {
++                                    copyWeather(from.weatherRegional, into.weatherRegional);
++                                }
++                            }
++                        }
++                    }
++                }
++            }
+         }
+ 
+         @Override
+@@ -334,6 +364,16 @@ public final class RegionizedWorldData {
+                     into.chunkHoldersToBroadcast.add(chunkHolder);
+                 }
+             }
++            // Canvas start - weather per-region
++            if (from.world.canvasConfig().weather.perRegion) {
++                for (final RegionizedWorldData regionizedWorldData : dataSet) {
++                    if (regionizedWorldData.weatherRegional == null) {
++                        regionizedWorldData.weatherRegional = new RegionalWeatherState();
++                    }
++                    copyWeather(from.weatherRegional, regionizedWorldData.weatherRegional);
++                }
++            }
++            // Canvas end - weather per-region
+         }
+     };
+ 
+@@ -795,4 +835,48 @@ public final class RegionizedWorldData {
+     public int getChunkCount() {
+         return this.chunks.size();
+     }
++
++    // Canvas start - weather per-region
++    public RegionalWeatherState weatherRegional = new RegionalWeatherState();
++    public static class RegionalWeatherState {
++        public int clearTime;
++        public int rainTime;
++        public int thunderTime;
++
++        public boolean raining;
++        public boolean thundering;
++
++        public float rainLevel;     // 0..1
++        public float thunderLevel;  // 0..1
++
++        public long regionSeed;
++        public boolean initialized;
++
++        public float oRainLevel;
++        public float oThunderLevel;
++    }
++    private static void copyWeather(final RegionalWeatherState src, final RegionalWeatherState dst) {
++        if (src == null || dst == null) return;
++        dst.clearTime = src.clearTime;
++        dst.rainTime = src.rainTime;
++        dst.thunderTime = src.thunderTime;
++        dst.raining = src.raining;
++        dst.thundering = src.thundering;
++        dst.rainLevel = src.rainLevel;
++        dst.thunderLevel = src.thunderLevel;
++        dst.regionSeed = src.regionSeed;
++        dst.initialized = src.initialized;
++    }
++
++    private static int weatherWeight(final RegionalWeatherState st, final ServerLevel level) {
++        final var weights = level.canvasConfig().weather.weatherWeights;
++        if (st.thundering) return weights.thunder;
++        if (st.raining)    return weights.rain;
++        return weights.clear;
++    }
++
++    public transient boolean _wasRaining;
++    public transient float _oldRainLevel;
++    public transient float _oldThunderLevel;
++    // Canvas end - weather per-region
+ }
+diff --git a/net/minecraft/server/level/ServerChunkCache.java b/net/minecraft/server/level/ServerChunkCache.java
+index 62bd76bdefc87130d53b4fb78ec9e91b7f1308e5..3b366191fffdf33a14b4c0df5323e78224fde89f 100644
+--- a/net/minecraft/server/level/ServerChunkCache.java
++++ b/net/minecraft/server/level/ServerChunkCache.java
+@@ -559,6 +559,31 @@ public class ServerChunkCache extends ChunkSource implements ca.spottedleaf.moon
+             spawnCookie = NaturalSpawner.createState(chunkCount, !this.level.paperConfig().entities.spawning.perPlayerMobSpawns ? new LocalMobCapCalculator(this.chunkMap) : null, false, regionizedWorldData); // Folia - region threading - note: function only cares about loaded entities, doesn't need all // Canvas - optimize natural spawning
+         }
+         // Paper end - Optional per player mob spawns
++        if (this.level.canvasConfig().weather.perRegion) {
++            final var st = regionizedWorldData.weatherRegional;
++            if (st != null && st.initialized) {
++                final boolean wasRaining = regionizedWorldData._wasRaining;
++                final float oldRainLevel = regionizedWorldData._oldRainLevel;
++                final float oldThunderLevel = regionizedWorldData._oldThunderLevel;
++                for (net.minecraft.server.level.ServerPlayer player : regionizedWorldData.getLocalPlayers()) {
++                    if (player.level() == this.level) {
++                        player.tickWeather();
++                    }
++                }
++                if (wasRaining != st.raining) {
++                    for (net.minecraft.server.level.ServerPlayer player : regionizedWorldData.getLocalPlayers()) {
++                        if (player.level() == this.level) {
++                            player.setPlayerWeather((!wasRaining ? org.bukkit.WeatherType.DOWNFALL : org.bukkit.WeatherType.CLEAR), false);
++                        }
++                    }
++                }
++                for (net.minecraft.server.level.ServerPlayer player : regionizedWorldData.getLocalPlayers()) {
++                    if (player.level() == this.level) {
++                        player.updateWeather(oldRainLevel, st.rainLevel, oldThunderLevel, st.thunderLevel);
++                    }
++                }
++            }
++        }
+         regionizedWorldData.lastSpawnState = spawnCookie; // Folia - region threading
+         boolean doMobSpawning = this.level.getGameRules().get(GameRules.SPAWN_MOBS) && !this.level.getLocalPlayers().isEmpty(); // CraftBukkit // Folia - region threading
+         int tickSpeed = this.level.getGameRules().get(GameRules.RANDOM_TICK_SPEED);
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index 33971e08cfe0a9b255362e8856da1485f33fced4..8ced3b683c6d4c86237f03b481ed1a4cc70c7aff 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -854,6 +854,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+     }
+ 
+     // Folia start - region threading
++    private final io.canvasmc.canvas.world.weather.WeatherServer canvas$weatherServer = new io.canvasmc.canvas.world.weather.WeatherServer(); // Canvas - weather per-region
+     public void tick(BooleanSupplier haveTime, final io.papermc.paper.threadedregions.TickRegions.TickRegionData region) {
+         final io.papermc.paper.threadedregions.RegionizedWorldData regionizedWorldData = this.getCurrentWorldData();
+         regionizedWorldData.setHandlingTick(true);
+@@ -877,6 +878,17 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+             for (WorldBorder worldBorder : worldBorders) {
+                 worldBorder.tick();
+             }
++            // Canvas start - weather per-region
++            if (region.world.canvasConfig().weather.perRegion) {
++                final var st0 = regionizedWorldData.weatherRegional;
++                if (st0 != null && st0.initialized) {
++                    regionizedWorldData._wasRaining = st0.raining;
++                    regionizedWorldData._oldThunderLevel = st0.thunderLevel;
++                    regionizedWorldData._oldRainLevel = st0.rainLevel;
++                }
++                canvas$weatherServer.tickRegion(this, regionizedWorldData);
++            }
++            // Canvas end - weather per-region
+             // this.advanceWeatherCycle();
+             // Folia end - region threading
+         }
+@@ -1394,6 +1406,7 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+         }
+         */
+         // Folia start - region threading
++        if (this.canvasConfig().weather.perRegion) return; // Canvas - weather per-region - Don't tick weather for the whole world if per-region weather is enabled
+         ServerPlayer[] players = this.players.toArray(new ServerPlayer[0]);
+         for (ServerPlayer player : players) {
+         // Folia end - region threading
+@@ -3136,4 +3149,56 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+         throw new UnsupportedOperationException("Unsupported in region threading"); // Folia - region threading
+     }
+     // Paper end - lag compensation
++
++    // Canvas start - weather per-region
++    private @org.jetbrains.annotations.Nullable io.papermc.paper.threadedregions.RegionizedWorldData currentRegionDataOrNull() {
++        try {
++            return io.papermc.paper.threadedregions.TickRegionScheduler.getCurrentRegionizedWorldData();
++        } catch (Throwable t) {
++            return null;
++        }
++    }
++
++    private @org.jetbrains.annotations.Nullable io.papermc.paper.threadedregions.RegionizedWorldData.RegionalWeatherState regionalWeatherOrNull() {
++        final var data = currentRegionDataOrNull();
++        return data != null ? data.weatherRegional : null;
++    }
++
++    @Override
++    public boolean isRaining() {
++        if (!this.canHaveWeather()) return false;
++
++        final var st = regionalWeatherOrNull();
++        if (st != null) {
++            return st.rainLevel > 0.2f;
++        }
++        return super.isRaining();
++    }
++
++    @Override
++    public boolean isThundering() {
++        if (!this.canHaveWeather()) return false;
++
++        final var st = regionalWeatherOrNull();
++        if (st != null) {
++            return (st.thunderLevel * st.rainLevel) > 0.9f;
++        }
++        return super.isThundering();
++    }
++
++    public float getRainLevel(float partialTick) {
++        final var st = regionalWeatherOrNull();
++        if (st != null) {
++            return net.minecraft.util.Mth.lerp(partialTick, st.oRainLevel, st.rainLevel);
++        }
++        return super.getRainLevel(partialTick);
++    }
++
++    public float getThunderLevel(float partialTick) {
++        final var st = regionalWeatherOrNull();
++        if (st != null) {
++            return net.minecraft.util.Mth.lerp(partialTick, st.oThunderLevel, st.thunderLevel);
++        }
++        return super.getThunderLevel(partialTick);
++    }
+ }
+diff --git a/net/minecraft/server/level/ServerPlayer.java b/net/minecraft/server/level/ServerPlayer.java
+index 9478cdf451a7a542ba34c162586d782ca12ccf5f..e003e179386d85ab05ede972860745028acfb185 100644
+--- a/net/minecraft/server/level/ServerPlayer.java
++++ b/net/minecraft/server/level/ServerPlayer.java
+@@ -3772,6 +3772,60 @@ public class ServerPlayer extends Player implements ca.spottedleaf.moonrise.patc
+         }
+     }
+ 
++    // Canvas start - weather per-region
++    private boolean canvas$regionalWeatherInit;
++    private boolean canvas$regionalWasRaining;
++    private float canvas$regionalRainLevel;
++    private float canvas$regionalThunderLevel;
++    public void canvas$syncRegionalWeather(final io.papermc.paper.threadedregions.RegionizedWorldData.RegionalWeatherState st) {
++        if (this.weatherType != null) {
++            return;
++        }
++
++        if (st == null || this.connection == null) {
++            return;
++        }
++
++        final boolean raining = st.raining;
++        final float rainLevel = st.rainLevel;
++        final float thunderLevel = st.thunderLevel;
++
++        // First sync (join / region move)
++        if (!this.canvas$regionalWeatherInit) {
++            this.connection.send(new ClientboundGameEventPacket(
++                raining ? ClientboundGameEventPacket.START_RAINING : ClientboundGameEventPacket.STOP_RAINING, 0.0F
++            ));
++            this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.RAIN_LEVEL_CHANGE, rainLevel));
++            this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE, thunderLevel));
++
++            this.canvas$regionalWeatherInit = true;
++            this.canvas$regionalWasRaining = raining;
++            this.canvas$regionalRainLevel = rainLevel;
++            this.canvas$regionalThunderLevel = thunderLevel;
++            return;
++        }
++
++        // START/STOP raining
++        if (this.canvas$regionalWasRaining != raining) {
++            this.connection.send(new ClientboundGameEventPacket(
++                raining ? ClientboundGameEventPacket.START_RAINING : ClientboundGameEventPacket.STOP_RAINING, 0.0F
++            ));
++            this.canvas$regionalWasRaining = raining;
++        }
++
++        // Level changes (epsilon to avoid spam)
++        if (Math.abs(this.canvas$regionalRainLevel - rainLevel) > 1.0E-4F) {
++            this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.RAIN_LEVEL_CHANGE, rainLevel));
++            this.canvas$regionalRainLevel = rainLevel;
++        }
++
++        if (Math.abs(this.canvas$regionalThunderLevel - thunderLevel) > 1.0E-4F) {
++            this.connection.send(new ClientboundGameEventPacket(ClientboundGameEventPacket.THUNDER_LEVEL_CHANGE, thunderLevel));
++            this.canvas$regionalThunderLevel = thunderLevel;
++        }
++    }
++    // Canvas end - weather per-region
++
+     public void tickWeather() {
+         if (this.weatherType == null) return;
+ 

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -692,7 +692,7 @@ public class WorldConfig extends Part {
             option("mergeStrategy")
                 .docs(
                     "The strategy for merging weather when perRegion is enabled. This is only used when perRegion is enabled",
-                    "KEEP_INTO: Keeps the weather of the region with the most players",
+                    "KEEP_INTO: Randomly merges the weather of the region",
                     "MOST_PLAYERS: Keeps the weather of the region with the most players",
                     "MOST_CHUNKS: Keeps the weather of the region with the most chunks",
                     "WEATHER_PRIORITY: Keeps the weather of the region with the highest priority"

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -678,4 +678,47 @@ public class WorldConfig extends Part {
         public boolean thunderStopsAfterSleep = true;
     }
 
+    public Weather weather = new Weather();
+    public static class Weather extends Part{
+
+        {
+            option("perRegion")
+                .docs("Enables weather per region, allowing different regions to have different weather. False by default (vanilla behavior)");
+            option("weatherWeights")
+                .docs(
+                    "The weights for each weather type. The higher the weight, the more likely it is to occur.",
+                    "This is only used when perRegion is enabled"
+                );
+            option("mergeStrategy")
+                .docs(
+                    "The strategy for merging weather when perRegion is enabled. This is only used when perRegion is enabled",
+                    "KEEP_INTO: Keeps the weather of the region with the most players",
+                    "MOST_PLAYERS: Keeps the weather of the region with the most players",
+                    "MOST_CHUNKS: Keeps the weather of the region with the most chunks",
+                    "WEATHER_PRIORITY: Keeps the weather of the region with the highest priority"
+                );
+        }
+        public boolean perRegion = false;
+
+        public WeatherWeights weatherWeights = new WeatherWeights();
+        public static class WeatherWeights extends Part {
+            {
+                option("clear").docs("The weight for clear weather");
+                option("rain").docs("The weight for rain weather");
+                option("thunder").docs("The weight for thunder weather");
+            }
+            public int clear = 0;
+            public int rain = 1;
+            public int thunder = 2;
+        }
+
+        public MergeStrategy mergeStrategy = MergeStrategy.KEEP_INTO;
+        public enum MergeStrategy {
+            KEEP_INTO,
+            MOST_PLAYERS,
+            MOST_CHUNKS,
+            WEATHER_PRIORITY
+        }
+    }
+
 }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/WorldConfig.java
@@ -697,6 +697,12 @@ public class WorldConfig extends Part {
                     "MOST_CHUNKS: Keeps the weather of the region with the most chunks",
                     "WEATHER_PRIORITY: Keeps the weather of the region with the highest priority"
                 );
+            option("commandGetClear")
+                .docs("The message sent to the player when they use the /weather get clear command");
+            option("commandGetRain")
+                .docs("The message sent to the player when they use the /weather get rain command");
+            option("commandGetThunder")
+                .docs("The message sent to the player when they use the /weather get thunder command");
         }
         public boolean perRegion = false;
 
@@ -719,6 +725,10 @@ public class WorldConfig extends Part {
             MOST_CHUNKS,
             WEATHER_PRIORITY
         }
+
+        public String commandGetClear = "The weather is clear";
+        public String commandGetRain = "The weather is rainy";
+        public String commandGetThunder = "The weather is thundering";
     }
 
 }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherControllerImpl.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherControllerImpl.java
@@ -5,10 +5,37 @@ import io.papermc.paper.threadedregions.RegionizedWorldData;
 import net.minecraft.server.level.ServerLevel;
 import org.bukkit.World;
 import org.bukkit.craftbukkit.CraftWorld;
+import org.jspecify.annotations.NullMarked;
 import org.jspecify.annotations.Nullable;
 
+/**
+ * Reads and mutates the per-region weather state stored in {@link RegionizedWorldData}.
+ * Must be called from the tick thread owning the region at the given chunk coordinates.
+ */
+@NullMarked
 public final class WeatherControllerImpl implements WeatherController {
 
+    /**
+     * Applies levels immediately (current + old), bypassing the progressive fade.
+     */
+    private static void setLevelsInstant(final RegionizedWorldData.RegionalWeatherState weatherState, final float rain, final float thunder) {
+        try {
+            weatherState.oRainLevel = rain;
+            weatherState.oThunderLevel = thunder;
+        } catch (Throwable ignored) {
+
+        }
+
+        weatherState.rainLevel = rain;
+        weatherState.thunderLevel = thunder;
+    }
+
+    /**
+     * Sets the region's weather. If the state was never touched, it is first seeded
+     * from the world's global weather. A positive {@code durationTicks} holds the
+     * weather that long; otherwise the current cycle continues. {@code instantLevels}
+     * skips the client-side fade and applies intensities immediately.
+     */
     @Override
     public void setRegionalWeather(World world, int chunkX, int chunkZ, WeatherType type, int durationTicks, boolean instantLevels) {
         Preconditions.checkNotNull(world, "world cannot be null");
@@ -18,90 +45,95 @@ public final class WeatherControllerImpl implements WeatherController {
         ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(level, chunkX, chunkZ, "Cannot retrieve chunk asynchronously");
 
         final RegionizedWorldData worldData = level.getCurrentWorldData();
-        final RegionizedWorldData.RegionalWeatherState st = worldData.weatherRegional;
+        final RegionizedWorldData.@Nullable RegionalWeatherState weatherState = worldData.weatherRegional;
 
-        if (st == null) {
-            return;
+        if (weatherState == null) {
+            return; // per-region weather disabled
         }
 
-        if (!st.initialized) {
-            st.regionSeed = level.getSeed() ^ worldData.regionData.id;
+        if (!weatherState.initialized) {
+            // seed from the world's current weather, then evolve independently
+            weatherState.regionSeed = level.getSeed() ^ worldData.regionData.id;
 
-            st.raining = level.isRaining();
-            st.thundering = level.isThundering();
+            weatherState.raining = level.isRaining();
+            weatherState.thundering = level.isThundering();
 
-            st.clearTime = 6000;
-            st.rainTime = 6000;
-            st.thunderTime = 6000;
+            weatherState.clearTime = 6000;
+            weatherState.rainTime = 6000;
+            weatherState.thunderTime = 6000;
 
-            st.rainLevel = st.raining ? 1.0f : 0.0f;
-            st.thunderLevel = st.thundering ? 1.0f : 0.0f;
+            weatherState.rainLevel = weatherState.raining ? 1.0f : 0.0f;
+            weatherState.thunderLevel = weatherState.thundering ? 1.0f : 0.0f;
 
             try {
-                st.oRainLevel = st.rainLevel;
-                st.oThunderLevel = st.thunderLevel;
+                weatherState.oRainLevel = weatherState.rainLevel;
+                weatherState.oThunderLevel = weatherState.thunderLevel;
             } catch (Throwable ignored) {
             }
 
-            st.initialized = true;
+            weatherState.initialized = true;
         }
 
-        final int d = durationTicks > 0 ? durationTicks : -1;
+        final int duration = durationTicks > 0 ? durationTicks : -1;
 
         switch (type) {
             case CLEAR -> {
-                st.raining = false;
-                st.thundering = false;
+                weatherState.raining = false;
+                weatherState.thundering = false;
 
                 // if duration provided: stay clear that long
-                if (d > 0) {
-                    st.clearTime = d;
-                    st.rainTime = 0;
-                    st.thunderTime = 0;
+                if (duration > 0) {
+                    weatherState.clearTime = duration;
+                    weatherState.rainTime = 0;
+                    weatherState.thunderTime = 0;
                 } else {
-                    st.clearTime = Math.max(st.clearTime, 1);
+                    weatherState.clearTime = Math.max(weatherState.clearTime, 1);
                 }
 
                 if (instantLevels) {
-                    setLevelsInstant(st, 0.0f, 0.0f);
+                    setLevelsInstant(weatherState, 0.0f, 0.0f);
                 }
             }
             case RAIN -> {
-                st.raining = true;
-                st.thundering = false;
+                weatherState.raining = true;
+                weatherState.thundering = false;
 
-                if (d > 0) {
-                    st.rainTime = d;
-                    st.thunderTime = 0;
-                    st.clearTime = 0;
+                if (duration > 0) {
+                    weatherState.rainTime = duration;
+                    weatherState.thunderTime = 0;
+                    weatherState.clearTime = 0;
                 } else {
-                    st.rainTime = Math.max(st.rainTime, 1);
+                    weatherState.rainTime = Math.max(weatherState.rainTime, 1);
                 }
 
                 if (instantLevels) {
-                    setLevelsInstant(st, 1.0f, 0.0f);
+                    setLevelsInstant(weatherState, 1.0f, 0.0f);
                 }
             }
             case THUNDER -> {
-                st.raining = true;
-                st.thundering = true;
+                weatherState.raining = true; // thunder implies rain
+                weatherState.thundering = true;
 
-                if (d > 0) {
-                    st.rainTime = d;
-                    st.thunderTime = d;
-                    st.clearTime = 0;
+                if (duration > 0) {
+                    weatherState.rainTime = duration;
+                    weatherState.thunderTime = duration;
+                    weatherState.clearTime = 0;
                 } else {
-                    st.rainTime = Math.max(st.rainTime, 1);
-                    st.thunderTime = Math.max(st.thunderTime, 1);
+                    weatherState.rainTime = Math.max(weatherState.rainTime, 1);
+                    weatherState.thunderTime = Math.max(weatherState.thunderTime, 1);
                 }
 
                 if (instantLevels) {
-                    setLevelsInstant(st, 1.0f, 1.0f);
+                    setLevelsInstant(weatherState, 1.0f, 1.0f);
                 }
             }
         }
     }
 
+    /**
+     * Returns a snapshot of the region's weather, or {@code null} if per-region
+     * weather is disabled for this world.
+     */
     @Override
     public @Nullable RegionalWeatherSnapshot getRegionalWeather(World world, int chunkX, int chunkZ) {
         Preconditions.checkNotNull(world, "world cannot be null");
@@ -109,33 +141,21 @@ public final class WeatherControllerImpl implements WeatherController {
         ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(level, chunkX, chunkZ, "Cannot retrieve chunk asynchronously");
 
         final RegionizedWorldData worldData = level.getCurrentWorldData();
-        final RegionizedWorldData.RegionalWeatherState st = worldData.weatherRegional;
-        if (st == null) {
+        final RegionizedWorldData.@Nullable RegionalWeatherState weatherState = worldData.weatherRegional;
+        if (weatherState == null) {
             return null;
         }
 
         return new RegionalWeatherSnapshot(
             worldData.regionData.id,
-            st.raining,
-            st.thundering,
-            st.clearTime,
-            st.rainTime,
-            st.thunderTime,
-            st.rainLevel,
-            st.thunderLevel
+            weatherState.raining,
+            weatherState.thundering,
+            weatherState.clearTime,
+            weatherState.rainTime,
+            weatherState.thunderTime,
+            weatherState.rainLevel,
+            weatherState.thunderLevel
         );
-    }
-
-    private static void setLevelsInstant(final RegionizedWorldData.RegionalWeatherState st, final float rain, final float thunder) {
-        try {
-            st.oRainLevel = rain;
-            st.oThunderLevel = thunder;
-        } catch (Throwable ignored) {
-
-        }
-
-        st.rainLevel = rain;
-        st.thunderLevel = thunder;
     }
 
 

--- a/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherControllerImpl.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherControllerImpl.java
@@ -1,0 +1,142 @@
+package io.canvasmc.canvas.world.weather;
+
+import com.google.common.base.Preconditions;
+import io.papermc.paper.threadedregions.RegionizedWorldData;
+import net.minecraft.server.level.ServerLevel;
+import org.bukkit.World;
+import org.bukkit.craftbukkit.CraftWorld;
+import org.jspecify.annotations.Nullable;
+
+public final class WeatherControllerImpl implements WeatherController {
+
+    @Override
+    public void setRegionalWeather(World world, int chunkX, int chunkZ, WeatherType type, int durationTicks, boolean instantLevels) {
+        Preconditions.checkNotNull(world, "world cannot be null");
+        Preconditions.checkNotNull(type, "type cannot be null");
+
+        final ServerLevel level = ((CraftWorld) world).getHandle();
+        ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(level, chunkX, chunkZ, "Cannot retrieve chunk asynchronously");
+
+        final RegionizedWorldData worldData = level.getCurrentWorldData();
+        final RegionizedWorldData.RegionalWeatherState st = worldData.weatherRegional;
+
+        if (st == null) {
+            return;
+        }
+
+        if (!st.initialized) {
+            st.regionSeed = level.getSeed() ^ worldData.regionData.id;
+
+            st.raining = level.isRaining();
+            st.thundering = level.isThundering();
+
+            st.clearTime = 6000;
+            st.rainTime = 6000;
+            st.thunderTime = 6000;
+
+            st.rainLevel = st.raining ? 1.0f : 0.0f;
+            st.thunderLevel = st.thundering ? 1.0f : 0.0f;
+
+            try {
+                st.oRainLevel = st.rainLevel;
+                st.oThunderLevel = st.thunderLevel;
+            } catch (Throwable ignored) {
+            }
+
+            st.initialized = true;
+        }
+
+        final int d = durationTicks > 0 ? durationTicks : -1;
+
+        switch (type) {
+            case CLEAR -> {
+                st.raining = false;
+                st.thundering = false;
+
+                // if duration provided: stay clear that long
+                if (d > 0) {
+                    st.clearTime = d;
+                    st.rainTime = 0;
+                    st.thunderTime = 0;
+                } else {
+                    st.clearTime = Math.max(st.clearTime, 1);
+                }
+
+                if (instantLevels) {
+                    setLevelsInstant(st, 0.0f, 0.0f);
+                }
+            }
+            case RAIN -> {
+                st.raining = true;
+                st.thundering = false;
+
+                if (d > 0) {
+                    st.rainTime = d;
+                    st.thunderTime = 0;
+                    st.clearTime = 0;
+                } else {
+                    st.rainTime = Math.max(st.rainTime, 1);
+                }
+
+                if (instantLevels) {
+                    setLevelsInstant(st, 1.0f, 0.0f);
+                }
+            }
+            case THUNDER -> {
+                st.raining = true;
+                st.thundering = true;
+
+                if (d > 0) {
+                    st.rainTime = d;
+                    st.thunderTime = d;
+                    st.clearTime = 0;
+                } else {
+                    st.rainTime = Math.max(st.rainTime, 1);
+                    st.thunderTime = Math.max(st.thunderTime, 1);
+                }
+
+                if (instantLevels) {
+                    setLevelsInstant(st, 1.0f, 1.0f);
+                }
+            }
+        }
+    }
+
+    @Override
+    public @Nullable RegionalWeatherSnapshot getRegionalWeather(World world, int chunkX, int chunkZ) {
+        Preconditions.checkNotNull(world, "world cannot be null");
+        final ServerLevel level = ((CraftWorld) world).getHandle();
+        ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(level, chunkX, chunkZ, "Cannot retrieve chunk asynchronously");
+
+        final RegionizedWorldData worldData = level.getCurrentWorldData();
+        final RegionizedWorldData.RegionalWeatherState st = worldData.weatherRegional;
+        if (st == null) {
+            return null;
+        }
+
+        return new RegionalWeatherSnapshot(
+            worldData.regionData.id,
+            st.raining,
+            st.thundering,
+            st.clearTime,
+            st.rainTime,
+            st.thunderTime,
+            st.rainLevel,
+            st.thunderLevel
+        );
+    }
+
+    private static void setLevelsInstant(final RegionizedWorldData.RegionalWeatherState st, final float rain, final float thunder) {
+        try {
+            st.oRainLevel = rain;
+            st.oThunderLevel = thunder;
+        } catch (Throwable ignored) {
+
+        }
+
+        st.rainLevel = rain;
+        st.thunderLevel = thunder;
+    }
+
+
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherServer.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherServer.java
@@ -5,85 +5,117 @@ import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
 
+/**
+ * Per-region weather engine, called each tick from the region's tick loop.
+ * Advances the clear/rain/thunder timers, fades the intensity levels and
+ * syncs the result to the players inside the region.
+ */
 public class WeatherServer {
 
+    /**
+     * Level change per tick (~5s fade from 0 to 1).
+     */
     private static final float LEVEL_STEP = 0.01f;
 
     public void tickRegion(ServerLevel level, RegionizedWorldData worldData) {
-        final RegionizedWorldData.RegionalWeatherState st = worldData.weatherRegional;
-        if (st == null) return;
+        final RegionizedWorldData.RegionalWeatherState weatherState = worldData.weatherRegional;
+        if (weatherState == null) return;
 
-        initIfNeeded(level, worldData, st);
-        tickTimers(level, st);
+        initIfNeeded(level, worldData, weatherState);
+        tickTimers(level, weatherState);
 
-        st.oRainLevel = st.rainLevel;
-        st.oThunderLevel = st.thunderLevel;
-
-        st.rainLevel = approach(st.rainLevel, st.raining ? 1.0f : 0.0f, LEVEL_STEP);
-        st.thunderLevel = approach(st.thunderLevel, st.thundering ? 1.0f : 0.0f, LEVEL_STEP);
+        // keep previous levels for client-side interpolation, then fade toward target
+        weatherState.oRainLevel = weatherState.rainLevel;
+        weatherState.oThunderLevel = weatherState.thunderLevel;
+        weatherState.rainLevel = approach(weatherState.rainLevel, weatherState.raining ? 1.0f : 0.0f, LEVEL_STEP);
+        weatherState.thunderLevel = approach(weatherState.thunderLevel, weatherState.thundering ? 1.0f : 0.0f, LEVEL_STEP);
 
         final var players = worldData.getLocalPlayers();
         if (!players.isEmpty()) {
             for (final ServerPlayer player : players) {
-                player.canvas$syncRegionalWeather(st);
+                player.canvas$syncRegionalWeather(weatherState);
             }
         }
     }
 
-    private void initIfNeeded(ServerLevel level, RegionizedWorldData worldData, RegionizedWorldData.RegionalWeatherState st) {
-        if (st.initialized) return;
+    /**
+     * Seeds the state from the world's current weather on first tick.
+     */
+    private void initIfNeeded(ServerLevel level, RegionizedWorldData worldData, RegionizedWorldData.RegionalWeatherState weatherState) {
+        if (weatherState.initialized) return;
 
-        st.regionSeed = level.getSeed() ^ worldData.regionData.id;
-        st.raining = level.isRaining();
-        st.thundering = level.isThundering();
-        st.clearTime = 6000;
-        st.rainTime = 6000;
-        st.thunderTime = 6000;
-        st.rainLevel = st.raining ? 1.0f : 0.0f;
-        st.thunderLevel = st.thundering ? 1.0f : 0.0f;
-        st.initialized = true;
+        weatherState.regionSeed = level.getSeed() ^ worldData.regionData.id;
+
+        weatherState.raining = level.isRaining();
+        weatherState.thundering = level.isThundering();
+
+        weatherState.clearTime = 6000;
+        weatherState.rainTime = 6000;
+        weatherState.thunderTime = 6000;
+
+        weatherState.rainLevel = weatherState.raining ? 1.0f : 0.0f;
+        weatherState.thunderLevel = weatherState.thundering ? 1.0f : 0.0f;
+
+        weatherState.initialized = true;
     }
 
-    private void tickTimers(ServerLevel level, RegionizedWorldData.RegionalWeatherState st) {
+    /**
+     * Weather cycle: clear -> rain (30% chance of thunder) -> clear, with
+     * random durations rolled when each timer expires.
+     */
+    private void tickTimers(ServerLevel level, RegionizedWorldData.RegionalWeatherState weatherState) {
         final RandomSource rng = level.getRandom();
 
-        if (!st.raining) {
-            if (--st.clearTime <= 0) {
-                st.raining = true;
-                st.rainTime = randomRainDuration(rng);
+        if (!weatherState.raining) {
+            if (--weatherState.clearTime <= 0) {
+                weatherState.raining = true;
+                weatherState.rainTime = randomRainDuration(rng);
+
                 if (rng.nextInt(100) < 30) {
-                    st.thundering = true;
-                    st.thunderTime = randomThunderDuration(rng);
+                    weatherState.thundering = true;
+                    weatherState.thunderTime = randomThunderDuration(rng);
                 }
             }
         } else {
-            if (--st.rainTime <= 0) {
-                st.raining = false;
-                st.thundering = false;
-                st.clearTime = randomClearDuration(rng);
+            if (--weatherState.rainTime <= 0) {
+                weatherState.raining = false;
+                weatherState.thundering = false;
+                weatherState.clearTime = randomClearDuration(rng);
             }
         }
 
-        if (st.thundering) {
-            if (--st.thunderTime <= 0) {
-                st.thundering = false;
-                st.thunderTime = randomThunderDuration(rng);
+        if (weatherState.thundering) {
+            if (--weatherState.thunderTime <= 0) {
+                weatherState.thundering = false;
+                weatherState.thunderTime = randomThunderDuration(rng);
             }
         }
     }
 
+    /**
+     * 5 to 15 minutes.
+     */
     private int randomClearDuration(RandomSource rng) {
         return 6000 + rng.nextInt(12000);
     }
 
+    /**
+     * 5 to 15 minutes.
+     */
     private int randomRainDuration(RandomSource rng) {
         return 6000 + rng.nextInt(12000);
     }
 
+    /**
+     * 2.5 to 7.5 minutes.
+     */
     private int randomThunderDuration(RandomSource rng) {
         return 3000 + rng.nextInt(6000);
     }
 
+    /**
+     * Moves {@code current} toward {@code target} by at most {@code step}.
+     */
     private float approach(float current, float target, float step) {
         if (current < target) return Math.min(current + step, target);
         if (current > target) return Math.max(current - step, target);

--- a/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherServer.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherServer.java
@@ -1,0 +1,92 @@
+package io.canvasmc.canvas.world.weather;
+
+import io.papermc.paper.threadedregions.RegionizedWorldData;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.server.level.ServerPlayer;
+import net.minecraft.util.RandomSource;
+
+public class WeatherServer {
+
+    private static final float LEVEL_STEP = 0.01f;
+
+    public void tickRegion(ServerLevel level, RegionizedWorldData worldData) {
+        final RegionizedWorldData.RegionalWeatherState st = worldData.weatherRegional;
+        if (st == null) return;
+
+        initIfNeeded(level, worldData, st);
+        tickTimers(level, st);
+
+        st.oRainLevel = st.rainLevel;
+        st.oThunderLevel = st.thunderLevel;
+
+        st.rainLevel = approach(st.rainLevel, st.raining ? 1.0f : 0.0f, LEVEL_STEP);
+        st.thunderLevel = approach(st.thunderLevel, st.thundering ? 1.0f : 0.0f, LEVEL_STEP);
+
+        final var players = worldData.getLocalPlayers();
+        if (!players.isEmpty()) {
+            for (final ServerPlayer player : players) {
+                player.canvas$syncRegionalWeather(st);
+            }
+        }
+    }
+
+    private void initIfNeeded(ServerLevel level, RegionizedWorldData worldData, RegionizedWorldData.RegionalWeatherState st) {
+        if (st.initialized) return;
+
+        st.regionSeed = level.getSeed() ^ worldData.regionData.id;
+        st.raining = level.isRaining();
+        st.thundering = level.isThundering();
+        st.clearTime = 6000;
+        st.rainTime = 6000;
+        st.thunderTime = 6000;
+        st.rainLevel = st.raining ? 1.0f : 0.0f;
+        st.thunderLevel = st.thundering ? 1.0f : 0.0f;
+        st.initialized = true;
+    }
+
+    private void tickTimers(ServerLevel level, RegionizedWorldData.RegionalWeatherState st) {
+        final RandomSource rng = level.getRandom();
+
+        if (!st.raining) {
+            if (--st.clearTime <= 0) {
+                st.raining = true;
+                st.rainTime = randomRainDuration(rng);
+                if (rng.nextInt(100) < 30) {
+                    st.thundering = true;
+                    st.thunderTime = randomThunderDuration(rng);
+                }
+            }
+        } else {
+            if (--st.rainTime <= 0) {
+                st.raining = false;
+                st.thundering = false;
+                st.clearTime = randomClearDuration(rng);
+            }
+        }
+
+        if (st.thundering) {
+            if (--st.thunderTime <= 0) {
+                st.thundering = false;
+                st.thunderTime = randomThunderDuration(rng);
+            }
+        }
+    }
+
+    private int randomClearDuration(RandomSource rng) {
+        return 6000 + rng.nextInt(12000);
+    }
+
+    private int randomRainDuration(RandomSource rng) {
+        return 6000 + rng.nextInt(12000);
+    }
+
+    private int randomThunderDuration(RandomSource rng) {
+        return 3000 + rng.nextInt(6000);
+    }
+
+    private float approach(float current, float target, float step) {
+        if (current < target) return Math.min(current + step, target);
+        if (current > target) return Math.max(current - step, target);
+        return current;
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherServer.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/world/weather/WeatherServer.java
@@ -4,12 +4,15 @@ import io.papermc.paper.threadedregions.RegionizedWorldData;
 import net.minecraft.server.level.ServerLevel;
 import net.minecraft.server.level.ServerPlayer;
 import net.minecraft.util.RandomSource;
+import org.jspecify.annotations.NullMarked;
+import org.jspecify.annotations.Nullable;
 
 /**
  * Per-region weather engine, called each tick from the region's tick loop.
  * Advances the clear/rain/thunder timers, fades the intensity levels and
  * syncs the result to the players inside the region.
  */
+@NullMarked
 public class WeatherServer {
 
     /**
@@ -18,7 +21,7 @@ public class WeatherServer {
     private static final float LEVEL_STEP = 0.01f;
 
     public void tickRegion(ServerLevel level, RegionizedWorldData worldData) {
-        final RegionizedWorldData.RegionalWeatherState weatherState = worldData.weatherRegional;
+        final RegionizedWorldData.@Nullable RegionalWeatherState weatherState = worldData.weatherRegional;
         if (weatherState == null) return;
 
         initIfNeeded(level, worldData, weatherState);


### PR DESCRIPTION
## Description
Enabling this setting allows each region on Folia to have its own weather, rather than a single global setting for everyone (disabled by default).
This could be ideal for Skyblock, OneBlock, and similar server types.

## Currently incompatible (for the time being)
Plugins that attempt to modify the weather, whether globally or otherwise.
WeatherControllerImpl is not called in API

## Additional feature
Added a `get` option to the `/weather` command to check the weather in the current region.

## Note
This PR is essentially a copy-paste from my own fork.