### PR TITLE
Fix portal momentum

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerLevel.java.patch
@@ -191,6 +191,69 @@
          // CraftBukkit start
          // If we stop due to everyone sleeping we should reset the weather duration to some other random value.
          // Not that everyone ever manages to get the whole server to sleep at the same time....
+@@ -1471,16 +_,62 @@
+         entity.totalEntityAge++; // Paper - age-like counter for all entities
+         final boolean isActive = io.papermc.paper.entity.activation.ActivationRange.checkIfActive(entity); // Paper - EAR 2
+         if (isActive) { // Paper - EAR 2
++        // Canvas start - preserve portal tick order across regions
++        if (entity.canvas$portalTickState == 2) {
++            // The previous tick handled the portal before physics. If teleportation did not happen,
++            // compensate that skipped physics tick, then perform this tick normally.
++            entity.tick();
++            if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(entity)) {
++                // The first compensation tick crossed a region; resume compensation in its new owner.
++                return;
++            }
++            // Any portal entered by the tick above can be handled immediately by this region.
++            entity.canvas$portalTickState = 0;
++            if (entity.handlePortal()) {
++                return;
++            }
++
++            // Keep the compensation marker until the second tick has completed on one region owner.
++            entity.canvas$portalTickState = 2;
++            entity.tick();
++            // Both owed physics ticks are now complete. Preserve state 1 only if this tick entered
++            // another portal; otherwise a region hand-off must resume normal ticking, not compensate again.
++            if (entity.canvas$portalTickState == 2) entity.canvas$portalTickState = 0;
++            if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(entity)) {
++                return;
++            }
++            // As above, consume state 1 only because handlePortal runs immediately below.
++            if (entity.canvas$portalTickState == 1) entity.canvas$portalTickState = 0;
++            if (entity.handlePortal()) {
++                return;
++            }
++        } else if (entity.canvas$portalTickState == 1) {
++            // Entering the portal changed region ownership during the preceding entity tick. Handle
++            // the portal before collision, drag, or gravity can mutate its position and momentum again.
++            if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(entity)) {
++                return;
++            }
++            entity.canvas$portalTickState = 0;
++            if (entity.handlePortal()) {
++                return;
++            }
++            // The pre-physics portal attempt failed, so the skipped physics tick is still owed.
++            entity.canvas$portalTickState = 2;
++        } else {
+         entity.tick();
+         // Folia start - region threading
+         if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(entity)) {
+             // removed from region while ticking
+             return;
+         }
++        // State 1 is only deferred across a region hand-off. This region can handle it now.
++        if (entity.canvas$portalTickState == 1) entity.canvas$portalTickState = 0;
+         if (entity.handlePortal()) {
+             // portalled
+             return;
+         }
++        }
++        // Canvas end - preserve portal tick order across regions
+         // Folia end - region threading
+         } else {entity.inactiveTick();} // Paper - EAR 2
+ 
 @@ -1771,7 +_,7 @@
  
      public void unload(final LevelChunk levelChunk) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/Entity.java.patch
@@ -1,5 +1,17 @@
 --- a/net/minecraft/world/entity/Entity.java
 +++ b/net/minecraft/world/entity/Entity.java
+@@ -389,6 +_,11 @@
+     public long activatedTick = Integer.MIN_VALUE;
+     public boolean isTemporarilyActive;
+     public long activatedImmunityTick = Integer.MIN_VALUE;
++    // Canvas start - preserve portal tick order across regions
++    // Transient state: a newly-entered portal must be handled before another physics tick if the
++    // entity changed region ownership while entering it. This is deliberately not serialized.
++    public int canvas$portalTickState;
++    // Canvas end - preserve portal tick order across regions
+ 
+     public void inactiveTick() {
+     }
 @@ -908,7 +_,7 @@
          }
  
@@ -113,6 +125,76 @@
                  if (this.level.paperConfig().collisions.onlyPlayersCollide && !(entity instanceof ServerPlayer || this instanceof ServerPlayer)) return; // Paper - Collision option for requiring a player participant
                  double xa = entity.getX() - this.getX();
                  double za = entity.getZ() - this.getZ();
+@@ -3594,6 +_,7 @@
+         } else {
+             if (this.portalProcess == null || !this.portalProcess.isSamePortal(portal)) {
+                 this.portalProcess = new PortalProcessor(portal, pos.immutable());
++                if (!(this instanceof Player)) this.canvas$portalTickState = 1; // Canvas - preserve portal tick order across regions
+             } else if (!this.portalProcess.isInsidePortalThisTick()) {
+                 this.portalProcess.updateEntryPosition(pos.immutable());
+                 this.portalProcess.setAsInsidePortalThisTick(true);
+@@ -3604,14 +_,50 @@
+     public boolean handlePortal() { // Folia - region threading - ret type -> boolean
+-        if (this.level() instanceof ServerLevel level) {
+-            this.processPortalCooldown();
+-            if (this.portalProcess != null) {
+-                if (this.portalProcess.processPortalTeleportation(level, this, this.canUsePortal(false))) {
+-                    this.setPortalCooldown();
+-                    return this.portalProcess.portalAsync(level, this); // Folia - region threading
+-                } else if (this.portalProcess.hasExpired()) {
+-                    this.portalProcess = null;
+-                }
+-            }
+-        }
++        if (!(this.level() instanceof ServerLevel level)) {
++            return false;
++        }
++
++        final PortalProcessor processor = this.portalProcess;
++        // Canvas start - preserve portal tick order across regions
++        // true means that this tick must stop: the portal hand-off either started or must be
++        // retried by the region that owns both the entity and its portal entry block.
++        if (processor != null && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(this)) {
++            if (!(this instanceof Player) && processor.isInsidePortalThisTick()) {
++                this.canvas$portalTickState = 1;
++            }
++            return true;
++        }
++
++        final boolean allowedToTeleport = processor != null && this.canUsePortal(false);
++        if (
++            processor != null
++                && processor.isReadyToTeleport(level, this, allowedToTeleport)
++                && processor.requiresPortalEntryBlockOwnership()
++                && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(level, processor.getEntryPosition())
++        ) {
++            // Region topology may settle between ticks, but the entity and an along-path portal
++            // can also remain in distinct regions. Retry once, then abandon cleanly rather than
++            // freezing the entity forever with physics disabled.
++            // Players keep moving before their next portal check and therefore cannot safely retain
++            // a stale inside marker; only the non-player pre-physics state machine may defer.
++            if (!(this instanceof Player) && processor.shouldDeferForPortalRegionOwnership(this.tickCount)) {
++                this.canvas$portalTickState = 1;
++                return true;
++            }
++            this.portalProcess = null;
++            this.canvas$portalTickState = 0;
++            return false;
++        }
++        // Canvas end - preserve portal tick order across regions
++
++        this.processPortalCooldown();
++        if (processor != null) {
++            if (processor.processPortalTeleportation(level, this, allowedToTeleport)) {
++                this.setPortalCooldown();
++                this.canvas$portalTickState = 0; // Canvas - portal attempt was committed
++                return processor.portalAsync(level, this); // Folia - region threading
++            } else if (processor.hasExpired()) {
++                this.portalProcess = null;
++            }
++        }
+         return false; // Folia - region threading
+     }
 @@ -3898,6 +_,7 @@
      }
  
@@ -121,6 +203,39 @@
          if (level instanceof ServerLevel serverLevel) {
              RandomSource random = level.getRandom();
  
+@@ -4418,13 +_,31 @@
+     }
+ 
+     protected final void transform(final TeleportTransition telpeort) {
++        this.transform(PositionMoveRotation.of(this), telpeort);
++    }
++
++    // Canvas start - preserve live entity state through async dimension copies
++    protected final void transform(final PositionMoveRotation source, final TeleportTransition teleport) {
+         PositionMoveRotation move = PositionMoveRotation.calculateAbsolute(
+-            PositionMoveRotation.of(this), PositionMoveRotation.of(telpeort), telpeort.relatives()
++            source, PositionMoveRotation.of(teleport), teleport.relatives()
+         );
+         this.transform(
+             move.position(), move.yRot(), move.xRot(), move.deltaMovement()
+         );
+     }
++    // Canvas end - preserve live entity state through async dimension copies
++
++    // Canvas start - preserve portal momentum
++    protected final void transformForPortal(
++        final PositionMoveRotation source, final TeleportTransition teleport, final boolean preserveWorldSpaceVelocity
++    ) {
++        if (preserveWorldSpaceVelocity) {
++            this.transform(teleport.position(), teleport.yRot(), source.xRot(), source.deltaMovement());
++        } else {
++            this.transform(source, teleport);
++        }
++    }
++    // Canvas end - preserve portal momentum
+ 
+     protected void transform(final @Nullable Vec3 pos, final @Nullable Float yaw, final @Nullable Float pitch, final @Nullable Vec3 velocity) {
+         if (yaw != null) {
 @@ -4724,7 +_,7 @@
      public boolean endPortalLogicAsync(final BlockPos portalPos) {
          ca.spottedleaf.moonrise.common.util.TickThread.ensureTickThread(this, "Cannot portal entity async");
@@ -139,6 +254,105 @@
          if (destination == null) {
              // wat
              return false;
+@@ -4767,14 +_,18 @@
+                         targetPos, 16, // load 16 blocks to be safe from block physics
+                         ca.spottedleaf.concurrentutil.util.Priority.HIGH,
+                         (chunks) -> {
+-                            net.minecraft.world.level.levelgen.feature.EndPlatformFeature.createEndPlatform(destination, targetPos.below(), true, null);
++                            // Canvas start - vanilla non-player End portal placement
++                            // Players stand on the platform; non-player entities retain the extra block of clearance
++                            // needed by vanilla contraptions. The platform is created after placement below.
++                            Vec3 finalPos = Vec3.atBottomCenterOf(this instanceof Player ? targetPos.below() : targetPos);
++                            // Canvas end - vanilla non-player End portal placement
+ 
+                             // the portal obsidian is placed at targetPos.y - 2, so if we want to place the entity
+                             // on the obsidian, we need to spawn at targetPos.y - 1
+                             portalInfoCompletable.complete(
+                                 new net.minecraft.world.level.portal.TeleportTransition(
+-                                    destination, Vec3.atBottomCenterOf(targetPos.below()), Vec3.ZERO, Direction.WEST.toYRot(), 0.0f,
+-                                    Relative.union(Relative.DELTA, Set.of(Relative.X_ROT)),
++                                    destination, finalPos, Vec3.ZERO, Direction.WEST.toYRot(), 0.0f,
++                                    Set.of(), // Canvas - End portals preserve world-space momentum; applied per entity below
+                                     TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET),
+                                     org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.END_PORTAL
+                                 )
+@@ -4846,7 +_,9 @@
+                             portalInfoCompletable.complete(
+                                 new TeleportTransition(destination, Vec3.atCenterOf(targetPos), Vec3.ZERO,
+                                     90.0f, 0.0f,
+-                                    TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET))
++                                    Relative.union(Relative.direction(true, true, true), Set.of(Relative.X_ROT)),
++                                    TeleportTransition.PLAY_PORTAL_SOUND.then(TeleportTransition.PLACE_PORTAL_TICKET),
++                                    org.bukkit.event.player.PlayerTeleportEvent.TeleportCause.NETHER_PORTAL)
+                             );
+                             return;
+                         }
+@@ -5018,6 +_,18 @@
+             canvas$ensureCanPortalAsync(destination, takePassengers);
+         }
+         final ServerLevel finalDestination = destination;
++        // Canvas start - vanilla End platform timing
++        final boolean enteringEnd = type == PortalType.END
++            && finalDestination.getTypeKey() == net.minecraft.world.level.dimension.LevelStem.END;
++        final java.util.function.Consumer<Entity> finalTeleportComplete = enteringEnd
++            ? teleported -> {
++                net.minecraft.world.level.levelgen.feature.EndPlatformFeature.createEndPlatform(
++                    finalDestination, ServerLevel.END_SPAWN_POINT.below(), true, null
++                );
++                if (teleportComplete != null) teleportComplete.accept(teleported);
++            }
++            : teleportComplete;
++        // Canvas end - vanilla End platform timing
+         // Canvas end - region threading
+ 
+         Vec3 initialPosition = this.position();
+@@ -5040,7 +_,12 @@
+             node.root.prePortalLogic(originWorld, destination, type);
+         }
+ 
++        // Canvas start - preserve live entity state through async dimension copies
++        // restoreFrom serializes through NBT, whose load path clamps motion components above 10.
++        // Retain the live state, as vanilla's synchronous cross-dimension path does.
++        List<PositionMoveRotation> portalSources = new ArrayList<>(fullPassengerTree.size());
+         for (EntityTreeNode node : fullPassengerTree) {
++            portalSources.add(PositionMoveRotation.of(node.root));
+             // we will update pos/rot/speed later
+             node.root = node.root.transformForAsyncTeleport(destination, null, null, null, null);
+             // set portal cooldown
+@@ -5051,6 +_,7 @@
+             }
+             // Canvas end - region threading
+         }
++        // Canvas end - preserve live entity state through async dimension copies
+ 
+         // ensure the region is always ticking in case of a shutdown
+         // otherwise, the shutdown will not be able to complete the shutdown as it requires a ticking region
+@@ -5079,8 +_,12 @@
+                 teleportHoldId
+             );
+             // adjust passenger tree to final pos/rot/speed
+-            for (EntityTreeNode node : fullPassengerTree) {
+-                node.root.transform(info);
++            for (int i = 0; i < fullPassengerTree.size(); ++i) {
++                EntityTreeNode node = fullPassengerTree.get(i);
++                PositionMoveRotation source = portalSources.get(i);
++                // The End has no exit-frame axis. Preserve each entity's world-space velocity rather
++                // than rotating the whole passenger tree toward the platform's fixed west-facing yaw.
++                node.root.transformForPortal(source, info, enteringEnd);
+             }
+ 
+             // place
+@@ -5096,8 +_,8 @@
+                     this.canvas$teleportingToDimension = null;
+                     this.canvas$lastTeleportOrigin = null;
+                     // Canvas end - region threading
+-                    if (teleportComplete != null) {
+-                        teleportComplete.accept(teleported);
++                    if (finalTeleportComplete != null) {
++                        finalTeleportComplete.accept(teleported);
+                     }
+                     // Canvas start - region threading
+                     if (io.canvasmc.canvas.event.EntityPostPortalAsyncEvent.getHandlerList().getRegisteredListeners().length > 0) {
 @@ -5356,7 +_,7 @@
  
      public boolean canTeleport(final Level from, final Level to) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/PortalProcessor.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/PortalProcessor.java.patch
@@ -1,0 +1,39 @@
+--- a/net/minecraft/world/entity/PortalProcessor.java
++++ b/net/minecraft/world/entity/PortalProcessor.java
+@@ -10,6 +_,8 @@
+     private final Portal portal;
+     private BlockPos entryPosition;
+     private int portalTime;
+     private boolean insidePortalThisTick;
++    private boolean canvas$hasPortalRegionOwnershipDeferral; // Canvas - bound cross-region portal retries
++    private int canvas$portalRegionOwnershipDeferralTick; // Canvas - bound cross-region portal retries
+ 
+     public PortalProcessor(final Portal portal, final BlockPos portalEntryPosition) {
+@@ -18,6 +_,27 @@
+         this.insidePortalThisTick = true;
+     }
+ 
++    // Canvas start - do not consume a portal attempt before its region owns the hand-off
++    public boolean isReadyToTeleport(final ServerLevel level, final Entity entity, final boolean allowedToTeleport) {
++        return this.insidePortalThisTick
++            && allowedToTeleport
++            && this.portalTime >= this.portal.getPortalTransitionTime(level, entity);
++    }
++
++    public boolean requiresPortalEntryBlockOwnership() {
++        return this.portal.requiresPortalEntryBlockOwnership();
++    }
++
++    public boolean shouldDeferForPortalRegionOwnership(final int currentTick) {
++        if (!this.canvas$hasPortalRegionOwnershipDeferral) {
++            this.canvas$hasPortalRegionOwnershipDeferral = true;
++            this.canvas$portalRegionOwnershipDeferralTick = currentTick;
++            return true;
++        }
++        return this.canvas$portalRegionOwnershipDeferralTick == currentTick;
++    }
++    // Canvas end - do not consume a portal attempt before its region owns the hand-off
++
+     public boolean processPortalTeleportation(final ServerLevel serverLevel, final Entity entity, final boolean allowedToTeleport) {
+         if (!this.insidePortalThisTick) {
+             this.decayTick();

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/item/FallingBlockEntity.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/item/FallingBlockEntity.java.patch
@@ -1,0 +1,20 @@
+--- a/net/minecraft/world/entity/item/FallingBlockEntity.java
++++ b/net/minecraft/world/entity/item/FallingBlockEntity.java
+@@ -69,7 +_,7 @@
+     public int fallDamageMax = 40;
+     public float fallDamagePerDistance = 0.0F;
+     public @Nullable CompoundTag blockData;
+-    public boolean forceTickAfterTeleportToDuplicate;
++    public boolean forceTickAfterTeleportToDuplicate = io.canvasmc.canvas.GlobalConfiguration.getInstance().allowUnsafeEndPortalTeleportation; // Canvas - unsafe end portal teleportation
+     protected static final EntityDataAccessor<BlockPos> DATA_START_POS = SynchedEntityData.defineId(FallingBlockEntity.class, EntityDataSerializers.BLOCK_POS);
+     public boolean autoExpire = true; // Paper - Expand FallingBlock API
+ 
+@@ -383,7 +_,7 @@
+         ResourceKey<Level> oldDimension = this.level().dimension();
+         boolean fromOrToEnd = (oldDimension == Level.END || newDimension == Level.END) && oldDimension != newDimension;
+         Entity newEntity = super.teleport(transition);
+-        this.forceTickAfterTeleportToDuplicate = newEntity != null && fromOrToEnd && io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowUnsafeEndPortalTeleportation; // Paper
++        this.forceTickAfterTeleportToDuplicate = newEntity != null && fromOrToEnd && (io.papermc.paper.configuration.GlobalConfiguration.get().unsupportedSettings.allowUnsafeEndPortalTeleportation || io.canvasmc.canvas.GlobalConfiguration.getInstance().allowUnsafeEndPortalTeleportation); // Paper // Canvas - unsafe end portal teleportation
+         return newEntity;
+     }
+ }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/ShulkerBullet.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/ShulkerBullet.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/projectile/ShulkerBullet.java
 +++ b/net/minecraft/world/entity/projectile/ShulkerBullet.java
-@@ -227,6 +_,16 @@
+@@ -227,9 +_,19 @@
  
          Vec3 movement = this.getDeltaMovement();
          this.setPos(this.position().add(movement));
@@ -16,7 +16,11 @@
 +        // Canvas end - MC-22157
          this.applyEffectsFromBlocks();
          if (this.portalProcess != null && this.portalProcess.isInsidePortalThisTick()) {
-             this.handlePortal();
+-            this.handlePortal();
++            if (this.handlePortal()) return; // Canvas - stop ticking after portal hand-off
+         }
+ 
+         if (hitResult != null && this.isAlive() && hitResult.getType() != HitResult.Type.MISS) {
 @@ -305,6 +_,12 @@
              if (target instanceof LivingEntity livingTarget) {
                  livingTarget.addEffect(new MobEffectInstance(MobEffects.LEVITATION, 200), MoreObjects.firstNonNull(owner, this), org.bukkit.event.entity.EntityPotionEffectEvent.Cause.ATTACK); // CraftBukkit

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java.patch
@@ -1,0 +1,37 @@
+--- a/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
++++ b/net/minecraft/world/entity/projectile/arrow/AbstractArrow.java
+@@ -276,7 +_,7 @@
+                     .clipIncludingBorder(
+                         new ClipContext(originalPosition, originalPosition.add(movement), ClipContext.Block.COLLIDER, ClipContext.Fluid.NONE, this)
+                     );
+-                this.stepMoveAndHit(blockHitResult);
++                if (this.stepMoveAndHit(blockHitResult)) return; // Canvas - stop ticking after portal hand-off
+             } else {
+                 this.setPos(originalPosition.add(movement));
+                 this.applyEffectsFromBlocks();
+@@ -299,7 +_,7 @@
+         return 0.99F;
+     }
+ 
+-    private void stepMoveAndHit(final BlockHitResult blockHitResult) {
++    private boolean stepMoveAndHit(final BlockHitResult blockHitResult) { // Canvas - stop ticking after portal hand-off
+         while (this.isAlive()) {
+             Vec3 initialPosition = this.position();
+             ArrayList<EntityHitResult> entitiesHit = new ArrayList<>(this.findHitEntities(initialPosition, blockHitResult.getLocation()));
+@@ -309,7 +_,7 @@
+             this.setPos(nextLocation);
+             this.applyEffectsFromBlocks(initialPosition, nextLocation);
+             if (this.portalProcess != null && this.portalProcess.isInsidePortalThisTick()) {
+-                this.handlePortal();
++                if (this.handlePortal()) return true; // Canvas - stop ticking after portal hand-off
+             }
+ 
+             if (entitiesHit.isEmpty()) {
+@@ -327,6 +_,7 @@
+                 break;
+             }
+         }
++        return false; // Canvas - stop ticking after portal hand-off
+     }
+ 
+     private ProjectileDeflection hitTargetsOrDeflectSelf(final Collection<EntityHitResult> entityHitResults) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
@@ -12,3 +12,16 @@
              // CraftBukkit start - Entity in portal
              org.bukkit.event.entity.EntityPortalEnterEvent event = new org.bukkit.event.entity.EntityPortalEnterEvent(entity.getBukkitEntity(), org.bukkit.craftbukkit.util.CraftLocation.toBukkit(pos, level), org.bukkit.PortalType.ENDER); // Paper - add portal type
              if (!event.callEvent()) return; // Paper - make cancellable
+@@ -76,6 +_,12 @@
+                 if (level.paperConfig().misc.disableEndCredits) {player.seenCredits = true; return;} // Paper - Option to disable end credits
+                 player.showEndCredits();
+             } else {
++                // Canvas start - unsafe end portal teleportation
++                if (io.canvasmc.canvas.GlobalConfiguration.getInstance().allowUnsafeEndPortalTeleportation && !(entity instanceof net.minecraft.world.entity.player.Player)) {
++                    entity.endPortalLogicAsync(pos);
++                    return;
++                }
++                // Canvas end - unsafe end portal teleportation
+                 entity.setAsInsidePortal(this, pos);
+             }
+         }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/EndPortalBlock.java.patch
@@ -25,3 +25,22 @@
                  entity.setAsInsidePortal(this, pos);
              }
          }
+@@ -134,13 +_,15 @@
+ 
+     // Folia start - region threading
++    @Override
++    public boolean requiresPortalEntryBlockOwnership() {
++        return false;
++    }
++
+     @Override
+     public boolean portalAsync(ServerLevel sourceWorld, Entity portalTarget, BlockPos portalPos) {
+         if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(portalTarget)) {
+             return false;
+         }
+-        if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(sourceWorld, portalPos)) {
+-            return false;
+-        }
+ 
+         return portalTarget.endPortalLogicAsync(portalPos);
+     }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/Portal.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/block/Portal.java.patch
@@ -1,0 +1,13 @@
+--- a/net/minecraft/world/level/block/Portal.java
++++ b/net/minecraft/world/level/block/Portal.java
+@@ -16,6 +_,10 @@
+     // Folia start - region threading
+     public boolean portalAsync(ServerLevel sourceWorld, Entity portalTarget, BlockPos portalPos);
+ 
++    default boolean requiresPortalEntryBlockOwnership() {
++        return true;
++    }
++
+     // Folia end - region threading
+     default Portal.Transition getLocalTransition() {
+         return Portal.Transition.NONE;

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -551,6 +551,12 @@ public class GlobalConfiguration extends Part {
                 "Folia's portaling rewrite makes the world loading screen not display on the client properly, and",
                 "instead shows an empty void. With this enabled, Canvas will display the proper world loading screen"
             );
+        option("allowUnsafeEndPortalTeleportation")
+            .docs(
+                "Allows non-player entities to use End portals through Canvas' async portal path. This enables",
+                "sand duping machines, but can cause unsafe teleportation behavior in Folia's region threading model.",
+                "See: https://github.com/PaperMC/Folia/issues/297"
+            );
         option("cacheMinecraft2BukkitEntityTypeConversion").docs("Whether to cache expensive CraftEntityType#minecraftToBukkit call");
         option("tileEntitySnapshotCreation").docs("Enables creation of tile entity snapshots on retrieving blockstates");
 
@@ -566,6 +572,7 @@ public class GlobalConfiguration extends Part {
     public String serverModName = ServerBuildInfo.buildInfo().brandName();
     public boolean displayWorldLoadScreenForPortaling = true;
     public boolean displayWorldLoadScreenForTeleporting = true;
+    public boolean allowUnsafeEndPortalTeleportation = false;
     public boolean cacheMinecraft2BukkitEntityTypeConversion = false;
     public boolean tileEntitySnapshotCreation = false;
     public String defaultRespawnDimensionKey = Level.OVERWORLD.identifier().toString();

--- a/canvas-server/src/test/java/io/canvasmc/canvas/PortalMomentumTestSuite.java
+++ b/canvas-server/src/test/java/io/canvasmc/canvas/PortalMomentumTestSuite.java
@@ -1,0 +1,11 @@
+package io.canvasmc.canvas;
+
+import net.minecraft.server.level.PortalTickStateTest;
+import net.minecraft.world.entity.PortalMomentumTransformTest;
+import org.junit.platform.suite.api.SelectClasses;
+import org.junit.platform.suite.api.Suite;
+
+@Suite
+@SelectClasses({PortalTickStateTest.class, PortalMomentumTransformTest.class})
+public class PortalMomentumTestSuite {
+}

--- a/canvas-server/src/test/java/net/minecraft/server/level/PortalTickStateTest.java
+++ b/canvas-server/src/test/java/net/minecraft/server/level/PortalTickStateTest.java
@@ -1,0 +1,475 @@
+package net.minecraft.server.level;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+import static org.junit.jupiter.api.Assertions.assertNull;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
+import static org.mockito.Mockito.inOrder;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.mockStatic;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import ca.spottedleaf.moonrise.common.util.TickThread;
+import io.papermc.paper.entity.activation.ActivationRange;
+import java.util.List;
+import net.minecraft.SharedConstants;
+import net.minecraft.core.BlockPos;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.world.entity.Entity;
+import net.minecraft.world.entity.PortalProcessor;
+import net.minecraft.world.entity.player.Player;
+import net.minecraft.world.level.block.Portal;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+import org.mockito.InOrder;
+import org.mockito.MockedStatic;
+
+public class PortalTickStateTest {
+    @BeforeAll
+    static void bootstrapMinecraftRegistries() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void nonPlayerPortalEntryStartsPrePhysicsHandling() {
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+
+        entity.setAsInsidePortal(mock(Portal.class), BlockPos.ZERO);
+
+        assertNotNull(entity.portalProcess);
+        assertEquals(1, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void playerPortalEntryDoesNotUseNonPlayerTickState() {
+        Player player = mock(Player.class, CALLS_REAL_METHODS);
+
+        player.setAsInsidePortal(mock(Portal.class), BlockPos.ZERO);
+
+        assertNotNull(player.portalProcess);
+        assertEquals(0, player.canvas$portalTickState);
+    }
+
+    @Test
+    void directPortalHandlerClearsStateBeforeAsyncHandoff() {
+        ServerLevel level = mock(ServerLevel.class);
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        Portal portal = mock(Portal.class);
+        BlockPos entryPosition = new BlockPos(16, 64, 16);
+        PortalProcessor processor = new PortalProcessor(portal, entryPosition);
+        entity.portalProcess = processor;
+        entity.canvas$portalTickState = 1;
+        doReturn(level).when(entity).level();
+        doReturn(true).when(entity).canUsePortal(false);
+        doReturn(300).when(entity).getDimensionChangingDelay();
+        when(portal.getPortalTransitionTime(level, entity)).thenReturn(0);
+        when(portal.requiresPortalEntryBlockOwnership()).thenReturn(true);
+        when(portal.portalAsync(level, entity, entryPosition)).thenAnswer(invocation -> {
+            assertEquals(0, entity.canvas$portalTickState);
+            return true;
+        });
+
+        boolean portalled;
+        try (MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)) {
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(level, entryPosition)).thenReturn(true);
+            portalled = entity.handlePortal();
+        }
+
+        assertTrue(portalled);
+        assertEquals(0, entity.canvas$portalTickState);
+        assertFalse(processor.isInsidePortalThisTick());
+        assertEquals(1, processor.getPortalTime());
+        assertEquals(300, entity.getPortalCooldown());
+    }
+
+    @Test
+    void committedPortalFailureDoesNotAdvertiseAFakeRetry() {
+        ServerLevel level = mock(ServerLevel.class);
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        Portal portal = mock(Portal.class);
+        BlockPos entryPosition = new BlockPos(-16, 70, 16);
+        PortalProcessor processor = new PortalProcessor(portal, entryPosition);
+        entity.portalProcess = processor;
+        entity.canvas$portalTickState = 1;
+        doReturn(level).when(entity).level();
+        doReturn(true).when(entity).canUsePortal(false);
+        doReturn(300).when(entity).getDimensionChangingDelay();
+        when(portal.getPortalTransitionTime(level, entity)).thenReturn(0);
+        when(portal.requiresPortalEntryBlockOwnership()).thenReturn(true);
+        when(portal.portalAsync(level, entity, entryPosition)).thenReturn(false);
+
+        boolean portalled;
+        try (MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)) {
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(level, entryPosition)).thenReturn(true);
+            portalled = entity.handlePortal();
+        }
+
+        assertFalse(portalled);
+        assertEquals(0, entity.canvas$portalTickState);
+        assertFalse(processor.isInsidePortalThisTick());
+        assertEquals(1, processor.getPortalTime());
+        assertEquals(300, entity.getPortalCooldown());
+    }
+
+    @Test
+    void wrongEntityOwnerDefersWithoutConsumingPortalState() {
+        ServerLevel level = mock(ServerLevel.class);
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        Portal portal = mock(Portal.class);
+        PortalProcessor processor = new PortalProcessor(portal, BlockPos.ZERO);
+        entity.portalProcess = processor;
+        entity.canvas$portalTickState = 1;
+        doReturn(level).when(entity).level();
+
+        boolean handled;
+        try (MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)) {
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(false);
+            handled = entity.handlePortal();
+        }
+
+        assertTrue(handled);
+        assertEquals(1, entity.canvas$portalTickState);
+        assertTrue(processor.isInsidePortalThisTick());
+        assertEquals(0, processor.getPortalTime());
+        assertEquals(0, entity.getPortalCooldown());
+        verify(portal, never()).getPortalTransitionTime(level, entity);
+        verify(portal, never()).portalAsync(level, entity, BlockPos.ZERO);
+    }
+
+    @Test
+    void wrongPortalBlockOwnerDefersThenRetriesWithoutConsumingPortalState() {
+        ServerLevel level = mock(ServerLevel.class);
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        Portal portal = mock(Portal.class);
+        BlockPos entryPosition = new BlockPos(32, 64, 32);
+        PortalProcessor processor = new PortalProcessor(portal, entryPosition);
+        entity.portalProcess = processor;
+        entity.canvas$portalTickState = 1;
+        doReturn(level).when(entity).level();
+        doReturn(true).when(entity).canUsePortal(false);
+        doReturn(300).when(entity).getDimensionChangingDelay();
+        when(portal.getPortalTransitionTime(level, entity)).thenReturn(0);
+        when(portal.requiresPortalEntryBlockOwnership()).thenReturn(true);
+        when(portal.portalAsync(level, entity, entryPosition)).thenReturn(true);
+
+        boolean deferred;
+        boolean portalled;
+        try (MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)) {
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(level, entryPosition)).thenReturn(false, true);
+            deferred = entity.handlePortal();
+
+            assertTrue(deferred);
+            assertEquals(1, entity.canvas$portalTickState);
+            assertTrue(processor.isInsidePortalThisTick());
+            assertEquals(0, processor.getPortalTime());
+            assertEquals(0, entity.getPortalCooldown());
+            verify(portal, never()).portalAsync(level, entity, entryPosition);
+
+            portalled = entity.handlePortal();
+        }
+
+        assertTrue(portalled);
+        assertEquals(0, entity.canvas$portalTickState);
+        assertFalse(processor.isInsidePortalThisTick());
+        assertEquals(1, processor.getPortalTime());
+        assertEquals(300, entity.getPortalCooldown());
+        verify(portal).portalAsync(level, entity, entryPosition);
+    }
+
+    @Test
+    void permanentlySplitPortalRegionAbandonsAfterABoundedRetry() {
+        ServerLevel level = mock(ServerLevel.class);
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        Portal portal = mock(Portal.class);
+        BlockPos entryPosition = new BlockPos(48, 64, -48);
+        PortalProcessor processor = new PortalProcessor(portal, entryPosition);
+        entity.portalProcess = processor;
+        entity.canvas$portalTickState = 1;
+        doReturn(level).when(entity).level();
+        doReturn(true).when(entity).canUsePortal(false);
+        when(portal.getPortalTransitionTime(level, entity)).thenReturn(0);
+        when(portal.requiresPortalEntryBlockOwnership()).thenReturn(true);
+
+        boolean deferred;
+        boolean sameTickDeferred;
+        boolean handled;
+        try (MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)) {
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(level, entryPosition)).thenReturn(false);
+            deferred = entity.handlePortal();
+            sameTickDeferred = entity.handlePortal();
+
+            assertTrue(deferred);
+            assertTrue(sameTickDeferred);
+            assertEquals(processor, entity.portalProcess);
+            assertEquals(1, entity.canvas$portalTickState);
+            assertTrue(processor.isInsidePortalThisTick());
+            assertEquals(0, processor.getPortalTime());
+            assertEquals(0, entity.getPortalCooldown());
+
+            entity.tickCount++;
+            handled = entity.handlePortal();
+        }
+
+        assertFalse(handled);
+        assertNull(entity.portalProcess);
+        assertEquals(0, entity.canvas$portalTickState);
+        assertTrue(processor.isInsidePortalThisTick());
+        assertEquals(0, processor.getPortalTime());
+        assertEquals(0, entity.getPortalCooldown());
+        verify(portal, never()).portalAsync(level, entity, entryPosition);
+    }
+
+    @Test
+    void playerDoesNotCarryAStalePortalMarkerAcrossTicks() {
+        ServerLevel level = mock(ServerLevel.class);
+        Player player = mock(Player.class, CALLS_REAL_METHODS);
+        Portal portal = mock(Portal.class);
+        BlockPos entryPosition = new BlockPos(-80, 70, -80);
+        PortalProcessor processor = new PortalProcessor(portal, entryPosition);
+        player.portalProcess = processor;
+        doReturn(level).when(player).level();
+        doReturn(true).when(player).canUsePortal(false);
+        when(portal.getPortalTransitionTime(level, player)).thenReturn(0);
+        when(portal.requiresPortalEntryBlockOwnership()).thenReturn(true);
+
+        boolean handled;
+        try (MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)) {
+            tickThread.when(() -> TickThread.isTickThreadFor(player)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(level, entryPosition)).thenReturn(false);
+            handled = player.handlePortal();
+        }
+
+        assertFalse(handled);
+        assertNull(player.portalProcess);
+        assertTrue(processor.isInsidePortalThisTick());
+        assertEquals(0, processor.getPortalTime());
+        assertEquals(0, player.getPortalCooldown());
+        verify(portal, never()).portalAsync(level, player, entryPosition);
+    }
+
+    @Test
+    void portalWithoutSourceBlockReadsCommitsFromTheEntityOwner() {
+        ServerLevel level = mock(ServerLevel.class);
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        Portal portal = mock(Portal.class);
+        BlockPos entryPosition = new BlockPos(80, 60, 80);
+        PortalProcessor processor = new PortalProcessor(portal, entryPosition);
+        entity.portalProcess = processor;
+        entity.canvas$portalTickState = 1;
+        doReturn(level).when(entity).level();
+        doReturn(true).when(entity).canUsePortal(false);
+        doReturn(300).when(entity).getDimensionChangingDelay();
+        when(portal.getPortalTransitionTime(level, entity)).thenReturn(0);
+        when(portal.requiresPortalEntryBlockOwnership()).thenReturn(false);
+        when(portal.portalAsync(level, entity, entryPosition)).thenReturn(true);
+
+        boolean portalled;
+        try (MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)) {
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(level, entryPosition)).thenReturn(false);
+            portalled = entity.handlePortal();
+        }
+
+        assertTrue(portalled);
+        assertEquals(0, entity.canvas$portalTickState);
+        assertFalse(processor.isInsidePortalThisTick());
+        assertEquals(1, processor.getPortalTime());
+        assertEquals(300, entity.getPortalCooldown());
+        verify(portal).portalAsync(level, entity, entryPosition);
+    }
+
+    @Test
+    void pendingPortalIsHandledBeforeAnotherPhysicsTick() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 1;
+        when(entity.handlePortal()).thenReturn(true);
+
+        tickAsActiveEntity(level, entity, true);
+
+        verify(entity, never()).tick();
+        verify(entity).handlePortal();
+        assertEquals(0, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void ownershipDeferralRemainsPendingAfterThePrePhysicsCheck() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 1;
+        when(entity.handlePortal()).thenAnswer(invocation -> {
+            entity.canvas$portalTickState = 1;
+            return true;
+        });
+
+        tickAsActiveEntity(level, entity, true);
+
+        verify(entity, never()).tick();
+        verify(entity).handlePortal();
+        assertEquals(1, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void failedPendingPortalSchedulesCompensation() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 1;
+        when(entity.getPassengers()).thenReturn(List.of());
+        when(entity.handlePortal()).thenReturn(false);
+
+        tickAsActiveEntity(level, entity, true);
+
+        verify(entity, never()).tick();
+        verify(entity).handlePortal();
+        assertEquals(2, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void pendingPortalRemainsPendingUntilItsRegionOwnsTheEntity() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 1;
+
+        tickAsActiveEntity(level, entity, false);
+
+        verify(entity, never()).tick();
+        verify(entity, never()).handlePortal();
+        assertEquals(1, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void failedPrePhysicsPortalCompensatesTheSkippedTickInOrder() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 2;
+        when(entity.getPassengers()).thenReturn(List.of());
+        when(entity.handlePortal()).thenReturn(false);
+
+        tickAsActiveEntity(level, entity, true);
+
+        InOrder order = inOrder(entity);
+        order.verify(entity).tick();
+        order.verify(entity).handlePortal();
+        order.verify(entity).tick();
+        order.verify(entity).handlePortal();
+        assertEquals(0, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void successfulFirstCompensationStopsImmediately() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 2;
+        when(entity.handlePortal()).thenReturn(true);
+
+        tickAsActiveEntity(level, entity, true);
+
+        verify(entity).tick();
+        verify(entity).handlePortal();
+        verify(entity, times(1)).tick();
+        assertEquals(0, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void compensationStopsWhenTheFirstTickChangesRegionOwnership() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 2;
+
+        tickAsActiveEntity(level, entity, false);
+
+        verify(entity).tick();
+        verify(entity, never()).handlePortal();
+        assertEquals(2, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void sameRegionPortalEntryIsConsumedByTheImmediatePortalCheck() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        doAnswer(invocation -> {
+            entity.canvas$portalTickState = 1;
+            return null;
+        }).when(entity).tick();
+        when(entity.handlePortal()).thenReturn(true);
+
+        tickAsActiveEntity(level, entity, true);
+
+        verify(entity).tick();
+        verify(entity).handlePortal();
+        assertEquals(0, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void secondCompensationTickKeepsANewPortalStateAcrossRegionHandoff() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 2;
+        final int[] ticks = {0};
+        doAnswer(invocation -> {
+            if (++ticks[0] == 2) entity.canvas$portalTickState = 1;
+            return null;
+        }).when(entity).tick();
+        when(entity.handlePortal()).thenReturn(false);
+
+        try (
+            MockedStatic<ActivationRange> activationRange = mockStatic(ActivationRange.class);
+            MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)
+        ) {
+            activationRange.when(() -> ActivationRange.checkIfActive(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(true, false);
+
+            level.tickNonPassenger(entity);
+        }
+
+        verify(entity, times(2)).tick();
+        verify(entity, times(1)).handlePortal();
+        assertEquals(1, entity.canvas$portalTickState);
+    }
+
+    @Test
+    void completedCompensationDoesNotRepeatAfterARegionHandoff() {
+        ServerLevel level = mock(ServerLevel.class, CALLS_REAL_METHODS);
+        Entity entity = mock(Entity.class);
+        entity.canvas$portalTickState = 2;
+        when(entity.handlePortal()).thenReturn(false);
+
+        try (
+            MockedStatic<ActivationRange> activationRange = mockStatic(ActivationRange.class);
+            MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)
+        ) {
+            activationRange.when(() -> ActivationRange.checkIfActive(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(true, false);
+
+            level.tickNonPassenger(entity);
+        }
+
+        verify(entity, times(2)).tick();
+        verify(entity, times(1)).handlePortal();
+        assertEquals(0, entity.canvas$portalTickState);
+    }
+
+    private static void tickAsActiveEntity(final ServerLevel level, final Entity entity, final boolean ownsEntity) {
+        try (
+            MockedStatic<ActivationRange> activationRange = mockStatic(ActivationRange.class);
+            MockedStatic<TickThread> tickThread = mockStatic(TickThread.class)
+        ) {
+            activationRange.when(() -> ActivationRange.checkIfActive(entity)).thenReturn(true);
+            tickThread.when(() -> TickThread.isTickThreadFor(entity)).thenReturn(ownsEntity);
+
+            level.tickNonPassenger(entity);
+        }
+    }
+}

--- a/canvas-server/src/test/java/net/minecraft/world/entity/PortalMomentumTransformTest.java
+++ b/canvas-server/src/test/java/net/minecraft/world/entity/PortalMomentumTransformTest.java
@@ -1,0 +1,90 @@
+package net.minecraft.world.entity;
+
+import static org.mockito.Answers.CALLS_REAL_METHODS;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import java.util.Set;
+import net.minecraft.SharedConstants;
+import net.minecraft.server.Bootstrap;
+import net.minecraft.server.level.ServerLevel;
+import net.minecraft.world.level.portal.TeleportTransition;
+import net.minecraft.world.phys.Vec3;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+public class PortalMomentumTransformTest {
+    @BeforeAll
+    static void bootstrapMinecraftRegistries() {
+        SharedConstants.tryDetectVersion();
+        Bootstrap.bootStrap();
+    }
+
+    @Test
+    void asyncPortalUsesLiveSourceMotionInsteadOfCopiedNbtMotion() {
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        doNothing().when(entity).transform(any(Vec3.class), any(Float.class), any(Float.class), any(Vec3.class));
+        Vec3 target = new Vec3(8.5, 70.0, -3.5);
+        Vec3 liveVelocity = new Vec3(12.5, 0.25, -11.0);
+        PositionMoveRotation source = new PositionMoveRotation(Vec3.ZERO, liveVelocity, 90.0F, 17.0F);
+        TeleportTransition transition = new TeleportTransition(
+            mock(ServerLevel.class),
+            target,
+            Vec3.ZERO,
+            90.0F,
+            0.0F,
+            Relative.union(Relative.DELTA, Set.of(Relative.X_ROT)),
+            TeleportTransition.DO_NOTHING
+        );
+
+        entity.transformForPortal(source, transition, false);
+
+        verify(entity).transform(target, 90.0F, 17.0F, liveVelocity);
+    }
+
+    @Test
+    void endPortalPreservesWorldSpaceMotionAndPitchForEachEntity() {
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        doNothing().when(entity).transform(any(Vec3.class), any(Float.class), any(Float.class), any(Vec3.class));
+        Vec3 target = new Vec3(100.5, 50.0, 0.5);
+        Vec3 liveVelocity = new Vec3(11.25, 2.5, -13.75);
+        PositionMoveRotation source = new PositionMoveRotation(Vec3.ZERO, liveVelocity, 0.0F, -23.0F);
+        TeleportTransition transition = new TeleportTransition(
+            mock(ServerLevel.class),
+            target,
+            Vec3.ZERO,
+            90.0F,
+            0.0F,
+            Set.of(),
+            TeleportTransition.DO_NOTHING
+        );
+
+        entity.transformForPortal(source, transition, true);
+
+        verify(entity).transform(target, 90.0F, -23.0F, liveVelocity);
+    }
+
+    @Test
+    void missingNetherExitFramePreservesWorldSpaceMotion() {
+        Entity entity = mock(Entity.class, CALLS_REAL_METHODS);
+        doNothing().when(entity).transform(any(Vec3.class), any(Float.class), any(Float.class), any(Vec3.class));
+        Vec3 target = new Vec3(-32.5, 72.0, 48.5);
+        Vec3 liveVelocity = new Vec3(6.75, -0.5, -4.25);
+        PositionMoveRotation source = new PositionMoveRotation(Vec3.ZERO, liveVelocity, 15.0F, 11.0F);
+        TeleportTransition transition = new TeleportTransition(
+            mock(ServerLevel.class),
+            target,
+            Vec3.ZERO,
+            90.0F,
+            0.0F,
+            Relative.union(Relative.direction(true, true, true), Set.of(Relative.X_ROT)),
+            TeleportTransition.DO_NOTHING
+        );
+
+        entity.transformForPortal(source, transition, false);
+
+        verify(entity).transform(target, 90.0F, 11.0F, liveVelocity);
+    }
+}


### PR DESCRIPTION
Fixes entity velocity being lost during Canvas's asynchronous portal teleportation.

This issue caused:

- Sand dupers to send sand to the End without the expected outward spread
- Items and primed TNT to lose momentum after using Nether portals
- TNT to stop at the portal exit and explode in place
- Some projectiles to continue ticking at their old position after teleporting