### PR TITLE
Fix nullable canvasWorldData in Projectiles

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/Projectile.java.patch
@@ -1,6 +1,6 @@
 --- a/net/minecraft/world/entity/projectile/Projectile.java
 +++ b/net/minecraft/world/entity/projectile/Projectile.java
-@@ -45,10 +_,53 @@
+@@ -45,10 +_,54 @@
      public boolean hasBeenShot = false;
      private @Nullable Entity lastDeflectedBy;
      protected boolean hitCancelled = false; // CraftBukkit
@@ -24,7 +24,8 @@
 +            return;
 +        }
 +        // if current world data is null, we may be async or on startup thread
-+        final io.canvasmc.canvas.threadedregions.CanvasRegionizedWorldData canvasRegionData = this.level().getCurrentWorldData().getCanvasWorldData();
++        final io.papermc.paper.threadedregions.RegionizedWorldData currentWorldData = this.level().getCurrentWorldData();
++        final io.canvasmc.canvas.threadedregions.CanvasRegionizedWorldData canvasRegionData = currentWorldData == null ? null : currentWorldData.getCanvasWorldData();
 +        if (canvasRegionData != null) {
 +            long currentTick = canvasRegionData.getRegionData().getCurrentTick();
 +            if (canvasRegionData.projectilesLoadedTick != currentTick) {


### PR DESCRIPTION
Simple fix for a regression from base Folia. This can occur during startup for some plugins

```log
[22:06:00 WARN]: java.lang.NullPointerException: Cannot invoke "io.papermc.paper.threadedregions.RegionizedWorldData.getCanvasWorldData()" because the return value of "net.minecraft.world.level.Level.getCurrentWorldData()" is null
[22:06:00 WARN]:        at net.minecraft.world.entity.projectile.Projectile.setPos(Projectile.java:67)
[22:06:00 WARN]:        at net.minecraft.world.entity.Entity.<init>(Entity.java:599)
[22:06:00 WARN]:        at net.minecraft.world.entity.projectile.Projectile.<init>(Projectile.java:52)
[22:06:00 WARN]:        at net.minecraft.world.entity.projectile.arrow.AbstractArrow.<init>(AbstractArrow.java:84)
[22:06:00 WARN]:        at net.minecraft.world.entity.projectile.arrow.Arrow.<init>(Arrow.java:27)
[22:06:00 WARN]:        at net.minecraft.world.entity.EntityType.create(EntityType.java:380)
[22:06:00 WARN]:        at net.minecraft.world.entity.EntityType.create(EntityType.java:376)
```