### PR TITLE
Fix log format string in BalancedChunkSystem

### DIFF
--- a/canvas-server/src/main/java/io/canvasmc/canvas/world/chunk/BalancedChunkSystem.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/world/chunk/BalancedChunkSystem.java
@@ -547,7 +547,7 @@ public final class BalancedChunkSystem extends BalancedPrioritisedThreadPool {
                     if (!BalancedChunkSystem.this.stream.executeTask()) break;
                     ret = true;
                 } catch (final Throwable thrown) {
-                    LOGGER.error("Exception thrown from thread '{}", this.thread.getName(), thrown);
+                    LOGGER.error("Exception thrown from thread '{}'", this.thread.getName(), thrown);
                 }
             } while (System.nanoTime() - deadline <= 0L);
             return ret;


### PR DESCRIPTION
Missing closing apostrophe in SLF4J format string on line 550 causes FormatErrorMessageException at runtime when any chunk worker thread throws an exception during task execution