### PR TITLE
Full Canvas Test Suite

### DIFF
--- a/canvas-api/src/test/java/io/canvasmc/canvas/WorldUnloadResultTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/WorldUnloadResultTest.java
@@ -1,0 +1,17 @@
+package io.canvasmc.canvas;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.EnumSource;
+
+public class WorldUnloadResultTest {
+
+    @ParameterizedTest
+    @EnumSource(WorldUnloadResult.class)
+    public void reportsSuccessAndFailureAsComplements(final WorldUnloadResult result) {
+        assertEquals(result == WorldUnloadResult.SUCCESS, result.isSuccess());
+        assertEquals(result != WorldUnloadResult.SUCCESS, result.isFailure());
+        assertEquals(!result.isSuccess(), result.isFailure());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityPortalAsyncEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityPortalAsyncEventTest.java
@@ -1,0 +1,36 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.PortalType;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.junit.jupiter.api.Test;
+
+public class EntityPortalAsyncEventTest {
+
+    @Test
+    public void exposesAndAllowsUpdatingPortalTransitionState() {
+        final Entity entity = mock(Entity.class);
+        final World from = mock(World.class);
+        final World initialDestination = mock(World.class);
+        final World updatedDestination = mock(World.class);
+        final EntityPortalAsyncEvent event = new EntityPortalAsyncEvent(entity, from, initialDestination, PortalType.NETHER);
+
+        assertSame(entity, event.getEntity());
+        assertSame(from, event.getFrom());
+        assertSame(initialDestination, event.getTo());
+        assertSame(PortalType.NETHER, event.getPortalType());
+        assertSame(EntityPortalAsyncEvent.getHandlerList(), event.getHandlers());
+        assertFalse(event.isCancelled());
+
+        event.setTo(updatedDestination);
+        event.setCancelled(true);
+
+        assertSame(updatedDestination, event.getTo());
+        assertTrue(event.isCancelled());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityPostPortalAsyncEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityPostPortalAsyncEventTest.java
@@ -1,0 +1,26 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.PortalType;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.junit.jupiter.api.Test;
+
+public class EntityPostPortalAsyncEventTest {
+
+    @Test
+    public void preservesCompletedPortalTransitionState() {
+        final Entity entity = mock(Entity.class);
+        final World from = mock(World.class);
+        final World to = mock(World.class);
+        final EntityPostPortalAsyncEvent event = new EntityPostPortalAsyncEvent(entity, from, to, PortalType.ENDER);
+
+        assertSame(entity, event.getEntity());
+        assertSame(from, event.getFrom());
+        assertSame(to, event.getTo());
+        assertSame(PortalType.ENDER, event.getPortalType());
+        assertSame(EntityPostPortalAsyncEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityPostTeleportAsyncEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityPostTeleportAsyncEventTest.java
@@ -1,0 +1,33 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.junit.jupiter.api.Test;
+
+public class EntityPostTeleportAsyncEventTest {
+
+    @Test
+    public void preservesCompletedTeleportStateAndNullFallback() {
+        final Entity entity = mock(Entity.class);
+        final Location from = new Location(mock(World.class), 1.0, 2.0, 3.0);
+        final EntityPostTeleportAsyncEvent event = new EntityPostTeleportAsyncEvent(
+            entity,
+            from,
+            null,
+            PlayerTeleportEvent.TeleportCause.ENDER_PEARL,
+            EntityTeleportAsyncEvent.TeleportType.CROSS_REGION
+        );
+
+        assertSame(entity, event.getEntity());
+        assertSame(from, event.getFrom());
+        assertSame(from, event.getTo());
+        assertSame(PlayerTeleportEvent.TeleportCause.ENDER_PEARL, event.getCause());
+        assertSame(EntityTeleportAsyncEvent.TeleportType.CROSS_REGION, event.getType());
+        assertSame(EntityPostTeleportAsyncEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityTeleportAsyncEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/EntityTeleportAsyncEventTest.java
@@ -1,0 +1,46 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Entity;
+import org.bukkit.event.player.PlayerTeleportEvent;
+import org.junit.jupiter.api.Test;
+
+public class EntityTeleportAsyncEventTest {
+
+    @Test
+    public void handlesFallbackDestinationMutationAndCancellation() {
+        final Entity entity = mock(Entity.class);
+        final Location from = new Location(mock(World.class), 1.0, 2.0, 3.0);
+        final EntityTeleportAsyncEvent event = new EntityTeleportAsyncEvent(
+            entity,
+            from,
+            null,
+            PlayerTeleportEvent.TeleportCause.COMMAND,
+            EntityTeleportAsyncEvent.TeleportType.CROSS_WORLD
+        );
+
+        assertSame(entity, event.getEntity());
+        assertSame(from, event.getFrom());
+        assertSame(from, event.getTo());
+        assertSame(PlayerTeleportEvent.TeleportCause.COMMAND, event.getCause());
+        assertSame(EntityTeleportAsyncEvent.TeleportType.CROSS_WORLD, event.getType());
+        assertSame(EntityTeleportAsyncEvent.getHandlerList(), event.getHandlers());
+        assertFalse(event.isCancelled());
+
+        final Location destination = new Location(mock(World.class), 4.0, 5.0, 6.0);
+        event.setTo(destination);
+        event.setCancelled(true);
+
+        assertEquals(destination, event.getTo());
+        assertNotSame(destination, event.getTo());
+        assertTrue(event.isCancelled());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerPostRespawnAsyncEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerPostRespawnAsyncEventTest.java
@@ -1,0 +1,40 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.junit.jupiter.api.Test;
+
+public class PlayerPostRespawnAsyncEventTest {
+
+    @Test
+    public void exposesCompletedRespawnState() {
+        final Player player = mock(Player.class);
+        final Location location = new Location(mock(World.class), 1.0, 2.0, 3.0);
+        final PlayerPostRespawnAsyncEvent event = new PlayerPostRespawnAsyncEvent(
+            player,
+            location,
+            false,
+            true,
+            false,
+            PlayerRespawnEvent.RespawnReason.END_PORTAL
+        );
+
+        assertSame(player, event.getPlayer());
+        assertEquals(location, event.getRespawnLocation());
+        assertNotSame(location, event.getRespawnLocation());
+        assertFalse(event.isBedSpawn());
+        assertTrue(event.isAnchorSpawn());
+        assertFalse(event.isMissingRespawnBlock());
+        assertSame(PlayerRespawnEvent.RespawnReason.END_PORTAL, event.getRespawnReason());
+        assertSame(PlayerPostRespawnAsyncEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerRespawnAsyncEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerRespawnAsyncEventTest.java
@@ -1,0 +1,49 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertNotSame;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.Location;
+import org.bukkit.World;
+import org.bukkit.entity.Player;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.junit.jupiter.api.Test;
+
+public class PlayerRespawnAsyncEventTest {
+
+    @Test
+    public void validatesAndCopiesUpdatedRespawnLocations() {
+        final Player player = mock(Player.class);
+        final Location initial = new Location(mock(World.class), 1.0, 2.0, 3.0);
+        final PlayerRespawnAsyncEvent event = new PlayerRespawnAsyncEvent(
+            player,
+            initial,
+            true,
+            false,
+            true,
+            PlayerRespawnEvent.RespawnReason.DEATH
+        );
+
+        assertSame(player, event.getPlayer());
+        assertEquals(initial, event.getRespawnLocation());
+        assertNotSame(initial, event.getRespawnLocation());
+        assertTrue(event.isBedSpawn());
+        assertFalse(event.isAnchorSpawn());
+        assertTrue(event.isMissingRespawnBlock());
+        assertSame(PlayerRespawnEvent.RespawnReason.DEATH, event.getRespawnReason());
+        assertSame(PlayerRespawnAsyncEvent.getHandlerList(), event.getHandlers());
+
+        final Location updated = new Location(mock(World.class), 4.0, 5.0, 6.0);
+        event.setRespawnLocation(updated);
+        assertEquals(updated, event.getRespawnLocation());
+        assertNotSame(updated, event.getRespawnLocation());
+
+        assertThrows(IllegalArgumentException.class, () -> event.setRespawnLocation(null));
+        assertThrows(IllegalArgumentException.class, () -> event.setRespawnLocation(new Location(null, 0.0, 0.0, 0.0)));
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerSaveEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerSaveEventTest.java
@@ -1,0 +1,23 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.entity.Player;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
+
+public class PlayerSaveEventTest {
+
+    @ParameterizedTest
+    @ValueSource(booleans = {false, true})
+    public void exposesPlayerAndQuitReason(final boolean quit) {
+        final Player player = mock(Player.class);
+        final PlayerSaveEvent event = new PlayerSaveEvent(player, quit);
+
+        assertSame(player, event.getPlayer());
+        assertEquals(quit, event.isQuit());
+        assertSame(PlayerSaveEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerViewEndCreditsEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/PlayerViewEndCreditsEventTest.java
@@ -1,0 +1,40 @@
+package io.canvasmc.canvas.event;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.mockito.Mockito.mock;
+
+import java.util.stream.Stream;
+import org.bukkit.entity.Player;
+import org.bukkit.event.Event;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
+
+public class PlayerViewEndCreditsEventTest {
+
+    public static Stream<Arguments> creditResults() {
+        return Stream.of(
+            Arguments.of(false, Event.Result.DEFAULT, false),
+            Arguments.of(true, Event.Result.DEFAULT, true),
+            Arguments.of(false, Event.Result.ALLOW, true),
+            Arguments.of(true, Event.Result.ALLOW, true),
+            Arguments.of(false, Event.Result.DENY, false),
+            Arguments.of(true, Event.Result.DENY, false)
+        );
+    }
+
+    @ParameterizedTest
+    @MethodSource("creditResults")
+    public void resolvesVanillaAndOverriddenCreditDecisions(final boolean vanillaResult, final Event.Result result, final boolean expected) {
+        final Player player = mock(Player.class);
+        final PlayerViewEndCreditsEvent event = new PlayerViewEndCreditsEvent(player, vanillaResult);
+
+        event.setResult(result);
+
+        assertSame(player, event.getPlayer());
+        assertEquals(vanillaResult, event.willVanillaShowCredits());
+        assertEquals(expected, event.willShowCredits());
+        assertSame(PlayerViewEndCreditsEvent.getHandlerList(), event.getHandlers());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/event/world/WorldUnloadAsyncEventTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/event/world/WorldUnloadAsyncEventTest.java
@@ -1,0 +1,26 @@
+package io.canvasmc.canvas.event.world;
+
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import org.bukkit.World;
+import org.junit.jupiter.api.Test;
+
+public class WorldUnloadAsyncEventTest {
+
+    @Test
+    public void exposesWorldAndTracksCancellation() {
+        final World world = mock(World.class);
+        final WorldUnloadAsyncEvent event = new WorldUnloadAsyncEvent(world);
+
+        assertSame(world, event.getWorld());
+        assertSame(WorldUnloadAsyncEvent.getHandlerList(), event.getHandlers());
+        assertFalse(event.isCancelled());
+
+        event.setCancelled(true);
+
+        assertTrue(event.isCancelled());
+    }
+}

--- a/canvas-api/src/test/java/io/canvasmc/canvas/region/RegionizedDataCallbackTest.java
+++ b/canvas-api/src/test/java/io/canvasmc/canvas/region/RegionizedDataCallbackTest.java
@@ -1,0 +1,45 @@
+package io.canvasmc.canvas.region;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+import it.unimi.dsi.fastutil.longs.Long2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.objects.ReferenceOpenHashSet;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+
+public class RegionizedDataCallbackTest {
+
+    @ParameterizedTest
+    @CsvSource({
+        "0, 0, 4",
+        "15, 15, 4",
+        "16, 16, 4",
+        "-1, -1, 4",
+        "-16, -16, 4",
+        "-17, -17, 4",
+        "2147483647, -2147483648, 5"
+    })
+    public void packsSignedRegionSectionCoordinates(final int chunkX, final int chunkZ, final int shift) {
+        final long coordinates = callback().getRegionSectionCoordinates(chunkX, chunkZ, shift);
+
+        assertEquals(chunkX >> shift, (int) coordinates);
+        assertEquals(chunkZ >> shift, (int) (coordinates >>> 32));
+    }
+
+    private static RegionTickData.IRegionizedData.IRegionizedCallback<Object> callback() {
+        return new RegionTickData.IRegionizedData.IRegionizedCallback<>() {
+            @Override
+            public void merge(final Object from, final Object into, final long fromTickOffset) {
+            }
+
+            @Override
+            public void split(
+                final Object from,
+                final int chunkToRegionShift,
+                final Long2ReferenceOpenHashMap<Object> regionToData,
+                final ReferenceOpenHashSet<Object> dataSet
+            ) {
+            }
+        };
+    }
+}

--- a/canvas-server/src/test/java/io/canvasmc/canvas/CanvasTestSuite.java
+++ b/canvas-server/src/test/java/io/canvasmc/canvas/CanvasTestSuite.java
@@ -1,0 +1,17 @@
+package io.canvasmc.canvas;
+
+import org.junit.platform.suite.api.ConfigurationParameter;
+import org.junit.platform.suite.api.ExcludeClassNamePatterns;
+import org.junit.platform.suite.api.IncludeTags;
+import org.junit.platform.suite.api.SelectPackages;
+import org.junit.platform.suite.api.Suite;
+import org.junit.platform.suite.api.SuiteDisplayName;
+
+@Suite(failIfNoTests = false)
+@SuiteDisplayName("Canvas tests")
+@IncludeTags("Normal")
+@SelectPackages("io.canvasmc.canvas")
+@ExcludeClassNamePatterns(".*TestSuite")
+@ConfigurationParameter(key = "TestSuite", value = "Normal")
+public class CanvasTestSuite {
+}


### PR DESCRIPTION
This pull request is a work in progress and is not ready to merge.

The initial commit wires Canvas-specific server tests into JUnit. Individual
tests and test infrastructure will be added over time.

Below is a list of planned tests.


## API Events and Lifecycle

- [x] World unload result status
- [x] Async entity portal event state
- [x] Post-portal event state
- [x] Async entity teleport event state
- [x] Post-teleport event state
- [x] Player save event reason
- [x] End credits event decisions
- [x] Async world unload event state
- [x] Async player respawn event state
- [x] Post-respawn event state

## General Utilities

- [x] Region section coordinate packing
- [ ] Canonical reference initialization
- [ ] Collecting list operations
- [ ] Locked reference concurrency
- [ ] Time span parsing and serialization
- [ ] Time span validation
- [ ] Time span instant calculations
- [ ] Weak concurrent collection operations
- [ ] Faster random source determinism
- [ ] Utility time formatting
- [ ] Utility string and flag handling
- [ ] Utility future waiting
- [ ] Utility directory cleanup
- [ ] Utility text gradients
- [ ] Silent logger behavior
- [ ] CPU information reporting
- [ ] Collecting list cast failure
- [ ] Faster random bounds
- [ ] Faster random positional formula
- [ ] Flowable fluid utilities
- [ ] Time span large units
- [ ] Time span overflow
- [ ] Utility random derivation
- [ ] Utility target time
- [ ] Canvas version fetcher basics

## Collections, Maps, and Tickets

- [ ] Fast heap priority queue operations
- [ ] Activity bit-set semantics
- [ ] Activity array-map semantics
- [ ] Behavior control array-set semantics
- [ ] Ticket holder lifecycle
- [ ] Weak concurrent collection array contract
- [ ] Weak concurrent collection compaction
- [ ] Fast heap priority queue differential
- [ ] Activity array-map differential
- [ ] Behavior control array-set iteration
- [ ] Trojan array list
- [ ] Ticket record callback

## Structures and Migrations

- [ ] Structure utility helpers
- [ ] Box octree spatial queries
- [ ] Legacy pearl tag migration
- [ ] Compressed pearl file migration
- [ ] Paletted structure block compression
- [ ] Pearls migration corrupt file
- [ ] Box octree boundary
- [ ] Box octree cross-octant behavior
- [ ] Paletted structure block info empty state
- [ ] Paletted structure block info identity
- [ ] Paletted structure block info packing
- [ ] Structure template optimizer bounds
- [ ] Structure template optimizer fallback
- [ ] Structure template optimizer transform

## SIMD

- [ ] SIMD Java version detection
- [ ] SIMD map-palette parity
- [ ] Vector map-palette boundary length
- [ ] Vector map-palette randomized behavior

## Spark and Commands

- [ ] Unsupported Folia duration statistics
- [ ] Folia platform metadata
- [ ] Folia player ping snapshots
- [ ] Folia class-source lookup
- [ ] Folia server configuration inventory
- [ ] Folia server configuration YAML parser
- [ ] Folia world information counts
- [ ] Subcommand metadata
- [ ] Subcommand tree
- [ ] World distance type

## World, Blocks, Bars, and Chunks

- [ ] Per-world distance configuration
- [ ] Natural spawn chunk-map coverage
- [ ] Combined heightmap updates
- [ ] Cached block-state tags
- [ ] Region resource-bar codec
- [ ] Region resource-bar display manager
- [ ] Region resource-bar format
- [ ] Region resource-bar tick
- [ ] Regionized bar normalization
- [ ] Sleep-until-time block-entity tick invoker
- [ ] Sleeping ticker
- [ ] Balanced chunk-system lifecycle
- [ ] Balanced chunk-system priority
- [ ] Combined heightmap bottom boundary
- [ ] Natural spawn chunk-map radius

## Region-Threading

- [ ] Same region never ticks concurrently
- [ ] Independent regions tick concurrently
- [ ] Region split transfers scheduled work exactly once
- [ ] Region merge transfers scheduled work exactly once
- [ ] Region retirement rejects new work
- [ ] Scheduler exception isolation
- [ ] Scheduler shutdown drains accepted work
- [ ] Scheduler shutdown rejects late work
- [ ] Affinity scheduler preserves region ownership
- [ ] Cross-region entity movement
- [ ] Cross-region player teleport
- [ ] Cross-world player teleport
- [ ] Portal event ordering across regions
- [ ] Respawn event ordering across regions
- [ ] Player disconnect during teleport
- [ ] Player save racing with world unload
- [ ] Entity removal racing with region transfer
- [ ] Regionized scoreboard snapshot consistency
- [ ] Region profiler registration and cleanup
- [ ] Region watchdog detection
- [ ] World shutdown with multiple active regions

## Persistence and Recovery

- [ ] Ender pearl save and restart restoration
- [ ] Ender pearl migration idempotence
- [ ] Interrupted migration recovery
- [ ] Corrupt migration input preserves the original file
- [ ] Atomic player-save replacement
- [ ] Crash during player save
- [ ] Crash during world save
- [ ] Restart after an unclean shutdown
- [ ] World-folder migration collision handling
- [ ] Configuration write interruption recovery
- [ ] Malformed configuration fallback
- [ ] Per-world configuration isolation

## Networking and Commands

- [ ] Alternative keepalive normal response
- [ ] Alternative keepalive timeout
- [ ] Disconnect during keepalive
- [ ] Signed chat packet processing on the correct region
- [ ] Signed command packet processing on the correct region
- [ ] Command execution permission checks
- [ ] Command execution from console
- [ ] Command execution from a region-owned player
- [ ] Command callback after sender disconnect
- [ ] Invalid command argument reporting
- [ ] Region-bar command lifecycle
- [ ] Reload command failure rollback
- [ ] Maximum-player command boundaries

## Chunk and World Behavior

- [ ] Chunk task priority ordering
- [ ] Chunk task cancellation
- [ ] Chunk executor exception isolation
- [ ] Chunk executor shutdown
- [ ] Stream-group completion
- [ ] Stream-group partial failure
- [ ] Natural spawning across region boundaries
- [ ] Heightmap updates at world minimum and maximum
- [ ] Sleeping block entity wake-up
- [ ] Sleeping block entity removal while queued
- [ ] Region resource-bar cleanup after logout
- [ ] Region resource-bar transfer between worlds
- [ ] Region resource-bar invalid persisted data
- [ ] World unload with pending chunk work