### PR TITLE
fix: skip entity-ticking chunks removed during mid-tick polling

### DIFF
--- a/.osc-metadata/sync.json
+++ b/.osc-metadata/sync.json
@@ -1,0 +1,5 @@
+{
+  "fork_synced_at": "2026-07-26T10:22:47.033675+00:00",
+  "commits_behind_before_sync": 0,
+  "action_taken": "noop"
+}

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -10,15 +10,32 @@
  
          // note: we can use the backing array here because:
          // 1. we do not care about new additions
-@@ -171,7 +_,7 @@
+@@ -171,11 +_,18 @@
  
-         java.util.Objects.checkFromToIndex(0, size, raw.length);
-         for (int i = 0; i < size; ++i) {
+-        java.util.Objects.checkFromToIndex(0, size, raw.length);
+-        for (int i = 0; i < size; ++i) {
 -            world.tickChunk(raw[i], randomTickSpeed);
-+            world.tickChunk(raw[i], randomTickSpeed, worldData); // Canvas - optimize random tick
- 
-             // call mid-tick tasks for chunk system
-             if ((i & 7) == 0) {
+-
+-            // call mid-tick tasks for chunk system
+-            if ((i & 7) == 0) {
+-                world.moonrise$executeMidTickTasks();
++        iterateTickingChunks(raw, size, chunk -> world.tickChunk(chunk, randomTickSpeed, worldData), i -> world.moonrise$executeMidTickTasks()); // Canvas - optimize random tick
++    }
++
++    static <T> void iterateTickingChunks(final T[] raw, final int size, final java.util.function.Consumer<T> tickChunk, final java.util.function.IntConsumer midTickTask) {
++        java.util.Objects.checkFromToIndex(0, size, raw.length);
++        for (int i = 0; i < size; ++i) {
++            final T chunk = raw[i];
++            if (chunk != null) {
++                tickChunk.accept(chunk);
++            }
++
++            // Preserve the original-index polling cadence even when the entry was removed.
++            if ((i & 7) == 0) {
++                midTickTask.accept(i);
+             }
+         }
+     }
 @@ -537,9 +_,9 @@
                  }
                  // Paper end - per player mob spawning backoff

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerChunkCache.java.patch
@@ -10,7 +10,7 @@
  
          // note: we can use the backing array here because:
          // 1. we do not care about new additions
-@@ -171,11 +_,18 @@
+@@ -171,11 +_,28 @@
  
 -        java.util.Objects.checkFromToIndex(0, size, raw.length);
 -        for (int i = 0; i < size; ++i) {
@@ -19,10 +19,20 @@
 -            // call mid-tick tasks for chunk system
 -            if ((i & 7) == 0) {
 -                world.moonrise$executeMidTickTasks();
-+        iterateTickingChunks(raw, size, chunk -> world.tickChunk(chunk, randomTickSpeed, worldData), i -> world.moonrise$executeMidTickTasks()); // Canvas - optimize random tick
++        iterateTickingChunks(
++            raw,
++            size,
++            chunk -> world.tickChunk(chunk, randomTickSpeed, worldData),
++            i -> world.moonrise$executeMidTickTasks()
++        ); // Canvas - optimize random tick
 +    }
 +
-+    static <T> void iterateTickingChunks(final T[] raw, final int size, final java.util.function.Consumer<T> tickChunk, final java.util.function.IntConsumer midTickTask) {
++    static <T> void iterateTickingChunks(
++        final T[] raw,
++        final int size,
++        final java.util.function.Consumer<T> tickChunk,
++        final java.util.function.IntConsumer midTickTask
++    ) {
 +        java.util.Objects.checkFromToIndex(0, size, raw.length);
 +        for (int i = 0; i < size; ++i) {
 +            final T chunk = raw[i];

--- a/canvas-server/src/test/java/net/minecraft/server/level/ServerChunkCacheIterationTest.java
+++ b/canvas-server/src/test/java/net/minecraft/server/level/ServerChunkCacheIterationTest.java
@@ -1,0 +1,101 @@
+package net.minecraft.server.level;
+
+import ca.spottedleaf.moonrise.common.list.ReferenceList;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertNotNull;
+
+class ServerChunkCacheIterationTest {
+
+    @Test
+    void stableSnapshotTicksEveryEntryAndPollsEveryEightIndices() {
+        final ReferenceList<Object> chunks = chunks(17);
+        final Object[] raw = chunks.getRawDataUnchecked();
+        final int size = chunks.size();
+        final List<Object> ticked = new ArrayList<>();
+        final List<Integer> polledIndices = new ArrayList<>();
+
+        ServerChunkCache.iterateTickingChunks(raw, size, ticked::add, polledIndices::add);
+
+        assertEquals(Arrays.asList(raw).subList(0, size), ticked);
+        assertEquals(List.of(0, 8, 16), polledIndices);
+    }
+
+    @Test
+    void removalsDuringPollingSkipVacatedTailSlots() {
+        final ReferenceList<Object> chunks = chunks(12);
+        final Object[] initial = chunks.getRawDataUnchecked().clone();
+        final Object[] raw = chunks.getRawDataUnchecked();
+        final int size = chunks.size();
+        final List<Object> ticked = new ArrayList<>();
+        final List<Integer> polledIndices = new ArrayList<>();
+
+        ServerChunkCache.iterateTickingChunks(raw, size, chunk -> {
+            assertNotNull(chunk);
+            ticked.add(chunk);
+        }, index -> {
+            polledIndices.add(index);
+            if (index == 0) {
+                chunks.remove(initial[1]);
+                chunks.remove(initial[2]);
+            }
+        });
+
+        assertEquals(List.of(initial[0], initial[11], initial[10], initial[3], initial[4], initial[5], initial[6], initial[7], initial[8], initial[9]), ticked);
+        assertEquals(List.of(0, 8), polledIndices);
+    }
+
+    @Test
+    void entriesAppendedAfterSnapshotAreDeferred() {
+        final ReferenceList<Object> chunks = chunks(10);
+        final Object[] raw = chunks.getRawDataUnchecked();
+        final int size = chunks.size();
+        final List<Object> ticked = new ArrayList<>();
+        final Object appended = new Object();
+
+        ServerChunkCache.iterateTickingChunks(raw, size, ticked::add, index -> {
+            if (index == 0) {
+                chunks.add(appended);
+            }
+        });
+
+        assertEquals(Arrays.asList(raw).subList(0, size), ticked);
+    }
+
+    @Test
+    void consecutiveNullTailSlotsStillPollAtOriginalIndices() {
+        final ReferenceList<Object> chunks = chunks(17);
+        final Object[] initial = chunks.getRawDataUnchecked().clone();
+        final Object[] raw = chunks.getRawDataUnchecked();
+        final int size = chunks.size();
+        final List<Object> ticked = new ArrayList<>();
+        final List<Integer> polledIndices = new ArrayList<>();
+
+        ServerChunkCache.iterateTickingChunks(raw, size, chunk -> {
+            assertNotNull(chunk);
+            ticked.add(chunk);
+        }, index -> {
+            polledIndices.add(index);
+            if (index == 0) {
+                for (int i = 1; i < size; ++i) {
+                    chunks.remove(initial[i]);
+                }
+            }
+        });
+
+        assertEquals(List.of(initial[0]), ticked);
+        assertEquals(List.of(0, 8, 16), polledIndices);
+    }
+
+    private static ReferenceList<Object> chunks(final int count) {
+        final ReferenceList<Object> chunks = new ReferenceList<>(new Object[0]);
+        for (int i = 0; i < count; ++i) {
+            chunks.add(new Object());
+        }
+        return chunks;
+    }
+}


### PR DESCRIPTION
Update the `ServerChunkCache.java` source patch so the loop captures each snapshot entry and skips it when a concurrent-in-the-same-tick removal has nulled that slot, while retaining the cached upper bound so chunks added after iteration starts remain excluded. `ServerChunkCache.iterateTickingChunksFaster()` snapshots the `entityTickingChunks` backing array and size, but invokes `moonrise$executeMidTickTasks()` every eight entries while traversing that snapshot.

Happy path: traverse a stable snapshot of entity-ticking chunks and verify every chunk is delivered to the tick callback once, in snapshot order, with the existing every-eight-indices mid-tick polling cadence; Edge cases: remove one or several chunks from the backing `ReferenceList` during the first mid-tick callback and verify vacated tail slots are skipped, remaining non-null entries continue ticking, and chunks appended after the cached size was captured are not ticked in the current pass.

Fixes #299

AI was used for assistance.
