### PR TITLE
fix: preserve fishing bobbers across dimension changes

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -47,13 +47,14 @@
                  int count = (int)(actualDamage * 0.5);
                  ((ServerLevel)this.level())
                      .sendParticles(ParticleTypes.DAMAGE_INDICATOR, entity.getX(), entity.getY(0.5), entity.getZ(), count, 0.1, 0.0, 0.1, 0.2);
-@@ -1390,9 +_,19 @@
+@@ -1390,9 +_,21 @@
      // Folia start - region threading
      @Override
      protected void preRemove(RemovalReason reason) {
          super.preRemove(reason);
 -        this.fishing = null;
-+        if (reason != RemovalReason.CHANGED_DIMENSION || this.getHealth() <= 0.0F) { // Canvas - preserve fishing hooks across live dimension changes
++        // Canvas start - preserve fishing hooks across live dimension changes
++        if (reason != RemovalReason.CHANGED_DIMENSION || this.getHealth() <= 0.0F) {
 +            final FishingHook fishingHook = this.fishing;
 +            this.fishing = null;
 +            if (fishingHook != null) {
@@ -64,6 +65,7 @@
 +                });
 +            }
 +        }
++        // Canvas end - preserve fishing hooks across live dimension changes
      }
 
      // Folia end - region threading

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -47,6 +47,28 @@
                  int count = (int)(actualDamage * 0.5);
                  ((ServerLevel)this.level())
                      .sendParticles(ParticleTypes.DAMAGE_INDICATOR, entity.getX(), entity.getY(0.5), entity.getZ(), count, 0.1, 0.0, 0.1, 0.2);
+@@ -1390,9 +_,19 @@
+     // Folia start - region threading
+     @Override
+     protected void preRemove(RemovalReason reason) {
+         super.preRemove(reason);
+-        this.fishing = null;
++        if (reason != RemovalReason.CHANGED_DIMENSION || this.getHealth() <= 0.0F) { // Canvas - preserve fishing hooks across live dimension changes
++            final FishingHook fishingHook = this.fishing;
++            this.fishing = null;
++            if (fishingHook != null) {
++                fishingHook.getBukkitEntity().taskScheduler.scheduleOrExecute((FishingHook hook) -> {
++                    if (!hook.isRemoved() && hook.getOwnerRaw() == this) {
++                        hook.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);
++                    }
++                });
++            }
++        }
+     }
+
+     // Folia end - region threading
+     public boolean isLocalPlayer() {
+         return false;
 @@ -1961,6 +_,7 @@
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -1,5 +1,76 @@
 --- a/net/minecraft/world/entity/projectile/FishingHook.java
 +++ b/net/minecraft/world/entity/projectile/FishingHook.java
+@@ -174,6 +_,6 @@
+         this.getInterpolation().interpolate();
+         super.tick();
+-        Player owner = this.getPlayerOwner();
++        Player owner = this.canvas$getPlayerOwnerRaw(); // Canvas - preserve fishing hooks across dimension changes
+
+         if (owner == null) {
+             this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
+        } else if (this.level().isClientSide() || !this.shouldStopFishing(owner)) {
+@@ -271,10 +_,57 @@
+     }
+
++    // Canvas start - preserve fishing hooks across dimension changes
++    private boolean canvas$ownerCheckPending;
++
++    private @Nullable Player canvas$getPlayerOwnerRaw() {
++        return this.getOwnerRaw() instanceof Player player ? player : null;
++    }
++
++    private void canvas$completeOwnerCheck(final boolean ownerCanContinueFishing) {
++        this.getBukkitEntity().taskScheduler.scheduleOrExecute((FishingHook hook) -> {
++            hook.canvas$ownerCheckPending = false;
++            if (!ownerCanContinueFishing && !hook.isRemoved()) {
++                hook.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN);
++            }
++        });
++    }
++    // Canvas end - preserve fishing hooks across dimension changes
++
+     private boolean shouldStopFishing(final Player owner) {
+-        // Folia start - region threading
++        // Canvas start - preserve fishing hooks across dimension changes
+         if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(owner)) {
+-            return true;
++            if (!this.canvas$ownerCheckPending) {
++                this.canvas$ownerCheckPending = true;
++                final Level hookLevel = this.level();
++                final Vec3 hookPosition = this.position();
++                final boolean scheduled = owner.getBukkitEntity().taskScheduler.schedule(
++                    (Player checkedOwner) -> {
++                        if (checkedOwner.isRemoved()) {
++                            this.canvas$completeOwnerCheck(checkedOwner.getRemovalReason() == Entity.RemovalReason.CHANGED_DIMENSION && checkedOwner.getHealth() > 0.0F);
++                            return;
++                        }
++
++                        if (!checkedOwner.canInteractWithLevel() || !checkedOwner.isAlive()) {
++                            this.canvas$completeOwnerCheck(false);
++                            return;
++                        }
++
++                        final ItemStack selectedItem = checkedOwner.getMainHandItem();
++                        final ItemStack selectedItemOffHand = checkedOwner.getOffhandItem();
++                        final boolean isHoldingRod = selectedItem.is(Items.FISHING_ROD) || selectedItemOffHand.is(Items.FISHING_ROD);
++                        final boolean isTooFarAway = checkedOwner.level() == hookLevel
++                            && hookPosition.distanceToSqr(checkedOwner.position()) > 1024.0;
++                        this.canvas$completeOwnerCheck(isHoldingRod && !isTooFarAway);
++                    },
++                    (Player _) -> this.canvas$completeOwnerCheck(false),
++                    1L
++                );
++                if (!scheduled) {
++                    this.canvas$completeOwnerCheck(false);
++                }
++            }
++            return true;
+         }
+-        // Folia end - region threading
++        // Canvas end - preserve fishing hooks across dimension changes
+         if (owner.canInteractWithLevel()) {
+             ItemStack selectedItem = owner.getMainHandItem();
+             ItemStack selectedItemOffHand = owner.getOffhandItem();
 @@ -508,6 +_,11 @@
          if (!this.level().isClientSide() && owner != null && !this.shouldStopFishing(owner)) {
              int dmg = 0;
@@ -27,3 +98,23 @@
          }
      }
  
+@@ -619,6 +_,17 @@
+     @Override
+     protected void preRemove(RemovalReason reason) {
+         super.preRemove(reason);
+-        this.updateOwnerInfo(null);
++        // Canvas start - preserve fishing hooks across dimension changes
++        final Player owner = this.canvas$getPlayerOwnerRaw();
++        if (owner != null && !ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(owner)) {
++            owner.getBukkitEntity().taskScheduler.scheduleOrExecute((Player checkedOwner) -> {
++                if (checkedOwner.fishing == this) {
++                    checkedOwner.fishing = null;
++                }
++            });
++        } else {
++            this.updateOwnerInfo(null);
++        }
++        // Canvas end - preserve fishing hooks across dimension changes
+     }
+
+     // Folia end - region threading

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/projectile/FishingHook.java.patch
@@ -9,7 +9,7 @@
          if (owner == null) {
              this.discard(org.bukkit.event.entity.EntityRemoveEvent.Cause.DESPAWN); // CraftBukkit - add Bukkit remove cause
         } else if (this.level().isClientSide() || !this.shouldStopFishing(owner)) {
-@@ -271,10 +_,57 @@
+@@ -271,10 +_,59 @@
      }
 
 +    // Canvas start - preserve fishing hooks across dimension changes
@@ -30,7 +30,7 @@
 +    // Canvas end - preserve fishing hooks across dimension changes
 +
      private boolean shouldStopFishing(final Player owner) {
--        // Folia start - region threading
+         // Folia start - region threading
 +        // Canvas start - preserve fishing hooks across dimension changes
          if (!ca.spottedleaf.moonrise.common.util.TickThread.isTickThreadFor(owner)) {
 -            return true;
@@ -66,8 +66,8 @@
 +            }
 +            return true;
          }
--        // Folia end - region threading
 +        // Canvas end - preserve fishing hooks across dimension changes
+         // Folia end - region threading
          if (owner.canInteractWithLevel()) {
              ItemStack selectedItem = owner.getMainHandItem();
              ItemStack selectedItemOffHand = owner.getOffhandItem();


### PR DESCRIPTION
Adjust the `Player` source patch so a `CHANGED_DIMENSION` removal preserves the active fishing relationship while terminal removals still clear it, allowing the same player entity to retain ownership through Canvas's asynchronous dimension transfer. Canvas removes a player's fishing-bobber relationship during the region-threaded player removal used by dimension changes, and the fishing hook independently treats an owner outside its tick region as a reason to stop fishing.

Cast a fishing bobber onto an Overworld pressure plate, enter a Nether portal, and verify the bobber remains present, the plate stays powered, and no region-thread ownership warning or exception is emitted; Return through a portal and reel in the retained bobber; verify the hook is removed once, the player's fishing reference is cleared, and a subsequent cast works normally.

Fixes #327

AI was used for assistance.
