### PR TITLE
Port Leaf’s C2ME density-function compiler and worldgen micro-opts

### DIFF
--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/MinecraftServer.java.patch
@@ -1,5 +1,15 @@
 --- a/net/minecraft/server/MinecraftServer.java
 +++ b/net/minecraft/server/MinecraftServer.java
+@@ -680,8 +_,7 @@
+         final ResourceKey<Level> dimensionKey = loading.info().dimensionKey();
+         final SavedDataStorage savedDataStorage = new SavedDataStorage(this.storageSource.getDimensionPath(dimensionKey).resolve(LevelResource.DATA.id()), this.getFixerUpper(), this.registryAccess());
+         savedDataStorage.set(WorldGenSettings.TYPE, new WorldGenSettings(worldDataAndGenSettings.genSettings().options(), worldDataAndGenSettings.genSettings().dimensions()));
+-        long seed = worldOptions.seed();
+-        long biomeZoomSeed = BiomeManager.obfuscateSeed(seed);
++        long biomeZoomSeed = worldOptions.biomeZoomSeed(); // Canvas - cache biome zoom seed
+         List<CustomSpawner> overworldCustomSpawners = ImmutableList.of(
+             new PhantomSpawner(), new PatrolSpawner(), new CatSpawner(), new VillageSiege(), new WanderingTraderSpawner(savedDataStorage) // Paper - save to world data
+         );
 @@ -1325,11 +_,7 @@
                  LOGGER.info("*************************************************************************************");
              }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/ServerPlayer.java.patch
@@ -84,6 +84,15 @@
          this.ejectPassengers();
  
          // Paper start - Workaround vehicle not tracking the passenger disconnection dismount
+@@ -3613,7 +_,7 @@
+         return new CommonPlayerSpawnInfo(
+             level.dimensionTypeRegistration(),
+             level.dimension(),
+-            BiomeManager.obfuscateSeed(level.getSeed()),
++            level.worldGenSettings.options().biomeZoomSeed(), // Canvas - cache biome zoom seed
+             this.gameMode.getGameModeForPlayer(),
+             this.gameMode.getPreviousGameModeForPlayer(),
+             level.isDebug(),
 @@ -3728,7 +_,7 @@
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/server/level/WorldGenRegion.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/server/level/WorldGenRegion.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/server/level/WorldGenRegion.java
++++ b/net/minecraft/server/level/WorldGenRegion.java
+@@ -125,7 +_,7 @@
+         this.levelData = level.getLevelData();
+         this.random = level.getChunkSource().randomState().getOrCreateRandomFactory(WORLDGEN_REGION_RANDOM).at(this.center.getPos().getWorldPosition());
+         this.dimensionType = level.dimensionType();
+-        this.biomeManager = new BiomeManager(this, BiomeManager.obfuscateSeed(this.seed));
++        this.biomeManager = new BiomeManager(this, level.worldGenSettings.options().biomeZoomSeed()); // Canvas - cache biome zoom seed
+         ChunkPos centerPos = center.getPos();
+         this.centerChunkX = centerPos.x();
+         this.centerChunkZ = centerPos.z();

--- a/canvas-server/minecraft-patches/sources/net/minecraft/util/CubicSpline.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/util/CubicSpline.java.patch
@@ -1,0 +1,53 @@
+--- a/net/minecraft/util/CubicSpline.java
++++ b/net/minecraft/util/CubicSpline.java
+@@ -270,8 +_,49 @@
+         }
+ 
+         private static int findIntervalStart(final float[] locations, final float input) {
+-            return Mth.binarySearch(0, locations.length, i -> input < locations[i]) - 1;
++            // Leaf start - C2ME - DensityFunction compiler
++            int min = 0;
++            int length = locations.length;
++
++            while (length > 0) {
++                int half = length / 2;
++                int middle = min + half;
++                if (input < locations[middle]) {
++                    length = half;
++                } else {
++                    min = middle + 1;
++                    length -= half + 1;
++                }
++            }
++
++            return min - 1;
++            // Leaf end - C2ME - DensityFunction compiler
++        }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public boolean equals(final Object object) {
++            if (this == object) return true;
++            if (object == null || this.getClass() != object.getClass()) return false;
++            CubicSpline.Multipoint<?> that = (CubicSpline.Multipoint<?>)object;
++            return java.util.Objects.equals(this.coordinate, that.coordinate())
++                && java.util.Arrays.equals(this.locations, that.locations())
++                && java.util.Objects.equals(this.values, that.values())
++                && java.util.Arrays.equals(this.derivatives, that.derivatives());
++        }
++
++        @Override
++        public int hashCode() {
++            int result = 1;
++
++            result = 31 * result + java.util.Objects.hashCode(this.coordinate);
++            result = 31 * result + java.util.Arrays.hashCode(this.locations);
++            result = 31 * result + java.util.Objects.hashCode(this.values);
++            result = 31 * result + java.util.Arrays.hashCode(this.derivatives);
++
++            return result;
+         }
++        // Leaf end - C2ME - DensityFunction compiler
+ 
+         @VisibleForTesting
+         @Override

--- a/canvas-server/minecraft-patches/sources/net/minecraft/util/Mth.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/util/Mth.java.patch
@@ -1,0 +1,21 @@
+--- a/net/minecraft/util/Mth.java
++++ b/net/minecraft/util/Mth.java
+@@ -175,6 +_,18 @@
+         return (input % mod + mod) % mod;
+     }
+ 
++    // Canvas start - faster floating-point positive modulo
++    public static float positiveModuloForPositiveIntegerDenominator(final float input, final float mod) {
++        float modulo = input % mod;
++        return modulo < 0 ? modulo + mod : modulo;
++    }
++
++    public static double positiveModuloForPositiveIntegerDenominator(final double input, final double mod) {
++        double modulo = input % mod;
++        return modulo < 0 ? modulo + mod : modulo;
++    }
++    // Canvas end - faster floating-point positive modulo
++
+     public static boolean isMultipleOf(final int dividend, final int divisor) {
+         return dividend % divisor == 0;
+     }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/biome/BiomeManager.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/biome/BiomeManager.java.patch
@@ -1,13 +1,27 @@
 --- a/net/minecraft/world/level/biome/BiomeManager.java
 +++ b/net/minecraft/world/level/biome/BiomeManager.java
-@@ -14,6 +_,7 @@
+@@ -14,6 +_,8 @@
      private static final int ZOOM_MASK = 3;
      private final BiomeManager.NoiseBiomeSource noiseBiomeSource;
      private final long biomeZoomSeed;
 +    private static final double canvas$maxFiddle = 0.4500000001D; // Canvas - optimize getBiome
++    private static final double[] canvas$quartOffsets = new double[]{0.0, 0.25, 0.5, 0.75}; // Canvas - optimize getBiome - eliminate divisions
  
      public BiomeManager(final BiomeManager.NoiseBiomeSource noiseBiomeSource, final long seed) {
          this.noiseBiomeSource = noiseBiomeSource;
+@@ -35,9 +_,9 @@
+         int parentX = absX >> 2;
+         int parentY = absY >> 2;
+         int parentZ = absZ >> 2;
+-        double fractX = (absX & 3) / 4.0;
+-        double fractY = (absY & 3) / 4.0;
+-        double fractZ = (absZ & 3) / 4.0;
++        double fractX = canvas$quartOffsets[absX & 3]; // Canvas - optimize getBiome - eliminate divisions
++        double fractY = canvas$quartOffsets[absY & 3];
++        double fractZ = canvas$quartOffsets[absZ & 3];
+         int minI = 0;
+         double minFiddledDistance = Double.POSITIVE_INFINITY;
+ 
 @@ -51,7 +_,33 @@
              double distanceX = xEven ? fractX : fractX - 1.0;
              double distanceY = yEven ? fractY : fractY - 1.0;

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Beardifier.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/Beardifier.java.patch
@@ -1,0 +1,104 @@
+--- a/net/minecraft/world/level/levelgen/Beardifier.java
++++ b/net/minecraft/world/level/levelgen/Beardifier.java
+@@ -107,52 +_,54 @@
+         }
+     }
+ 
++    // Leaf start - C2ME - Optimize world gen math
++    private Beardifier.Rigid[] c2me$pieceArray;
++    private JigsawJunction[] c2me$junctionArray;
++    private void c2me$initArrays() {
++        this.c2me$pieceArray = this.pieces.toArray(Beardifier.Rigid[]::new);
++        this.c2me$junctionArray = this.junctions.toArray(JigsawJunction[]::new);
++    }
++    // Leaf end - C2ME - Optimize world gen math
++
+     @Override
+     public double compute(final DensityFunction.FunctionContext context) {
+         if (this.affectedBox == null) {
+             return 0.0;
+         }
+ 
++        // Leaf start - C2ME - Optimize world gen math
+         int blockX = context.blockX();
+         int blockY = context.blockY();
+         int blockZ = context.blockZ();
+-        if (!this.affectedBox.isInside(blockX, blockY, blockZ)) {
+-            return 0.0;
+-        }
++        if (!this.affectedBox.isInside(blockX, blockY, blockZ)) return 0.0;
++        if (this.c2me$pieceArray == null || this.c2me$junctionArray == null) this.c2me$initArrays();
+ 
+-        double noiseValue = 0.0;
++        double density = 0.0;
+ 
+-        for (Beardifier.Rigid rigid : this.pieces) {
+-            BoundingBox box = rigid.box();
+-            int groundLevelDelta = rigid.groundLevelDelta();
+-            int dx = Math.max(0, Math.max(box.minX() - blockX, blockX - box.maxX()));
+-            int dz = Math.max(0, Math.max(box.minZ() - blockZ, blockZ - box.maxZ()));
+-            int groundY = box.minY() + groundLevelDelta;
+-            int dyToGround = blockY - groundY;
+-
+-            int dy = switch (rigid.terrainAdjustment()) {
+-                case NONE -> 0;
+-                case BURY, BEARD_THIN -> dyToGround;
+-                case BEARD_BOX -> Math.max(0, Math.max(groundY - blockY, blockY - box.maxY()));
+-                case ENCAPSULATE -> Math.max(0, Math.max(box.minY() - blockY, blockY - box.maxY()));
+-            };
+-
+-            noiseValue += switch (rigid.terrainAdjustment()) {
++        for (Beardifier.Rigid piece : this.c2me$pieceArray) {
++            BoundingBox blockBox = piece.box();
++            int groundLevelDelta = piece.groundLevelDelta();
++            int distanceXToBox = Math.max(0, Math.max(blockBox.minX() - blockX, blockX - blockBox.maxX()));
++            int distanceZToBox = Math.max(0, Math.max(blockBox.minZ() - blockZ, blockZ - blockBox.maxZ()));
++            int groundY = blockBox.minY() + groundLevelDelta;
++            int distanceToGround = blockY - groundY;
++            density += switch (piece.terrainAdjustment()) {
+                 case NONE -> 0.0;
+-                case BURY -> getBuryContribution(dx, dy / 2.0, dz);
+-                case BEARD_THIN, BEARD_BOX -> getBeardContribution(dx, dy, dz, dyToGround) * 0.8;
+-                case ENCAPSULATE -> getBuryContribution(dx / 2.0, dy / 2.0, dz / 2.0) * 0.8;
++                case BURY -> getBuryContribution(distanceXToBox, (double) distanceToGround / 2.0, distanceZToBox);
++                case BEARD_THIN -> getBeardContribution(distanceXToBox, distanceToGround, distanceZToBox, distanceToGround) * 0.8;
++                case BEARD_BOX -> getBeardContribution(distanceXToBox, Math.max(0, Math.max(groundY - blockY, blockY - blockBox.maxY())), distanceZToBox, distanceToGround) * 0.8;
++                case ENCAPSULATE -> getBuryContribution((double) distanceXToBox / 2.0, (double) Math.max(0, Math.max(blockBox.minY() - blockY, blockY - blockBox.maxY())) / 2.0, (double) distanceZToBox / 2.0) * 0.8;
+             };
+         }
+-
+-        for (JigsawJunction junction : this.junctions) {
+-            int dx = blockX - junction.getSourceX();
+-            int dy = blockY - junction.getSourceGroundY();
+-            int dz = blockZ - junction.getSourceZ();
+-            noiseValue += getBeardContribution(dx, dy, dz, dy) * 0.4;
++        for (JigsawJunction jigsawJunction : this.c2me$junctionArray) {
++            int deltaX = blockX - jigsawJunction.getSourceX();
++            int deltaY = blockY - jigsawJunction.getSourceGroundY();
++            int deltaZ = blockZ - jigsawJunction.getSourceZ();
++            density += getBeardContribution(deltaX, deltaY, deltaZ, deltaY) * 0.4;
+         }
+ 
+-        return noiseValue;
++        return density;
++        // Leaf end - C2ME - Optimize world gen math
+     }
+ 
+     @Override
+@@ -166,8 +_,14 @@
+     }
+ 
+     private static double getBuryContribution(final double dx, final double dy, final double dz) {
+-        double distance = Mth.length(dx, dy, dz);
+-        return Mth.clampedMap(distance, 0.0, 6.0, 1.0, 0.0);
++        // Leaf start - C2ME - Optimize world gen math
++        double len = Math.sqrt(dx * dx + dy * dy + dz * dz);
++        if (len > 6.0) {
++            return 0.0;
++        } else {
++            return 1.0 - len / 6.0;
++        }
++        // Leaf end - C2ME - Optimize world gen math
+     }
+ 
+     private static double getBeardContribution(final int dx, final int dy, final int dz, final int yToGround) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunction.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunction.java.patch
@@ -1,0 +1,64 @@
+--- a/net/minecraft/world/level/levelgen/DensityFunction.java
++++ b/net/minecraft/world/level/levelgen/DensityFunction.java
+@@ -29,7 +_,7 @@
+     DensityFunction mapChildren(final DensityFunction.Visitor visitor);
+ 
+     default DensityFunction mapAll(final DensityFunction.Visitor visitor) {
+-        class RecursiveVisitor implements DensityFunction.Visitor {
++        class RecursiveVisitor implements DensityFunction.Visitor, com.ishland.c2me.opts.dfc.common.ducks.IBlendingAwareVisitor, com.ishland.c2me.opts.dfc.common.ducks.ICompiledCachingAwareVisitor { // Leaf - C2ME - DensityFunction compiler
+             @Override
+             public DensityFunction apply(final DensityFunction input) {
+                 return visitor.apply(input.mapChildren(this));
+@@ -39,6 +_,24 @@
+             public DensityFunction.NoiseHolder visitNoise(final DensityFunction.NoiseHolder noise) {
+                 return visitor.visitNoise(noise);
+             }
++            // Leaf start - C2ME - DensityFunction compiler
++            @Override
++            public boolean c2me$isBlendingEnabled() {
++                return visitor instanceof com.ishland.c2me.opts.dfc.common.ducks.IBlendingAwareVisitor blendingAwareVisitor
++                    && blendingAwareVisitor.c2me$isBlendingEnabled();
++            }
++
++            @Override
++            public com.ishland.c2me.opts.dfc.common.gen.jvm.CompiledEntry c2me$visitIfAbsent(
++                final com.ishland.c2me.opts.dfc.common.gen.jvm.CompiledEntry entry,
++                final com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ArgumentVisitor argumentVisitor
++            ) {
++                if (visitor instanceof com.ishland.c2me.opts.dfc.common.ducks.ICompiledCachingAwareVisitor cachingAwareVisitor) {
++                    return cachingAwareVisitor.c2me$visitIfAbsent(entry, argumentVisitor);
++                }
++                return entry.newInstance(entry.getArgs(), argumentVisitor);
++            }
++            // Leaf end - C2ME - DensityFunction compiler
+         }
+ 
+         return new RecursiveVisitor().apply(this);
+@@ -111,6 +_,27 @@
+         public double maxValue() {
+             return this.noise == null ? 2.0 : this.noise.maxValue();
+         }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public boolean equals(final Object object) {
++            if (this == object) {
++                return true;
++            }
++            if (object == null || this.getClass() != object.getClass()) {
++                return false;
++            }
++            final DensityFunction.NoiseHolder other = (DensityFunction.NoiseHolder)object;
++            return this.noise != null || other.noise != null
++                ? java.util.Objects.equals(this.noise, other.noise)
++                : java.util.Objects.equals(this.noiseData, other.noiseData);
++        }
++
++        @Override
++        public int hashCode() {
++            return this.noise != null ? this.noise.hashCode() : java.util.Objects.hashCode(this.noiseData);
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+     interface SimpleFunction extends DensityFunction {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunctions.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/DensityFunctions.java.patch
@@ -1,0 +1,317 @@
+--- a/net/minecraft/world/level/levelgen/DensityFunctions.java
++++ b/net/minecraft/world/level/levelgen/DensityFunctions.java
+@@ -278,13 +_,13 @@
+         return new DensityFunctions.FindTopSurface(density, upperBound, lowerBound, stepSize);
+     }
+ 
+-    private record Ap2(
++    public record Ap2( // Leaf - C2ME - DensityFunction compiler - private -> public
+         @Override DensityFunctions.TwoArgumentSimpleFunction.Type type,
+         @Override DensityFunction argument1,
+         @Override DensityFunction argument2,
+         @Override double minValue,
+         @Override double maxValue
+-    ) implements DensityFunctions.TwoArgumentSimpleFunction {
++    ) implements DensityFunctions.TwoArgumentSimpleFunction { // Leaf - C2ME - DensityFunction compiler
+         @Override
+         public double compute(final DensityFunction.FunctionContext context) {
+             double v1 = this.argument1.compute(context);
+@@ -301,14 +_,25 @@
+         public void fillArray(final double[] output, final DensityFunction.ContextProvider contextProvider) {
+             this.argument1.fillArray(output, contextProvider);
+             switch (this.type) {
+-                case ADD:
+-                    double[] v2 = new double[output.length];
++                // Leaf start - C2ME - DensityFunction compiler
++                case ADD: {
++                    final com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache objectCache =
++                        contextProvider instanceof com.ishland.c2me.opts.dfc.common.ducks.IDfcObjectCacheCapable cacheCapable
++                            ? cacheCapable.c2me$getDfcObjectCache()
++                            : null;
++                    final double[] v2 = objectCache == null ? new double[output.length] : objectCache.getDoubleArray(output.length, false);
+                     this.argument2.fillArray(v2, contextProvider);
+ 
+                     for (int i = 0; i < output.length; i++) {
+                         output[i] += v2[i];
+                     }
++
++                    if (objectCache != null) {
++                        objectCache.recycle(v2);
++                    }
+                     break;
++                }
++                // Leaf end - C2ME - DensityFunction compiler
+                 case MUL:
+                     for (int i = 0; i < output.length; i++) {
+                         double v = output[i];
+@@ -339,7 +_,7 @@
+         }
+     }
+ 
+-    enum BeardifierMarker implements DensityFunctions.BeardifierOrMarker {
++    public enum BeardifierMarker implements DensityFunctions.BeardifierOrMarker { // Leaf - C2ME - DensityFunction compiler - package-private -> public
+         INSTANCE;
+ 
+         @Override
+@@ -372,7 +_,7 @@
+         }
+     }
+ 
+-    enum BlendAlpha implements DensityFunction.SimpleFunction {
++    public enum BlendAlpha implements DensityFunction.SimpleFunction { // Leaf - C2ME - DensityFunction compiler - package-private -> public
+         INSTANCE;
+ 
+         public static final KeyDispatchDataCodec<DensityFunction> CODEC = KeyDispatchDataCodec.of(MapCodec.unit(INSTANCE));
+@@ -403,7 +_,7 @@
+         }
+     }
+ 
+-    enum BlendOffset implements DensityFunction.SimpleFunction {
++    public enum BlendOffset implements DensityFunction.SimpleFunction { // Leaf - C2ME - DensityFunction compiler - package-private -> public
+         INSTANCE;
+ 
+         public static final KeyDispatchDataCodec<DensityFunction> CODEC = KeyDispatchDataCodec.of(MapCodec.unit(INSTANCE));
+@@ -434,7 +_,7 @@
+         }
+     }
+ 
+-    protected record Clamp(@Override DensityFunction input, @Override double minValue, @Override double maxValue) implements DensityFunctions.PureTransformer {
++    public record Clamp(@Override DensityFunction input, @Override double minValue, @Override double maxValue) implements DensityFunctions.PureTransformer { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         private static final MapCodec<DensityFunctions.Clamp> DATA_CODEC = RecordCodecBuilder.mapCodec(
+             i -> i.group(
+                     DensityFunction.CODEC.fieldOf("input").forGetter(DensityFunctions.Clamp::input),
+@@ -461,7 +_,7 @@
+         }
+     }
+ 
+-    private record Constant(double value) implements DensityFunction.SimpleFunction {
++    public record Constant(double value) implements DensityFunction.SimpleFunction { // Leaf - C2ME - DensityFunction compiler - private -> public
+         private static final KeyDispatchDataCodec<DensityFunctions.Constant> CODEC = DensityFunctions.singleArgumentCodec(
+             DensityFunctions.NOISE_VALUE_CODEC, DensityFunctions.Constant::new, DensityFunctions.Constant::value
+         );
+@@ -493,7 +_,7 @@
+         }
+     }
+ 
+-    protected static final class EndIslandDensityFunction implements DensityFunction.SimpleFunction {
++    public static final class EndIslandDensityFunction implements DensityFunction.SimpleFunction { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         public static final KeyDispatchDataCodec<DensityFunctions.EndIslandDensityFunction> CODEC = KeyDispatchDataCodec.of(
+             MapCodec.unit(new DensityFunctions.EndIslandDensityFunction(0L))
+         );
+@@ -577,9 +_,27 @@
+         public KeyDispatchDataCodec<? extends DensityFunction> codec() {
+             return CODEC;
+         }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public boolean equals(final Object object) {
++            if (this == object) {
++                return true;
++            }
++            if (object == null || this.getClass() != object.getClass()) {
++                return false;
++            }
++            return java.util.Objects.equals(this.islandNoise, ((DensityFunctions.EndIslandDensityFunction)object).islandNoise);
++        }
++
++        @Override
++        public int hashCode() {
++            return java.util.Objects.hashCode(this.islandNoise);
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+-    private record FindTopSurface(DensityFunction density, DensityFunction upperBound, int lowerBound, int cellHeight) implements DensityFunction {
++    public record FindTopSurface(DensityFunction density, DensityFunction upperBound, int lowerBound, int cellHeight) implements DensityFunction { // Leaf - C2ME - DensityFunction compiler - private -> public
+         private static final MapCodec<DensityFunctions.FindTopSurface> DATA_CODEC = RecordCodecBuilder.mapCodec(
+             i -> i.group(
+                     DensityFunction.CODEC.fieldOf("density").forGetter(DensityFunctions.FindTopSurface::density),
+@@ -668,7 +_,7 @@
+         }
+     }
+ 
+-    private record IntervalSelect(DensityFunction input, DoubleList thresholds, List<DensityFunction> functions) implements DensityFunction {
++    public record IntervalSelect(DensityFunction input, DoubleList thresholds, List<DensityFunction> functions) implements DensityFunction { // Leaf - C2ME - DensityFunction compiler - private -> public
+         private static final Codec<DoubleList> THRESHOLDS_CODEC = DensityFunctions.NOISE_VALUE_CODEC.listOf().xmap(DoubleArrayList::new, Function.identity());
+         public static final MapCodec<DensityFunctions.IntervalSelect> DATA_CODEC = RecordCodecBuilder.<DensityFunctions.IntervalSelect>mapCodec(
+                 i -> i.group(
+@@ -755,8 +_,8 @@
+         }
+     }
+ 
+-    protected record Mapped(DensityFunctions.Mapped.Type type, @Override DensityFunction input, @Override double minValue, @Override double maxValue)
+-        implements DensityFunctions.PureTransformer {
++    public record Mapped(DensityFunctions.Mapped.Type type, @Override DensityFunction input, @Override double minValue, @Override double maxValue)
++        implements DensityFunctions.PureTransformer { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         public static DensityFunctions.Mapped create(final DensityFunctions.Mapped.Type type, final DensityFunction input) {
+             double minValue = input.minValue();
+             double maxValue = input.maxValue();
+@@ -828,7 +_,8 @@
+         }
+     }
+ 
+-    record Marker(@Override DensityFunctions.Marker.Type type, @Override DensityFunction wrapped) implements DensityFunctions.MarkerOrMarked {
++    public record Marker(@Override DensityFunctions.Marker.Type type, @Override DensityFunction wrapped)
++        implements DensityFunctions.MarkerOrMarked, com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike { // Leaf - C2ME - DensityFunction compiler - package-private -> public
+         @Override
+         public double compute(final DensityFunction.FunctionContext context) {
+             return this.wrapped.compute(context);
+@@ -849,6 +_,77 @@
+             return this.type == DensityFunctions.Marker.Type.BlendDensity ? Double.POSITIVE_INFINITY : this.wrapped.maxValue();
+         }
+ 
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public double c2me$getCached(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            return Double.longBitsToDouble(com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike.CACHE_MISS_NAN_BITS);
++        }
++
++        @Override
++        public boolean c2me$getCached(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            return false;
++        }
++
++        @Override
++        public void c2me$cache(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType,
++            final double cached
++        ) {
++        }
++
++        @Override
++        public void c2me$cache(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++        }
++
++        @Override
++        public boolean c2me$isActualCache() {
++            return switch (this.type) {
++                case FlatCache, CacheAllInCell, Cache2D, CacheOnce -> true;
++                default -> false;
++            };
++        }
++
++        @Override
++        public String c2me$describeCacheLike() {
++            return "wrapping, " + this.type.getSerializedName();
++        }
++
++        @Override
++        public DensityFunction c2me$getDelegate() {
++            return this.wrapped;
++        }
++
++        @Override
++        public DensityFunction c2me$withDelegate(final DensityFunction delegate) {
++            return new DensityFunctions.Marker(this.type, delegate);
++        }
++
++        @Override
++        public DensityFunction mapAll(final DensityFunction.Visitor visitor) {
++            return visitor.apply(this.c2me$withDelegate(this.wrapped.mapAll(visitor)));
++        }
++        // Leaf end - C2ME - DensityFunction compiler
++
+         public enum Type implements StringRepresentable {
+             Interpolated("interpolated"),
+             FlatCache("flat_cache"),
+@@ -889,9 +_,9 @@
+         }
+     }
+ 
+-    private record MulOrAdd(
++    public record MulOrAdd(
+         DensityFunctions.MulOrAdd.Type specificType, @Override DensityFunction input, @Override double minValue, @Override double maxValue, double argument
+-    ) implements DensityFunctions.TwoArgumentSimpleFunction, DensityFunctions.PureTransformer {
++    ) implements DensityFunctions.TwoArgumentSimpleFunction, DensityFunctions.PureTransformer { // Leaf - C2ME - DensityFunction compiler - private -> public
+         @Override
+         public DensityFunctions.TwoArgumentSimpleFunction.Type type() {
+             return this.specificType == DensityFunctions.MulOrAdd.Type.MUL
+@@ -944,7 +_,7 @@
+         }
+     }
+ 
+-    protected record Noise(DensityFunction.NoiseHolder noise, @Deprecated double xzScale, double yScale) implements DensityFunction {
++    public record Noise(DensityFunction.NoiseHolder noise, @Deprecated double xzScale, double yScale) implements DensityFunction { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         public static final MapCodec<DensityFunctions.Noise> DATA_CODEC = RecordCodecBuilder.mapCodec(
+             i -> i.group(
+                     DensityFunction.NoiseHolder.CODEC.fieldOf("noise").forGetter(DensityFunctions.Noise::noise),
+@@ -1006,8 +_,8 @@
+         double transform(final double input);
+     }
+ 
+-    private record RangeChoice(DensityFunction input, double minInclusive, double maxExclusive, DensityFunction whenInRange, DensityFunction whenOutOfRange)
+-        implements DensityFunction {
++    public record RangeChoice(DensityFunction input, double minInclusive, double maxExclusive, DensityFunction whenInRange, DensityFunction whenOutOfRange)
++        implements DensityFunction { // Leaf - C2ME - DensityFunction compiler - private -> public
+         public static final MapCodec<DensityFunctions.RangeChoice> DATA_CODEC = RecordCodecBuilder.mapCodec(
+             i -> i.group(
+                     DensityFunction.CODEC.fieldOf("input").forGetter(DensityFunctions.RangeChoice::input),
+@@ -1063,7 +_,7 @@
+         }
+     }
+ 
+-    protected record Shift(@Override DensityFunction.NoiseHolder offsetNoise) implements DensityFunctions.ShiftNoise {
++    public record Shift(@Override DensityFunction.NoiseHolder offsetNoise) implements DensityFunctions.ShiftNoise { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         private static final KeyDispatchDataCodec<DensityFunctions.Shift> CODEC = DensityFunctions.singleArgumentCodec(
+             DensityFunction.NoiseHolder.CODEC, DensityFunctions.Shift::new, DensityFunctions.Shift::offsetNoise
+         );
+@@ -1084,7 +_,7 @@
+         }
+     }
+ 
+-    protected record ShiftA(@Override DensityFunction.NoiseHolder offsetNoise) implements DensityFunctions.ShiftNoise {
++    public record ShiftA(@Override DensityFunction.NoiseHolder offsetNoise) implements DensityFunctions.ShiftNoise { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         private static final KeyDispatchDataCodec<DensityFunctions.ShiftA> CODEC = DensityFunctions.singleArgumentCodec(
+             DensityFunction.NoiseHolder.CODEC, DensityFunctions.ShiftA::new, DensityFunctions.ShiftA::offsetNoise
+         );
+@@ -1105,7 +_,7 @@
+         }
+     }
+ 
+-    protected record ShiftB(@Override DensityFunction.NoiseHolder offsetNoise) implements DensityFunctions.ShiftNoise {
++    public record ShiftB(@Override DensityFunction.NoiseHolder offsetNoise) implements DensityFunctions.ShiftNoise { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         private static final KeyDispatchDataCodec<DensityFunctions.ShiftB> CODEC = DensityFunctions.singleArgumentCodec(
+             DensityFunction.NoiseHolder.CODEC, DensityFunctions.ShiftB::new, DensityFunctions.ShiftB::offsetNoise
+         );
+@@ -1149,9 +_,9 @@
+         }
+     }
+ 
+-    protected record ShiftedNoise(
++    public record ShiftedNoise(
+         DensityFunction shiftX, DensityFunction shiftY, DensityFunction shiftZ, double xzScale, double yScale, DensityFunction.NoiseHolder noise
+-    ) implements DensityFunction {
++    ) implements DensityFunction { // Leaf - C2ME - DensityFunction compiler - protected -> public
+         private static final MapCodec<DensityFunctions.ShiftedNoise> DATA_CODEC = RecordCodecBuilder.mapCodec(
+             i -> i.group(
+                     DensityFunction.CODEC.fieldOf("shift_x").forGetter(DensityFunctions.ShiftedNoise::shiftX),
+@@ -1401,7 +_,7 @@
+         }
+     }
+ 
+-    private record YClampedGradient(int fromY, int toY, double fromValue, double toValue) implements DensityFunction.SimpleFunction {
++    public record YClampedGradient(int fromY, int toY, double fromValue, double toValue) implements DensityFunction.SimpleFunction { // Leaf - C2ME - DensityFunction compiler - private -> public
+         private static final MapCodec<DensityFunctions.YClampedGradient> DATA_CODEC = RecordCodecBuilder.mapCodec(
+             i -> i.group(
+                     Codec.intRange(DimensionType.MIN_Y * 2, DimensionType.MAX_Y * 2).fieldOf("from_y").forGetter(DensityFunctions.YClampedGradient::fromY),

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java.patch
@@ -1,0 +1,42 @@
+--- a/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
++++ b/net/minecraft/world/level/levelgen/NoiseBasedChunkGenerator.java
+@@ -58,6 +_,7 @@
+     private static final BlockState AIR = Blocks.AIR.defaultBlockState();
+     private final Holder<NoiseGeneratorSettings> settings;
+     private final Supplier<Aquifer.FluidPicker> globalFluidPicker;
++    private int cachedSeaLevel = Integer.MIN_VALUE; // Canvas - Lithium - cache world generator sea level
+ 
+     public NoiseBasedChunkGenerator(final BiomeSource biomeSource, final Holder<NoiseGeneratorSettings> settings) {
+         super(biomeSource);
+@@ -265,6 +_,17 @@
+     @Override
+     public void buildSurface(final WorldGenRegion region, final StructureManager structureManager, final RandomState randomState, final ChunkAccess protoChunk) {
+         if (!SharedConstants.debugVoidTerrain(protoChunk.getPos()) && !SharedConstants.DEBUG_DISABLE_SURFACE) {
++            // Canvas start - optimize trivial End surface generation
++            if (io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.optimizeEndSurfaceGeneration) {
++                final NoiseGeneratorSettings settings = this.settings.value();
++                if (this.settings.is(NoiseGeneratorSettings.END)
++                    && !protoChunk.isUpgrading()
++                    && settings.surfaceRule() instanceof SurfaceRules.BlockRuleSource block
++                    && block.resultState() == settings.defaultBlock()) {
++                    return;
++                }
++            }
++            // Canvas end - optimize trivial End surface generation
+             WorldGenerationContext context = new WorldGenerationContext(this, region, region.getMinecraftWorld()); // Paper - Flat bedrock generator settings
+             Set<Holder<Biome>> possibleBiomes = collectPossibleBiomes(region, 1);
+             this.buildSurface(protoChunk, context, randomState, structureManager, region.getBiomeManager(), Blender.of(region), possibleBiomes);
+@@ -483,7 +_,12 @@
+ 
+     @Override
+     public int getSeaLevel() {
+-        return this.settings.value().seaLevel();
++        // Canvas start - Lithium - cache world generator sea level
++        if (this.cachedSeaLevel == Integer.MIN_VALUE) {
++            this.cachedSeaLevel = this.settings.value().seaLevel();
++        }
++        return this.cachedSeaLevel;
++        // Canvas end - Lithium - cache world generator sea level
+     }
+ 
+     @Override

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseChunk.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseChunk.java.patch
@@ -1,6 +1,351 @@
 --- a/net/minecraft/world/level/levelgen/NoiseChunk.java
 +++ b/net/minecraft/world/level/levelgen/NoiseChunk.java
-@@ -373,7 +_,17 @@
+@@ -21,7 +_,7 @@
+ import net.minecraft.world.level.levelgen.material.MaterialRuleList;
+ import org.jspecify.annotations.Nullable;
+ 
+-public class NoiseChunk implements DensityFunction.FunctionContext, DensityFunction.ContextProvider {
++public class NoiseChunk implements DensityFunction.FunctionContext, DensityFunction.ContextProvider, com.ishland.c2me.base.mixin.access.IChunkNoiseSampler, com.ishland.c2me.opts.dfc.common.ducks.IDfcObjectCacheCapable, com.ishland.c2me.opts.dfc.common.ducks.ICoordinatesFilling, com.ishland.c2me.opts.dfc.common.ducks.IPreloadedCoordinates { // Leaf - C2ME - DensityFunction compiler
+     private final int cellCountXZ;
+     private final int cellCountY;
+     private final int cellNoiseMinY;
+@@ -57,7 +_,25 @@
+     private long interpolationCounter;
+     private long arrayInterpolationCounter;
+     private int arrayIndex;
+-    private final DensityFunction.ContextProvider sliceFillingContextProvider = new DensityFunction.ContextProvider() {
++
++    // Leaf start - C2ME - DensityFunction compiler
++    private int c2me$oldStartBlockX = Integer.MAX_VALUE;
++    private int c2me$oldStartBlockY = Integer.MAX_VALUE;
++    private int c2me$oldStartBlockZ = Integer.MAX_VALUE;
++    private int[] c2me$cachedXArray;
++    private int[] c2me$cachedYArray;
++    private int[] c2me$cachedZArray;
++    NoiseChunk.NoiseInterpolator[] c2me$interpolatorsArray;
++    private final com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache c2Me$dfcObjectCache =
++        io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.densityFunctionCompiler
++            ? new com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache.Impl()
++            : com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache.Noop.INSTANCE;
++    private final Map<com.ishland.c2me.opts.dfc.common.gen.jvm.CompiledEntry, com.ishland.c2me.opts.dfc.common.gen.jvm.CompiledEntry>
++        c2me$compiledEntryCache = new it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap<>();
++    // Leaf end - C2ME - DensityFunction compiler
++
++    private final DensityFunction.ContextProvider sliceFillingContextProvider = new NoiseChunk.SliceFillingContextProvider(); // Leaf - C2ME - DensityFunction compiler
++    private final class SliceFillingContextProvider implements DensityFunction.ContextProvider, com.ishland.c2me.opts.dfc.common.ducks.IDfcObjectCacheCapable, com.ishland.c2me.opts.dfc.common.ducks.ICoordinatesFilling { // Leaf - C2ME - DensityFunction compiler
+         @Override
+         public DensityFunction.FunctionContext forIndex(final int cellYIndex) {
+             NoiseChunk.this.cellStartBlockY = (cellYIndex + NoiseChunk.this.cellNoiseMinY) * NoiseChunk.this.cellHeight;
+@@ -77,7 +_,23 @@
+                 output[cellYIndex] = function.compute(NoiseChunk.this);
+             }
+         }
+-    };
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache c2me$getDfcObjectCache() {
++            return NoiseChunk.this.c2me$getDfcObjectCache();
++        }
++
++        @Override
++        public void c2me$fillCoordinates(final int[] x, final int[] y, final int[] z) {
++            for (int i = 0; i < NoiseChunk.this.cellCountY + 1; i++) {
++                x[i] = NoiseChunk.this.cellStartBlockX + NoiseChunk.this.inCellX;
++                y[i] = (i + NoiseChunk.this.cellNoiseMinY) * NoiseChunk.this.cellHeight;
++                z[i] = NoiseChunk.this.cellStartBlockZ + NoiseChunk.this.inCellZ;
++            }
++        }
++    }
++    // Leaf end - C2ME - DensityFunction compiler
+ 
+     public static NoiseChunk forChunk(
+         final ChunkAccess chunk,
+@@ -140,7 +_,7 @@
+         }
+ 
+         NoiseRouter router = randomState.router();
+-        NoiseRouter wrappedRouter = router.mapAll(this::wrap);
++        NoiseRouter wrappedRouter = router.mapAll(this.c2me$wrapVisitor(this::wrap)); // Leaf - C2ME - DensityFunction compiler
+         this.preliminarySurfaceLevel = wrappedRouter.preliminarySurfaceLevel();
+         if (!settings.isAquifersEnabled()) {
+             this.aquifer = Aquifer.createDisabled(globalFluidPicker);
+@@ -153,10 +_,16 @@
+         }
+ 
+         List<NoiseChunk.BlockStateFiller> builder = new ArrayList<>();
+-        DensityFunction fullNoiseValue = DensityFunctions.cacheAllInCell(
+-                DensityFunctions.add(wrappedRouter.finalDensity(), DensityFunctions.BeardifierMarker.INSTANCE)
+-            )
+-            .mapAll(this::wrap);
++        // Leaf start - C2ME - DensityFunction compiler
++        DensityFunction fullNoiseValueTemp = wrappedRouter.c2me$getFinalFinalDensity();
++        if (fullNoiseValueTemp == null) {
++            fullNoiseValueTemp = DensityFunctions.cacheAllInCell(
++                    DensityFunctions.add(wrappedRouter.finalDensity(), DensityFunctions.BeardifierMarker.INSTANCE)
++                )
++                .mapAll(this.c2me$wrapVisitor(this::wrap));
++        }
++        final DensityFunction fullNoiseValue = fullNoiseValueTemp;
++        // Leaf end - C2ME - DensityFunction compiler
+         this.fullNoiseDensity = fullNoiseValue;
+         builder.add(context -> this.aquifer.computeSubstance(context, fullNoiseValue.compute(context)));
+         if (settings.oreVeinsEnabled()) {
+@@ -168,12 +_,14 @@
+ 
+     protected Climate.Sampler cachedClimateSampler(final NoiseRouter noises, final List<Climate.ParameterPoint> spawnTarget) {
+         return new Climate.Sampler(
+-            noises.temperature().mapAll(this::wrap),
+-            noises.vegetation().mapAll(this::wrap),
+-            noises.continents().mapAll(this::wrap),
+-            noises.erosion().mapAll(this::wrap),
+-            noises.depth().mapAll(this::wrap),
+-            noises.ridges().mapAll(this::wrap),
++            // Leaf start - C2ME - DensityFunction compiler
++            noises.temperature().mapAll(this.c2me$wrapVisitor(this::wrap)),
++            noises.vegetation().mapAll(this.c2me$wrapVisitor(this::wrap)),
++            noises.continents().mapAll(this.c2me$wrapVisitor(this::wrap)),
++            noises.erosion().mapAll(this.c2me$wrapVisitor(this::wrap)),
++            noises.depth().mapAll(this.c2me$wrapVisitor(this::wrap)),
++            noises.ridges().mapAll(this.c2me$wrapVisitor(this::wrap)),
++            // Leaf end - C2ME - DensityFunction compiler
+             spawnTarget
+         );
+     }
+@@ -201,6 +_,179 @@
+         return this.cellStartBlockZ + this.inCellZ;
+     }
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache c2me$getDfcObjectCache() {
++        return this.c2Me$dfcObjectCache;
++    }
++
++    @Override
++    public void c2me$fillCoordinates(final int[] x, final int[] y, final int[] z) {
++        int index = 0;
++        for (int yInCell = this.cellHeight - 1; yInCell >= 0; yInCell--) {
++            final int blockY = this.cellStartBlockY + yInCell;
++            for (int xInCell = 0; xInCell < this.cellWidth; xInCell++) {
++                final int blockX = this.cellStartBlockX + xInCell;
++                for (int zInCell = 0; zInCell < this.cellWidth; zInCell++) {
++                    x[index] = blockX;
++                    y[index] = blockY;
++                    z[index] = this.cellStartBlockZ + zInCell;
++                    index++;
++                }
++            }
++        }
++    }
++
++    private void c2me$reloadCachedArrays() {
++        if (this.c2me$cachedXArray == null || this.c2me$cachedYArray == null || this.c2me$cachedZArray == null) {
++            final int length = this.cellWidth * this.cellWidth * this.cellHeight;
++            this.c2me$cachedXArray = this.c2Me$dfcObjectCache.getIntArray(length, false);
++            this.c2me$cachedYArray = this.c2Me$dfcObjectCache.getIntArray(length, false);
++            this.c2me$cachedZArray = this.c2Me$dfcObjectCache.getIntArray(length, false);
++        }
++        if (this.c2me$oldStartBlockX != this.cellStartBlockX
++            || this.c2me$oldStartBlockY != this.cellStartBlockY
++            || this.c2me$oldStartBlockZ != this.cellStartBlockZ) {
++            this.c2me$fillCoordinates(this.c2me$cachedXArray, this.c2me$cachedYArray, this.c2me$cachedZArray);
++            this.c2me$oldStartBlockX = this.cellStartBlockX;
++            this.c2me$oldStartBlockY = this.cellStartBlockY;
++            this.c2me$oldStartBlockZ = this.cellStartBlockZ;
++        }
++    }
++
++    @Override
++    public int[] c2me$getXArray() {
++        this.c2me$reloadCachedArrays();
++        return this.c2me$cachedXArray;
++    }
++
++    @Override
++    public int[] c2me$getYArray() {
++        this.c2me$reloadCachedArrays();
++        return this.c2me$cachedYArray;
++    }
++
++    @Override
++    public int[] c2me$getZArray() {
++        this.c2me$reloadCachedArrays();
++        return this.c2me$cachedZArray;
++    }
++
++    private DensityFunction.Visitor c2me$wrapVisitor(final DensityFunction.Visitor visitor) {
++        if (!io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.densityFunctionCompiler) {
++            return visitor;
++        }
++        return new com.ishland.c2me.opts.dfc.common.gen.DelegatingBlendingCachingAwareVisitor(
++            visitor, this.c2me$compiledEntryCache, !this.blender.isEmpty()
++        );
++    }
++
++    @Override
++    public int getStartBlockX() {
++        return this.cellStartBlockX;
++    }
++
++    @Override
++    public int getStartBlockY() {
++        return this.cellStartBlockY;
++    }
++
++    @Override
++    public int getStartBlockZ() {
++        return this.cellStartBlockZ;
++    }
++
++    @Override
++    public int getHorizontalCellBlockCount() {
++        return this.cellWidth;
++    }
++
++    @Override
++    public int getVerticalCellBlockCount() {
++        return this.cellHeight;
++    }
++
++    @Override
++    public boolean getIsInInterpolationLoop() {
++        return this.interpolating;
++    }
++
++    @Override
++    public boolean getIsSamplingForCaches() {
++        return this.fillingCell;
++    }
++
++    @Override
++    public int getStartBiomeX() {
++        return this.firstNoiseX;
++    }
++
++    @Override
++    public int getStartBiomeZ() {
++        return this.firstNoiseZ;
++    }
++
++    @Override
++    public int getHorizontalCellCount() {
++        return this.cellCountXZ;
++    }
++
++    @Override
++    public int getVerticalCellCount() {
++        return this.cellCountY;
++    }
++
++    @Override
++    public int getMinimumCellY() {
++        return this.cellNoiseMinY;
++    }
++
++    @Override
++    public int getCellBlockX() {
++        return this.inCellX;
++    }
++
++    @Override
++    public int getCellBlockY() {
++        return this.inCellY;
++    }
++
++    @Override
++    public int getCellBlockZ() {
++        return this.inCellZ;
++    }
++
++    @Override
++    public BlockState invokeSampleBlockState() {
++        return this.getInterpolatedState();
++    }
++
++    @Override
++    public int getHorizontalBiomeEnd() {
++        return this.noiseSizeXZ;
++    }
++
++    @Override
++    public DensityFunctions.BeardifierOrMarker getBeardifying() {
++        return this.beardifier;
++    }
++
++    @Override
++    public int getStartCellX() {
++        return this.firstCellX;
++    }
++
++    @Override
++    public int getStartCellZ() {
++        return this.firstCellZ;
++    }
++
++    @Override
++    public Blender getBlender() {
++        return this.blender;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     public int maxPreliminarySurfaceLevel(final int minBlockX, final int minBlockZ, final int maxBlockX, final int maxBlockZ) {
+         int maxY = Integer.MIN_VALUE;
+ 
+@@ -311,10 +_,20 @@
+         this.fillingCell = false;
+     }
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    private NoiseChunk.NoiseInterpolator[] c2me$initInterpolatorsArray() {
++        NoiseChunk.NoiseInterpolator[] interpolatorsArray = this.c2me$interpolatorsArray;
++        if (interpolatorsArray == null) {
++            interpolatorsArray = this.c2me$interpolatorsArray = this.interpolators.toArray(NoiseChunk.NoiseInterpolator[]::new);
++        }
++        return interpolatorsArray;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     public void updateForY(final int posY, final double factorY) {
+         this.inCellY = posY - this.cellStartBlockY;
+ 
+-        for (NoiseChunk.NoiseInterpolator i : this.interpolators) {
++        for (NoiseChunk.NoiseInterpolator i : this.c2me$initInterpolatorsArray()) { // Leaf - C2ME - DensityFunction compiler - array iteration
+             i.updateForY(factorY);
+         }
+     }
+@@ -322,7 +_,7 @@
+     public void updateForX(final int posX, final double factorX) {
+         this.inCellX = posX - this.cellStartBlockX;
+ 
+-        for (NoiseChunk.NoiseInterpolator i : this.interpolators) {
++        for (NoiseChunk.NoiseInterpolator i : this.c2me$initInterpolatorsArray()) { // Leaf - C2ME - DensityFunction compiler - array iteration
+             i.updateForX(factorX);
+         }
+     }
+@@ -331,7 +_,7 @@
+         this.inCellZ = posZ - this.cellStartBlockZ;
+         this.interpolationCounter++;
+ 
+-        for (NoiseChunk.NoiseInterpolator i : this.interpolators) {
++        for (NoiseChunk.NoiseInterpolator i : this.c2me$initInterpolatorsArray()) { // Leaf - C2ME - DensityFunction compiler - array iteration
+             i.updateForZ(factorZ);
+         }
+     }
+@@ -345,7 +_,11 @@
+     }
+ 
+     public void swapSlices() {
+-        this.interpolators.forEach(NoiseChunk.NoiseInterpolator::swapSlices);
++        // Leaf start - C2ME - DensityFunction compiler
++        for (NoiseChunk.NoiseInterpolator noiseInterpolator : this.c2me$initInterpolatorsArray()) {
++            noiseInterpolator.swapSlices();
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+     public Aquifer aquifer() {
+@@ -373,13 +_,31 @@
      }
  
      protected DensityFunction wrap(final DensityFunction function) {
@@ -19,3 +364,713 @@
      }
  
      private DensityFunction wrapNew(final DensityFunction function) {
++        // Leaf start - C2ME - DensityFunction compiler
++        if (io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.densityFunctionCompiler
++            && this.interpolating
++            && function instanceof DensityFunctions.Marker) {
++            throw new IllegalStateException("Cannot create more wrapping during interpolation loop");
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+         return switch (function) {
+-            case DensityFunctions.Marker(DensityFunctions.Marker.Type type, DensityFunction wrapped) -> {
+-                switch (type) {
++            case DensityFunctions.Marker marker -> {
++                final DensityFunction wrapped = marker.wrapped();
++                switch (marker.type()) {
+                     case Interpolated:
+                         yield new NoiseChunk.NoiseInterpolator(wrapped);
+                     case FlatCache:
+@@ -407,7 +_,7 @@
+         };
+     }
+ 
+-    private class BlendAlpha implements NoiseChunk.NoiseChunkDensityFunction {
++    public class BlendAlpha implements NoiseChunk.NoiseChunkDensityFunction { // Leaf - C2ME - DensityFunction compiler - private -> public
+         @Override
+         public DensityFunction wrapped() {
+             return DensityFunctions.BlendAlpha.INSTANCE;
+@@ -487,7 +_,7 @@
+         }
+     }
+ 
+-    private class BlendOffset implements NoiseChunk.NoiseChunkDensityFunction {
++    public class BlendOffset implements NoiseChunk.NoiseChunkDensityFunction { // Leaf - C2ME - DensityFunction compiler - private -> public
+         @Override
+         public DensityFunction wrapped() {
+             return DensityFunctions.BlendOffset.INSTANCE;
+@@ -529,8 +_,8 @@
+         @Nullable BlockState calculate(final DensityFunction.FunctionContext context);
+     }
+ 
+-    private static class Cache2D implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked {
+-        private final DensityFunction function;
++    public static class Cache2D implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked, com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike { // Leaf - C2ME - DensityFunction compiler - private -> public
++        private DensityFunction function; // Leaf - C2ME - DensityFunction compiler - private final -> private
+         private long lastPos2D = ChunkPos.INVALID_CHUNK_POS;
+         private double lastValue;
+ 
+@@ -567,10 +_,78 @@
+         public DensityFunctions.Marker.Type type() {
+             return DensityFunctions.Marker.Type.Cache2D;
+         }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public double c2me$getCached(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            return this.lastPos2D == ChunkPos.pack(x, z)
++                ? this.lastValue
++                : Double.longBitsToDouble(com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike.CACHE_MISS_NAN_BITS);
++        }
++
++        @Override
++        public boolean c2me$getCached(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            return false;
++        }
++
++        @Override
++        public void c2me$cache(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType,
++            final double cached
++        ) {
++            this.lastPos2D = ChunkPos.pack(x, z);
++            this.lastValue = cached;
++        }
++
++        @Override
++        public void c2me$cache(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++        }
++
++        @Override
++        public boolean c2me$isActualCache() {
++            return true;
++        }
++
++        @Override
++        public String c2me$describeCacheLike() {
++            return "cache_2d";
++        }
++
++        @Override
++        public DensityFunction c2me$getDelegate() {
++            return this.function;
++        }
++
++        @Override
++        public DensityFunction c2me$withDelegate(final DensityFunction delegate) {
++            this.function = delegate;
++            return this;
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+-    private class CacheAllInCell implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked {
+-        private final DensityFunction noiseFiller;
++    private class CacheAllInCell implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked, com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike { // Leaf - C2ME - DensityFunction compiler
++        private DensityFunction noiseFiller; // Leaf - C2ME - DensityFunction compiler - private final -> private
+         private final double[] values;
+ 
+         private CacheAllInCell(final DensityFunction noiseFiller) {
+@@ -581,6 +_,19 @@
+ 
+         @Override
+         public double compute(final DensityFunction.FunctionContext context) {
++            // Leaf start - C2ME - DensityFunction compiler
++            if (!(context instanceof NoiseChunk)
++                && context instanceof com.ishland.c2me.opts.dfc.common.gen.jvm.vif.NoisePosVanillaInterface vanillaInterface
++                && vanillaInterface.getType() == com.ishland.c2me.opts.dfc.common.ast.EvalType.INTERPOLATION
++                && NoiseChunk.this.interpolating) {
++                final int x = context.blockX() - NoiseChunk.this.cellStartBlockX;
++                final int y = context.blockY() - NoiseChunk.this.cellStartBlockY;
++                final int z = context.blockZ() - NoiseChunk.this.cellStartBlockZ;
++                return x >= 0 && y >= 0 && z >= 0 && x < NoiseChunk.this.cellWidth && y < NoiseChunk.this.cellHeight && z < NoiseChunk.this.cellWidth
++                    ? this.values[((NoiseChunk.this.cellHeight - 1 - y) * NoiseChunk.this.cellWidth + x) * NoiseChunk.this.cellWidth + z]
++                    : this.noiseFiller.compute(context);
++            }
++            // Leaf end - C2ME - DensityFunction compiler
+             if (context != NoiseChunk.this) {
+                 return this.noiseFiller.compute(context);
+             }
+@@ -611,14 +_,119 @@
+         public DensityFunctions.Marker.Type type() {
+             return DensityFunctions.Marker.Type.CacheAllInCell;
+         }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public double c2me$getCached(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            if (evalType == com.ishland.c2me.opts.dfc.common.ast.EvalType.INTERPOLATION && NoiseChunk.this.interpolating) {
++                final int cellX = x - NoiseChunk.this.cellStartBlockX;
++                final int cellY = y - NoiseChunk.this.cellStartBlockY;
++                final int cellZ = z - NoiseChunk.this.cellStartBlockZ;
++                if (cellX >= 0
++                    && cellY >= 0
++                    && cellZ >= 0
++                    && cellX < NoiseChunk.this.cellWidth
++                    && cellY < NoiseChunk.this.cellHeight
++                    && cellZ < NoiseChunk.this.cellWidth) {
++                    return this.values[((NoiseChunk.this.cellHeight - 1 - cellY) * NoiseChunk.this.cellWidth + cellX) * NoiseChunk.this.cellWidth + cellZ];
++                }
++            }
++            return Double.longBitsToDouble(com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike.CACHE_MISS_NAN_BITS);
++        }
++
++        @Override
++        public boolean c2me$getCached(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            if (evalType == com.ishland.c2me.opts.dfc.common.ast.EvalType.INTERPOLATION && NoiseChunk.this.interpolating) {
++                for (int i = 0; i < result.length; i++) {
++                    final int cellX = x[i] - NoiseChunk.this.cellStartBlockX;
++                    final int cellY = y[i] - NoiseChunk.this.cellStartBlockY;
++                    final int cellZ = z[i] - NoiseChunk.this.cellStartBlockZ;
++                    if (cellX >= 0
++                        && cellY >= 0
++                        && cellZ >= 0
++                        && cellX < NoiseChunk.this.cellWidth
++                        && cellY < NoiseChunk.this.cellHeight
++                        && cellZ < NoiseChunk.this.cellWidth) {
++                        result[i] = this.values[((NoiseChunk.this.cellHeight - 1 - cellY) * NoiseChunk.this.cellWidth + cellX) * NoiseChunk.this.cellWidth + cellZ];
++                    } else {
++                        System.out.println("partial cell cache hit");
++                        return false;
++                    }
++                }
++            }
++            return false;
++        }
++
++        @Override
++        public void c2me$cache(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType,
++            final double cached
++        ) {
++        }
++
++        @Override
++        public void c2me$cache(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++        }
++
++        @Override
++        public boolean c2me$isActualCache() {
++            return true;
++        }
++
++        @Override
++        public String c2me$describeCacheLike() {
++            return "cache_all_in_cell";
++        }
++
++        @Override
++        public DensityFunction c2me$getDelegate() {
++            return this.noiseFiller;
++        }
++
++        @Override
++        public DensityFunction c2me$withDelegate(final DensityFunction delegate) {
++            this.noiseFiller = delegate;
++            return this;
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+-    private class CacheOnce implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked {
+-        private final DensityFunction function;
++    public class CacheOnce implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked, com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike { // Leaf - C2ME - DensityFunction compiler - private -> public
++        private DensityFunction function; // Leaf - C2ME - DensityFunction compiler - private final -> private
+         private long lastCounter;
+         private long lastArrayCounter;
+         private double lastValue;
+         private double @Nullable [] lastArray;
++        // Leaf start - C2ME - DensityFunction compiler
++        private double c2me$lastValue = Double.NaN;
++        private int c2me$lastX = Integer.MIN_VALUE;
++        private int c2me$lastY = Integer.MIN_VALUE;
++        private int c2me$lastZ = Integer.MIN_VALUE;
++        private int[] c2me$lastXa;
++        private int[] c2me$lastYa;
++        private int[] c2me$lastZa;
++        private double[] c2me$lastValuea;
++        // Leaf end - C2ME - DensityFunction compiler
+ 
+         private CacheOnce(final DensityFunction function) {
+             this.function = function;
+@@ -626,6 +_,32 @@
+ 
+         @Override
+         public double compute(final DensityFunction.FunctionContext context) {
++            // Leaf start - C2ME - DensityFunction compiler
++            if (!(context instanceof NoiseChunk)) {
++                final int blockX = context.blockX();
++                final int blockY = context.blockY();
++                final int blockZ = context.blockZ();
++                if (this.c2me$lastValuea != null) {
++                    for (int i = 0; i < this.c2me$lastValuea.length; i++) {
++                        if (this.c2me$lastXa[i] == blockX && this.c2me$lastYa[i] == blockY && this.c2me$lastZa[i] == blockZ) {
++                            return this.c2me$lastValuea[i];
++                        }
++                    }
++                }
++                if (!Double.isNaN(this.c2me$lastValue)
++                    && this.c2me$lastX == blockX
++                    && this.c2me$lastY == blockY
++                    && this.c2me$lastZ == blockZ) {
++                    return this.c2me$lastValue;
++                }
++                final double value = this.function.compute(context);
++                this.c2me$lastValue = value;
++                this.c2me$lastX = blockX;
++                this.c2me$lastY = blockY;
++                this.c2me$lastZ = blockZ;
++                return value;
++            }
++            // Leaf end - C2ME - DensityFunction compiler
+             if (context != NoiseChunk.this) {
+                 return this.function.compute(context);
+             }
+@@ -646,6 +_,27 @@
+ 
+         @Override
+         public void fillArray(final double[] output, final DensityFunction.ContextProvider contextProvider) {
++            // Leaf start - C2ME - DensityFunction compiler
++            if (!(contextProvider instanceof NoiseChunk)) {
++                if (contextProvider instanceof com.ishland.c2me.opts.dfc.common.gen.jvm.vif.EachApplierVanillaInterface vanillaInterface) {
++                    if (this.c2me$lastValuea != null
++                        && java.util.Arrays.equals(vanillaInterface.getY(), this.c2me$lastYa)
++                        && java.util.Arrays.equals(vanillaInterface.getX(), this.c2me$lastXa)
++                        && java.util.Arrays.equals(vanillaInterface.getZ(), this.c2me$lastZa)) {
++                        System.arraycopy(this.c2me$lastValuea, 0, output, 0, this.c2me$lastValuea.length);
++                    } else {
++                        this.function.fillArray(output, contextProvider);
++                        this.c2me$lastValuea = java.util.Arrays.copyOf(output, output.length);
++                        this.c2me$lastXa = vanillaInterface.getX();
++                        this.c2me$lastYa = vanillaInterface.getY();
++                        this.c2me$lastZa = vanillaInterface.getZ();
++                    }
++                } else {
++                    this.function.fillArray(output, contextProvider);
++                }
++                return;
++            }
++            // Leaf end - C2ME - DensityFunction compiler
+             if (this.lastArray != null && this.lastArrayCounter == NoiseChunk.this.arrayInterpolationCounter) {
+                 System.arraycopy(this.lastArray, 0, output, 0, output.length);
+             } else {
+@@ -669,10 +_,109 @@
+         public DensityFunctions.Marker.Type type() {
+             return DensityFunctions.Marker.Type.CacheOnce;
+         }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public double c2me$getCached(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            if (this.c2me$lastValuea != null) {
++                for (int i = 0; i < this.c2me$lastValuea.length; i++) {
++                    if (this.c2me$lastXa[i] == x && this.c2me$lastYa[i] == y && this.c2me$lastZa[i] == z) {
++                        return this.c2me$lastValuea[i];
++                    }
++                }
++            }
++            if (!Double.isNaN(this.c2me$lastValue)
++                && this.c2me$lastX == x
++                && this.c2me$lastY == y
++                && this.c2me$lastZ == z) {
++                return this.c2me$lastValue;
++            }
++            return Double.longBitsToDouble(com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike.CACHE_MISS_NAN_BITS);
++        }
++
++        @Override
++        public boolean c2me$getCached(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            if (this.c2me$lastValuea != null
++                && java.util.Arrays.equals(y, this.c2me$lastYa)
++                && java.util.Arrays.equals(x, this.c2me$lastXa)
++                && java.util.Arrays.equals(z, this.c2me$lastZa)) {
++                System.arraycopy(this.c2me$lastValuea, 0, result, 0, this.c2me$lastValuea.length);
++                return true;
++            }
++            return false;
++        }
++
++        @Override
++        public void c2me$cache(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType,
++            final double cached
++        ) {
++            this.c2me$lastValue = cached;
++            this.c2me$lastX = x;
++            this.c2me$lastY = y;
++            this.c2me$lastZ = z;
++        }
++
++        @Override
++        public void c2me$cache(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            if (this.c2me$lastValuea != null && this.c2me$lastValuea.length == result.length) {
++                System.arraycopy(result, 0, this.c2me$lastValuea, 0, result.length);
++                System.arraycopy(x, 0, this.c2me$lastXa, 0, result.length);
++                System.arraycopy(y, 0, this.c2me$lastYa, 0, result.length);
++                System.arraycopy(z, 0, this.c2me$lastZa, 0, result.length);
++            } else {
++                this.c2me$lastValuea = java.util.Arrays.copyOf(result, result.length);
++                this.c2me$lastXa = java.util.Arrays.copyOf(x, x.length);
++                this.c2me$lastYa = java.util.Arrays.copyOf(y, y.length);
++                this.c2me$lastZa = java.util.Arrays.copyOf(z, z.length);
++            }
++        }
++
++        @Override
++        public boolean c2me$isActualCache() {
++            return true;
++        }
++
++        @Override
++        public String c2me$describeCacheLike() {
++            return "cache_once";
++        }
++
++        @Override
++        public DensityFunction c2me$getDelegate() {
++            return this.function;
++        }
++
++        @Override
++        public DensityFunction c2me$withDelegate(final DensityFunction delegate) {
++            this.function = delegate;
++            return this;
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+-    private class FlatCache implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked {
+-        private final DensityFunction noiseFiller;
++    public class FlatCache implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked, com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike { // Leaf - C2ME - DensityFunction compiler - private -> public
++        private DensityFunction noiseFiller; // Leaf - C2ME - DensityFunction compiler - mutable delegate
+         private final double[] values;
+         private final int sizeXZ;
+ 
+@@ -717,6 +_,84 @@
+         public DensityFunctions.Marker.Type type() {
+             return DensityFunctions.Marker.Type.FlatCache;
+         }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public double c2me$getCached(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            final int localX = QuartPos.fromBlock(x) - NoiseChunk.this.firstNoiseX;
++            final int localZ = QuartPos.fromBlock(z) - NoiseChunk.this.firstNoiseZ;
++            return localX >= 0 && localZ >= 0 && localX < this.sizeXZ && localZ < this.sizeXZ
++                ? this.values[localX + localZ * this.sizeXZ]
++                : Double.longBitsToDouble(com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike.CACHE_MISS_NAN_BITS);
++        }
++
++        @Override
++        public boolean c2me$getCached(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            for (int i = 0; i < result.length; i++) {
++                final int localX = QuartPos.fromBlock(x[i]) - NoiseChunk.this.firstNoiseX;
++                final int localZ = QuartPos.fromBlock(z[i]) - NoiseChunk.this.firstNoiseZ;
++                if (localX >= 0 && localZ >= 0 && localX < this.sizeXZ && localZ < this.sizeXZ) {
++                    result[i] = this.values[localX + localZ * this.sizeXZ];
++                } else {
++                    System.out.println("partial flat cache hit");
++                    return false;
++                }
++            }
++            return true;
++        }
++
++        @Override
++        public void c2me$cache(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType,
++            final double cached
++        ) {
++        }
++
++        @Override
++        public void c2me$cache(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++        }
++
++        @Override
++        public boolean c2me$isActualCache() {
++            return true;
++        }
++
++        @Override
++        public String c2me$describeCacheLike() {
++            return "flat_cache";
++        }
++
++        @Override
++        public DensityFunction c2me$getDelegate() {
++            return this.noiseFiller;
++        }
++
++        @Override
++        public DensityFunction c2me$withDelegate(final DensityFunction delegate) {
++            this.noiseFiller = delegate;
++            return this;
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+     private interface NoiseChunkDensityFunction extends DensityFunction {
+@@ -733,10 +_,10 @@
+         }
+     }
+ 
+-    public class NoiseInterpolator implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked {
++    public class NoiseInterpolator implements NoiseChunk.NoiseChunkDensityFunction, DensityFunctions.MarkerOrMarked, com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike, com.ishland.c2me.base.mixin.access.IChunkNoiseSamplerDensityInterpolator { // Leaf - C2ME - DensityFunction compiler
+         private double[][] slice0;
+         private double[][] slice1;
+-        private final DensityFunction noiseFiller;
++        private DensityFunction noiseFiller; // Leaf - C2ME - DensityFunction compiler - private final -> private
+         private double noise000;
+         private double noise001;
+         private double noise100;
+@@ -801,6 +_,33 @@
+ 
+         @Override
+         public double compute(final DensityFunction.FunctionContext context) {
++            // Leaf start - C2ME - DensityFunction compiler
++            if (!(context instanceof NoiseChunk)
++                && context instanceof com.ishland.c2me.opts.dfc.common.gen.jvm.vif.NoisePosVanillaInterface vanillaInterface
++                && vanillaInterface.getType() == com.ishland.c2me.opts.dfc.common.ast.EvalType.INTERPOLATION) {
++                if (!NoiseChunk.this.interpolating) {
++                    return this.noiseFiller.compute(context);
++                }
++                final int cellX = context.blockX() - NoiseChunk.this.cellStartBlockX;
++                final int cellY = context.blockY() - NoiseChunk.this.cellStartBlockY;
++                final int cellZ = context.blockZ() - NoiseChunk.this.cellStartBlockZ;
++                return NoiseChunk.this.fillingCell
++                    ? Mth.lerp3(
++                        (double)cellX / NoiseChunk.this.cellWidth,
++                        (double)cellY / NoiseChunk.this.cellHeight,
++                        (double)cellZ / NoiseChunk.this.cellWidth,
++                        this.noise000,
++                        this.noise100,
++                        this.noise010,
++                        this.noise110,
++                        this.noise001,
++                        this.noise101,
++                        this.noise011,
++                        this.noise111
++                    )
++                    : this.value;
++            }
++            // Leaf end - C2ME - DensityFunction compiler
+             if (context != NoiseChunk.this) {
+                 return this.noiseFiller.compute(context);
+             } else if (!NoiseChunk.this.interpolating) {
+@@ -848,5 +_,136 @@
+         public DensityFunctions.Marker.Type type() {
+             return DensityFunctions.Marker.Type.Interpolated;
+         }
++
++        // Leaf start - C2ME - DensityFunction compiler
++        @Override
++        public double c2me$getCached(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            if (evalType == com.ishland.c2me.opts.dfc.common.ast.EvalType.INTERPOLATION) {
++                if (!NoiseChunk.this.interpolating) {
++                    throw new IllegalStateException("Trying to sample interpolator outside the interpolation loop");
++                }
++                if (NoiseChunk.this.fillingCell) {
++                    final int cellX = x - NoiseChunk.this.cellStartBlockX;
++                    final int cellY = y - NoiseChunk.this.cellStartBlockY;
++                    final int cellZ = z - NoiseChunk.this.cellStartBlockZ;
++                    return Mth.lerp3(
++                        (double)cellX / NoiseChunk.this.cellWidth,
++                        (double)cellY / NoiseChunk.this.cellHeight,
++                        (double)cellZ / NoiseChunk.this.cellWidth,
++                        this.noise000,
++                        this.noise100,
++                        this.noise010,
++                        this.noise110,
++                        this.noise001,
++                        this.noise101,
++                        this.noise011,
++                        this.noise111
++                    );
++                }
++                return this.value;
++            }
++            return Double.longBitsToDouble(com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike.CACHE_MISS_NAN_BITS);
++        }
++
++        @Override
++        public boolean c2me$getCached(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++            if (evalType == com.ishland.c2me.opts.dfc.common.ast.EvalType.INTERPOLATION
++                && NoiseChunk.this.interpolating
++                && NoiseChunk.this.fillingCell) {
++                for (int i = 0; i < result.length; i++) {
++                    final int cellX = x[i] - NoiseChunk.this.cellStartBlockX;
++                    final int cellY = y[i] - NoiseChunk.this.cellStartBlockY;
++                    final int cellZ = z[i] - NoiseChunk.this.cellStartBlockZ;
++                    result[i] = Mth.lerp3(
++                        (double)cellX / NoiseChunk.this.cellWidth,
++                        (double)cellY / NoiseChunk.this.cellHeight,
++                        (double)cellZ / NoiseChunk.this.cellWidth,
++                        this.noise000,
++                        this.noise100,
++                        this.noise010,
++                        this.noise110,
++                        this.noise001,
++                        this.noise101,
++                        this.noise011,
++                        this.noise111
++                    );
++                }
++                return true;
++            }
++            return false;
++        }
++
++        @Override
++        public void c2me$cache(
++            final int x,
++            final int y,
++            final int z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType,
++            final double cached
++        ) {
++        }
++
++        @Override
++        public void c2me$cache(
++            final double[] result,
++            final int[] x,
++            final int[] y,
++            final int[] z,
++            final com.ishland.c2me.opts.dfc.common.ast.EvalType evalType
++        ) {
++        }
++
++        @Override
++        public boolean c2me$isActualCache() {
++            return false;
++        }
++
++        @Override
++        public String c2me$describeCacheLike() {
++            return "interpolated";
++        }
++
++        @Override
++        public DensityFunction c2me$getDelegate() {
++            return this.noiseFiller;
++        }
++
++        @Override
++        public DensityFunction c2me$withDelegate(final DensityFunction delegate) {
++            this.noiseFiller = delegate;
++            return this;
++        }
++
++        @Override
++        public void invokeInterpolateX(final double deltaX) {
++            this.updateForX(deltaX);
++        }
++
++        @Override
++        public void invokeInterpolateY(final double deltaY) {
++            this.updateForY(deltaY);
++        }
++
++        @Override
++        public void invokeInterpolateZ(final double deltaZ) {
++            this.updateForZ(deltaZ);
++        }
++
++        @Override
++        public void invokeSwapBuffers() {
++            this.swapSlices();
++        }
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseRouter.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/NoiseRouter.java.patch
@@ -1,0 +1,259 @@
+--- a/net/minecraft/world/level/levelgen/NoiseRouter.java
++++ b/net/minecraft/world/level/levelgen/NoiseRouter.java
+@@ -4,23 +_,27 @@
+ import com.mojang.serialization.codecs.RecordCodecBuilder;
+ import java.util.function.Function;
+ 
+-public record NoiseRouter(
+-    DensityFunction barrierNoise,
+-    DensityFunction fluidLevelFloodednessNoise,
+-    DensityFunction fluidLevelSpreadNoise,
+-    DensityFunction lavaNoise,
+-    DensityFunction temperature,
+-    DensityFunction vegetation,
+-    DensityFunction continents,
+-    DensityFunction erosion,
+-    DensityFunction depth,
+-    DensityFunction ridges,
+-    DensityFunction preliminarySurfaceLevel,
+-    DensityFunction finalDensity,
+-    DensityFunction veinToggle,
+-    DensityFunction veinRidged,
+-    DensityFunction veinGap
+-) {
++// Leaf start - C2ME - DensityFunction compiler
++public final class NoiseRouter implements com.ishland.c2me.opts.dfc.common.ducks.NoiseRouterExtension {
++    private final DensityFunction barrierNoise;
++    private final DensityFunction fluidLevelFloodednessNoise;
++    private final DensityFunction fluidLevelSpreadNoise;
++    private final DensityFunction lavaNoise;
++    private final DensityFunction temperature;
++    private final DensityFunction vegetation;
++    private final DensityFunction continents;
++    private final DensityFunction erosion;
++    private final DensityFunction depth;
++    private final DensityFunction ridges;
++    private final DensityFunction preliminarySurfaceLevel;
++    private final DensityFunction finalDensity;
++    private final DensityFunction veinToggle;
++    private final DensityFunction veinRidged;
++    private final DensityFunction veinGap;
++    private DensityFunction c2me$finalFinalDensity;
++    private NoiseRouter c2me$originalNoiseRouter;
++// Leaf end - C2ME - DensityFunction compiler
++
+     public static final Codec<NoiseRouter> CODEC = RecordCodecBuilder.create(
+         i -> i.group(
+                 field("barrier", NoiseRouter::barrierNoise),
+@@ -42,12 +_,131 @@
+             .apply(i, NoiseRouter::new)
+     );
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    public NoiseRouter(
++        final DensityFunction barrierNoise,
++        final DensityFunction fluidLevelFloodednessNoise,
++        final DensityFunction fluidLevelSpreadNoise,
++        final DensityFunction lavaNoise,
++        final DensityFunction temperature,
++        final DensityFunction vegetation,
++        final DensityFunction continents,
++        final DensityFunction erosion,
++        final DensityFunction depth,
++        final DensityFunction ridges,
++        final DensityFunction preliminarySurfaceLevel,
++        final DensityFunction finalDensity,
++        final DensityFunction veinToggle,
++        final DensityFunction veinRidged,
++        final DensityFunction veinGap
++    ) {
++        this.barrierNoise = barrierNoise;
++        this.fluidLevelFloodednessNoise = fluidLevelFloodednessNoise;
++        this.fluidLevelSpreadNoise = fluidLevelSpreadNoise;
++        this.lavaNoise = lavaNoise;
++        this.temperature = temperature;
++        this.vegetation = vegetation;
++        this.continents = continents;
++        this.erosion = erosion;
++        this.depth = depth;
++        this.ridges = ridges;
++        this.preliminarySurfaceLevel = preliminarySurfaceLevel;
++        this.finalDensity = finalDensity;
++        this.veinToggle = veinToggle;
++        this.veinRidged = veinRidged;
++        this.veinGap = veinGap;
++    }
++
++    public DensityFunction barrierNoise() {
++        return this.barrierNoise;
++    }
++
++    public DensityFunction fluidLevelFloodednessNoise() {
++        return this.fluidLevelFloodednessNoise;
++    }
++
++    public DensityFunction fluidLevelSpreadNoise() {
++        return this.fluidLevelSpreadNoise;
++    }
++
++    public DensityFunction lavaNoise() {
++        return this.lavaNoise;
++    }
++
++    public DensityFunction temperature() {
++        return this.temperature;
++    }
++
++    public DensityFunction vegetation() {
++        return this.vegetation;
++    }
++
++    public DensityFunction continents() {
++        return this.continents;
++    }
++
++    public DensityFunction erosion() {
++        return this.erosion;
++    }
++
++    public DensityFunction depth() {
++        return this.depth;
++    }
++
++    public DensityFunction ridges() {
++        return this.ridges;
++    }
++
++    public DensityFunction preliminarySurfaceLevel() {
++        return this.preliminarySurfaceLevel;
++    }
++
++    public DensityFunction finalDensity() {
++        return this.finalDensity;
++    }
++
++    public DensityFunction veinToggle() {
++        return this.veinToggle;
++    }
++
++    public DensityFunction veinRidged() {
++        return this.veinRidged;
++    }
++
++    public DensityFunction veinGap() {
++        return this.veinGap;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     private static RecordCodecBuilder<NoiseRouter, DensityFunction> field(final String name, final Function<NoiseRouter, DensityFunction> getter) {
+         return DensityFunction.CODEC.fieldOf(name).forGetter(getter);
+     }
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public DensityFunction c2me$getFinalFinalDensity() {
++        return this.c2me$finalFinalDensity;
++    }
++
++    @Override
++    public void c2me$setFinalFinalDensity(final DensityFunction densityFunction) {
++        this.c2me$finalFinalDensity = densityFunction;
++    }
++
++    @Override
++    public void c2me$setOriginalNoiseRouter(final NoiseRouter originalNoiseRouter) {
++        this.c2me$originalNoiseRouter = originalNoiseRouter;
++    }
++
++    @Override
++    public NoiseRouter c2me$getOriginalNoiseRouter() {
++        return this.c2me$originalNoiseRouter;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     public NoiseRouter mapAll(final DensityFunction.Visitor visitor) {
+-        return new NoiseRouter(
++        // Leaf start - C2ME - DensityFunction compiler
++        final NoiseRouter mapped = new NoiseRouter(
+             this.barrierNoise.mapAll(visitor),
+             this.fluidLevelFloodednessNoise.mapAll(visitor),
+             this.fluidLevelSpreadNoise.mapAll(visitor),
+@@ -64,5 +_,78 @@
+             this.veinRidged.mapAll(visitor),
+             this.veinGap.mapAll(visitor)
+         );
++        final DensityFunction finalFinalDensity = this.c2me$getFinalFinalDensity();
++        if (finalFinalDensity != null) {
++            mapped.c2me$setFinalFinalDensity(finalFinalDensity.mapAll(visitor));
++        }
++        mapped.c2me$setOriginalNoiseRouter(this.c2me$getOriginalNoiseRouter());
++        return mapped;
++        // Leaf end - C2ME - DensityFunction compiler
++    }
++
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public boolean equals(final Object object) {
++        if (this == object) {
++            return true;
++        }
++        if (!(object instanceof NoiseRouter other)) {
++            return false;
++        }
++        return java.util.Objects.equals(this.barrierNoise, other.barrierNoise)
++            && java.util.Objects.equals(this.fluidLevelFloodednessNoise, other.fluidLevelFloodednessNoise)
++            && java.util.Objects.equals(this.fluidLevelSpreadNoise, other.fluidLevelSpreadNoise)
++            && java.util.Objects.equals(this.lavaNoise, other.lavaNoise)
++            && java.util.Objects.equals(this.temperature, other.temperature)
++            && java.util.Objects.equals(this.vegetation, other.vegetation)
++            && java.util.Objects.equals(this.continents, other.continents)
++            && java.util.Objects.equals(this.erosion, other.erosion)
++            && java.util.Objects.equals(this.depth, other.depth)
++            && java.util.Objects.equals(this.ridges, other.ridges)
++            && java.util.Objects.equals(this.preliminarySurfaceLevel, other.preliminarySurfaceLevel)
++            && java.util.Objects.equals(this.finalDensity, other.finalDensity)
++            && java.util.Objects.equals(this.veinToggle, other.veinToggle)
++            && java.util.Objects.equals(this.veinRidged, other.veinRidged)
++            && java.util.Objects.equals(this.veinGap, other.veinGap);
++    }
++
++    @Override
++    public int hashCode() {
++        int result = java.util.Objects.hashCode(this.barrierNoise);
++        result = 31 * result + java.util.Objects.hashCode(this.fluidLevelFloodednessNoise);
++        result = 31 * result + java.util.Objects.hashCode(this.fluidLevelSpreadNoise);
++        result = 31 * result + java.util.Objects.hashCode(this.lavaNoise);
++        result = 31 * result + java.util.Objects.hashCode(this.temperature);
++        result = 31 * result + java.util.Objects.hashCode(this.vegetation);
++        result = 31 * result + java.util.Objects.hashCode(this.continents);
++        result = 31 * result + java.util.Objects.hashCode(this.erosion);
++        result = 31 * result + java.util.Objects.hashCode(this.depth);
++        result = 31 * result + java.util.Objects.hashCode(this.ridges);
++        result = 31 * result + java.util.Objects.hashCode(this.preliminarySurfaceLevel);
++        result = 31 * result + java.util.Objects.hashCode(this.finalDensity);
++        result = 31 * result + java.util.Objects.hashCode(this.veinToggle);
++        result = 31 * result + java.util.Objects.hashCode(this.veinRidged);
++        result = 31 * result + java.util.Objects.hashCode(this.veinGap);
++        return result;
++    }
++
++    @Override
++    public String toString() {
++        return "NoiseRouter[barrierNoise=" + this.barrierNoise
++            + ", fluidLevelFloodednessNoise=" + this.fluidLevelFloodednessNoise
++            + ", fluidLevelSpreadNoise=" + this.fluidLevelSpreadNoise
++            + ", lavaNoise=" + this.lavaNoise
++            + ", temperature=" + this.temperature
++            + ", vegetation=" + this.vegetation
++            + ", continents=" + this.continents
++            + ", erosion=" + this.erosion
++            + ", depth=" + this.depth
++            + ", ridges=" + this.ridges
++            + ", preliminarySurfaceLevel=" + this.preliminarySurfaceLevel
++            + ", finalDensity=" + this.finalDensity
++            + ", veinToggle=" + this.veinToggle
++            + ", veinRidged=" + this.veinRidged
++            + ", veinGap=" + this.veinGap + ']';
+     }
++    // Leaf end - C2ME - DensityFunction compiler
+ }

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/RandomState.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/RandomState.java.patch
@@ -1,0 +1,82 @@
+--- a/net/minecraft/world/level/levelgen/RandomState.java
++++ b/net/minecraft/world/level/levelgen/RandomState.java
+@@ -81,7 +_,7 @@
+             }
+         }
+ 
+-        this.router = settings.noiseRouter().mapAll(new NoiseWiringHelper());
++        NoiseRouter wiredRouter = settings.noiseRouter().mapAll(new NoiseWiringHelper()); // Leaf - C2ME - DensityFunction compiler
+         DensityFunction.Visitor noiseFlattener = new DensityFunction.Visitor() {
+             private final Map<DensityFunction, DensityFunction> wrapped = new HashMap<>();
+ 
+@@ -98,15 +_,63 @@
+                 return this.wrapped.computeIfAbsent(input, this::wrapNew);
+             }
+         };
+-        this.sampler = new Climate.Sampler(
+-            this.router.temperature().mapAll(noiseFlattener),
+-            this.router.vegetation().mapAll(noiseFlattener),
+-            this.router.continents().mapAll(noiseFlattener),
+-            this.router.erosion().mapAll(noiseFlattener),
+-            this.router.depth().mapAll(noiseFlattener),
+-            this.router.ridges().mapAll(noiseFlattener),
++        // Leaf start - C2ME - DensityFunction compiler
++        Climate.Sampler wiredSampler = new Climate.Sampler(
++            wiredRouter.temperature().mapAll(noiseFlattener),
++            wiredRouter.vegetation().mapAll(noiseFlattener),
++            wiredRouter.continents().mapAll(noiseFlattener),
++            wiredRouter.erosion().mapAll(noiseFlattener),
++            wiredRouter.depth().mapAll(noiseFlattener),
++            wiredRouter.ridges().mapAll(noiseFlattener),
+             settings.spawnTarget()
+         );
++        // Leaf end - C2ME - DensityFunction compiler
++
++        // Leaf start - C2ME - DensityFunction compiler
++        if (io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.densityFunctionCompiler) {
++            final com.google.common.base.Stopwatch stopwatch = com.google.common.base.Stopwatch.createStarted();
++            final DensityFunction finalFinalDensity = DensityFunctions.add(wiredRouter.finalDensity(), DensityFunctions.BeardifierMarker.INSTANCE);
++            final NoiseRouter originalRouter = wiredRouter;
++            originalRouter.c2me$setFinalFinalDensity(finalFinalDensity);
++
++            final com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen.Context generationContext =
++                com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen.initContext();
++            wiredRouter = new NoiseRouter(
++                generationContext.compileDelayed("barrier", wiredRouter.barrierNoise()),
++                generationContext.compileDelayed("fluid_level_floodedness", wiredRouter.fluidLevelFloodednessNoise()),
++                generationContext.compileDelayed("fluid_level_spread", wiredRouter.fluidLevelSpreadNoise()),
++                generationContext.compileDelayed("lava", wiredRouter.lavaNoise()),
++                generationContext.compileDelayed("temperature", wiredRouter.temperature()),
++                generationContext.compileDelayed("vegetation", wiredRouter.vegetation()),
++                generationContext.compileDelayed("continents", wiredRouter.continents()),
++                generationContext.compileDelayed("erosion", wiredRouter.erosion()),
++                generationContext.compileDelayed("depth", wiredRouter.depth()),
++                generationContext.compileDelayed("ridges", wiredRouter.ridges()),
++                generationContext.compileDelayed("preliminary_surface_level", wiredRouter.preliminarySurfaceLevel()),
++                generationContext.compileDelayed("final_density", wiredRouter.finalDensity()),
++                generationContext.compileDelayed("vein_toggle", wiredRouter.veinToggle()),
++                generationContext.compileDelayed("vein_ridged", wiredRouter.veinRidged()),
++                generationContext.compileDelayed("vein_gap", wiredRouter.veinGap())
++            );
++            wiredRouter.c2me$setFinalFinalDensity(generationContext.compileDelayed("final_final_density", finalFinalDensity));
++            wiredRouter.c2me$setOriginalNoiseRouter(originalRouter);
++
++            wiredSampler = new Climate.Sampler(
++                generationContext.compileDelayed("multiNoiseSampler_temperature", wiredSampler.temperature()),
++                generationContext.compileDelayed("multiNoiseSampler_vegetation", wiredSampler.humidity()),
++                generationContext.compileDelayed("multiNoiseSampler_continents", wiredSampler.continentalness()),
++                generationContext.compileDelayed("multiNoiseSampler_erosion", wiredSampler.erosion()),
++                generationContext.compileDelayed("multiNoiseSampler_depth", wiredSampler.depth()),
++                generationContext.compileDelayed("multiNoiseSampler_ridges", wiredSampler.weirdness()),
++                wiredSampler.spawnTarget()
++            );
++            com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen.finalizeCompilation(generationContext);
++            stopwatch.stop();
++            io.canvasmc.canvas.GlobalConfiguration.LOGGER.info("Density function compilation finished in {}", stopwatch);
++        }
++        this.router = wiredRouter;
++        this.sampler = wiredSampler;
++        // Leaf end - C2ME - DensityFunction compiler
+     }
+ 
+     public NormalNoise getOrCreateNoise(final ResourceKey<NormalNoise.NoiseParameters> noise) {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/SurfaceRules.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/SurfaceRules.java.patch
@@ -1,5 +1,14 @@
 --- a/net/minecraft/world/level/levelgen/SurfaceRules.java
 +++ b/net/minecraft/world/level/levelgen/SurfaceRules.java
+@@ -236,7 +_,7 @@
+         }
+     }
+ 
+-    private record BlockRuleSource(BlockState resultState, SurfaceRules.StateRule rule) implements SurfaceRules.RuleSource {
++    record BlockRuleSource(BlockState resultState, SurfaceRules.StateRule rule) implements SurfaceRules.RuleSource { // Canvas - optimize trivial End surface generation - private -> package-private
+         private static final MapCodec<SurfaceRules.BlockRuleSource> CODEC = BlockState.CODEC
+             .xmap(SurfaceRules.BlockRuleSource::new, SurfaceRules.BlockRuleSource::resultState)
+             .fieldOf("result_state");
 @@ -666,8 +_,13 @@
      private record SequenceRule(List<SurfaceRules.SurfaceRule> rules) implements SurfaceRules.SurfaceRule {
          @Override

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/WorldOptions.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/WorldOptions.java.patch
@@ -1,0 +1,26 @@
+--- a/net/minecraft/world/level/levelgen/WorldOptions.java
++++ b/net/minecraft/world/level/levelgen/WorldOptions.java
+@@ -21,6 +_,7 @@
+     );
+     public static final WorldOptions DEMO_OPTIONS = new WorldOptions("North Carolina".hashCode(), true, true);
+     private final long seed;
++    private final long biomeZoomSeed; // Canvas - cache biome zoom seed
+     private final boolean generateStructures;
+     private final boolean generateBonusChest;
+     private final Optional<String> legacyCustomOptions;
+@@ -42,7 +_,14 @@
+         this.generateStructures = generateStructures;
+         this.generateBonusChest = generateBonusChest;
+         this.legacyCustomOptions = legacyCustomOptions;
+-    }
++        this.biomeZoomSeed = net.minecraft.world.level.biome.BiomeManager.obfuscateSeed(seed); // Canvas - cache biome zoom seed
++    }
++
++    // Canvas start - cache biome zoom seed
++    public long biomeZoomSeed() {
++        return this.biomeZoomSeed;
++    }
++    // Canvas end - cache biome zoom seed
+ 
+     public long seed() {
+         return this.seed;

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/blending/Blender.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/blending/Blender.java.patch
@@ -1,0 +1,11 @@
+--- a/net/minecraft/world/level/levelgen/blending/Blender.java
++++ b/net/minecraft/world/level/levelgen/blending/Blender.java
+@@ -149,7 +_,7 @@
+     private static double heightToOffset(final double height) {
+         double dimensionFactor = 1.0;
+         double targetY = height + 0.5;
+-        double targetYMod = Mth.positiveModulo(targetY, 8.0);
++        double targetYMod = Mth.positiveModuloForPositiveIntegerDenominator(targetY, 8.0); // Canvas - faster floating-point positive modulo
+         return 1.0 * (32.0 * (targetY - 128.0) - 3.0 * (targetY - 120.0) * targetYMod + 3.0 * targetYMod * targetYMod) / (128.0 * (32.0 - 3.0 * targetYMod));
+     }
+ 

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/feature/OreFeature.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/feature/OreFeature.java.patch
@@ -1,0 +1,10 @@
+--- a/net/minecraft/world/level/levelgen/feature/OreFeature.java
++++ b/net/minecraft/world/level/levelgen/feature/OreFeature.java
+@@ -71,6 +_,6 @@
+     ) {
+         int placed = 0;
+-        BitSet tested = new BitSet(sizeXZ * sizeY * sizeXZ);
++        BitSet tested = com.ishland.c2me.opts.allocs.CachedOrNewBitsGetter.getCachedOrNewBitSet(sizeXZ * sizeY * sizeXZ); // Leaf - C2ME - Reduce Allocations
+         BlockPos.MutableBlockPos orePos = new BlockPos.MutableBlockPos();
+         int size = config.size;
+         double[] data = new double[size * 4];

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/BlendedNoise.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/BlendedNoise.java.patch
@@ -1,0 +1,42 @@
+--- a/net/minecraft/world/level/levelgen/synth/BlendedNoise.java
++++ b/net/minecraft/world/level/levelgen/synth/BlendedNoise.java
+@@ -154,6 +_,39 @@
+         return this.maxValue;
+     }
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public boolean equals(final Object object) {
++        if (this == object) return true;
++        if (object == null || this.getClass() != object.getClass()) return false;
++        BlendedNoise that = (BlendedNoise)object;
++        return Double.compare(this.xzMultiplier, that.xzMultiplier) == 0
++            && Double.compare(this.yMultiplier, that.yMultiplier) == 0
++            && Double.compare(this.xzFactor, that.xzFactor) == 0
++            && Double.compare(this.yFactor, that.yFactor) == 0
++            && Double.compare(this.smearScaleMultiplier, that.smearScaleMultiplier) == 0
++            && java.util.Objects.equals(this.minLimitNoise, that.minLimitNoise)
++            && java.util.Objects.equals(this.maxLimitNoise, that.maxLimitNoise)
++            && java.util.Objects.equals(this.mainNoise, that.mainNoise);
++    }
++
++    @Override
++    public int hashCode() {
++        int result = 1;
++
++        result = 31 * result + java.util.Objects.hashCode(this.minLimitNoise);
++        result = 31 * result + java.util.Objects.hashCode(this.maxLimitNoise);
++        result = 31 * result + java.util.Objects.hashCode(this.mainNoise);
++        result = 31 * result + Double.hashCode(this.xzMultiplier);
++        result = 31 * result + Double.hashCode(this.yMultiplier);
++        result = 31 * result + Double.hashCode(this.xzFactor);
++        result = 31 * result + Double.hashCode(this.yFactor);
++        result = 31 * result + Double.hashCode(this.smearScaleMultiplier);
++
++        return result;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     @VisibleForTesting
+     public void parityConfigString(final StringBuilder sb) {
+         sb.append("BlendedNoise{minLimitNoise=");

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/ImprovedNoise.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/ImprovedNoise.java.patch
@@ -146,3 +146,35 @@
      }
  
      private double sampleWithDerivative(final int x, final int y, final int z, final double xr, final double yr, final double zr, final double[] derivativeOut) {
+@@ -155,6 +_,31 @@
+         return Mth.lerp3(xAlpha, yAlpha, zAlpha, d000, d100, d010, d110, d001, d101, d011, d111);
+     }
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public boolean equals(final Object object) {
++        if (this == object) return true;
++        if (object == null || this.getClass() != object.getClass()) return false;
++        ImprovedNoise that = (ImprovedNoise)object;
++        return Double.compare(this.xo, that.xo) == 0
++            && Double.compare(this.yo, that.yo) == 0
++            && Double.compare(this.zo, that.zo) == 0
++            && java.util.Arrays.equals(this.p, that.p);
++    }
++
++    @Override
++    public int hashCode() {
++        int result = 1;
++
++        result = 31 * result + java.util.Arrays.hashCode(this.p);
++        result = 31 * result + Double.hashCode(this.xo);
++        result = 31 * result + Double.hashCode(this.yo);
++        result = 31 * result + Double.hashCode(this.zo);
++
++        return result;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     @VisibleForTesting
+     public void parityConfigString(final StringBuilder sb) {
+         NoiseUtils.parityNoiseOctaveConfigString(sb, this.xo, this.yo, this.zo, this.p);

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/ImprovedNoise.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/ImprovedNoise.java.patch
@@ -43,7 +43,7 @@
          double xr = x - xf;
          double yr = y - yf;
          double zr = z - zf;
-@@ -53,12 +_,12 @@
+@@ -53,25 +_,27 @@
                  fudgeLimit = yr;
              }
  
@@ -58,6 +58,25 @@
      }
  
      public double noiseWithDerivative(final double _x, final double _y, final double _z, final double[] derivativeOut) {
+         double x = _x + this.xo;
+         double y = _y + this.yo;
+         double z = _z + this.zo;
+-        int xf = Mth.floor(x);
+-        int yf = Mth.floor(y);
+-        int zf = Mth.floor(z);
++        // Canvas start - optimize: remove frequent type conversions
++        double xf = Math.floor(x);
++        double yf = Math.floor(y);
++        double zf = Math.floor(z);
++        // Canvas end - optimize: remove frequent type conversions
+         double xr = x - xf;
+         double yr = y - yf;
+         double zr = z - zf;
+-        return this.sampleWithDerivative(xf, yf, zf, xr, yr, zr, derivativeOut);
++        return this.sampleWithDerivative((int) xf, (int) yf, (int) zf, xr, yr, zr, derivativeOut); // Canvas - optimize: remove frequent type conversions
+     }
+ 
+     private static double gradDot(final int hash, final double x, final double y, final double z) {
 @@ -83,24 +_,69 @@
      }
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/NormalNoise.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/NormalNoise.java.patch
@@ -1,0 +1,32 @@
+--- a/net/minecraft/world/level/levelgen/synth/NormalNoise.java
++++ b/net/minecraft/world/level/levelgen/synth/NormalNoise.java
+@@ -83,6 +_,29 @@
+         return this.parameters;
+     }
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public boolean equals(final Object object) {
++        if (this == object) return true;
++        if (object == null || this.getClass() != object.getClass()) return false;
++        NormalNoise that = (NormalNoise)object;
++        return Double.compare(this.valueFactor, that.valueFactor) == 0
++            && java.util.Objects.equals(this.first, that.first)
++            && java.util.Objects.equals(this.second, that.second);
++    }
++
++    @Override
++    public int hashCode() {
++        int result = 1;
++
++        result = 31 * result + Double.hashCode(this.valueFactor);
++        result = 31 * result + java.util.Objects.hashCode(this.first);
++        result = 31 * result + java.util.Objects.hashCode(this.second);
++
++        return result;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     @VisibleForTesting
+     public void parityConfigString(final StringBuilder sb) {
+         sb.append("NormalNoise {");

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/PerlinNoise.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/PerlinNoise.java.patch
@@ -51,3 +51,12 @@
      }
  
      @Deprecated
+@@ -186,7 +_,7 @@
+     }
+ 
+     public static double wrap(final double x) {
+-        return x - Mth.lfloor(x / 3.3554432E7 + 0.5) * 3.3554432E7;
++        return x - Math.floor(x / 3.3554432E7 + 0.5) * 3.3554432E7; // Canvas - optimize noise generation
+     }
+ 
+     protected int firstOctave() {

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/PerlinNoise.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/PerlinNoise.java.patch
@@ -51,3 +51,35 @@
      }
  
      @Deprecated
+@@ -197,6 +_,31 @@
+         return this.amplitudes;
+     }
+ 
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public boolean equals(final Object object) {
++        if (this == object) return true;
++        if (object == null || this.getClass() != object.getClass()) return false;
++        PerlinNoise that = (PerlinNoise)object;
++        return Double.compare(this.lowestFreqValueFactor, that.lowestFreqValueFactor) == 0
++            && Double.compare(this.lowestFreqInputFactor, that.lowestFreqInputFactor) == 0
++            && Arrays.equals(this.noiseLevels, that.noiseLevels)
++            && Arrays.equals(this.amplitudes.toDoubleArray(), that.amplitudes.toDoubleArray());
++    }
++
++    @Override
++    public int hashCode() {
++        int result = 1;
++
++        result = 31 * result + Arrays.hashCode(this.noiseLevels);
++        result = 31 * result + Arrays.hashCode(this.amplitudes.toDoubleArray());
++        result = 31 * result + Double.hashCode(this.lowestFreqValueFactor);
++        result = 31 * result + Double.hashCode(this.lowestFreqInputFactor);
++
++        return result;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
++
+     @VisibleForTesting
+     public void parityConfigString(final StringBuilder sb) {
+         sb.append("PerlinNoise{");

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/SimplexNoise.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/level/levelgen/synth/SimplexNoise.java.patch
@@ -1,0 +1,32 @@
+--- a/net/minecraft/world/level/levelgen/synth/SimplexNoise.java
++++ b/net/minecraft/world/level/levelgen/synth/SimplexNoise.java
+@@ -191,4 +_,29 @@
+         double n3 = this.getCornerNoise3D(gi3, x3, y3, z3, 0.6);
+         return 32.0 * (n0 + n1 + n2 + n3);
+     }
++
++    // Leaf start - C2ME - DensityFunction compiler
++    @Override
++    public boolean equals(final Object object) {
++        if (this == object) return true;
++        if (object == null || this.getClass() != object.getClass()) return false;
++        SimplexNoise that = (SimplexNoise) object;
++        return Double.compare(this.xo, that.xo) == 0
++            && Double.compare(this.yo, that.yo) == 0
++            && Double.compare(this.zo, that.zo) == 0
++            && java.util.Arrays.equals(this.p, that.p);
++    }
++
++    @Override
++    public int hashCode() {
++        int result = 1;
++
++        result = 31 * result + java.util.Arrays.hashCode(this.p);
++        result = 31 * result + Double.hashCode(this.xo);
++        result = 31 * result + Double.hashCode(this.yo);
++        result = 31 * result + Double.hashCode(this.zo);
++
++        return result;
++    }
++    // Leaf end - C2ME - DensityFunction compiler
+ }

--- a/canvas-server/src/main/java/com/ishland/c2me/base/mixin/access/IChunkNoiseSampler.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/base/mixin/access/IChunkNoiseSampler.java
@@ -1,0 +1,75 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.base.mixin.access;
+
+import net.minecraft.world.level.block.state.BlockState;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+import net.minecraft.world.level.levelgen.blending.Blender;
+
+public interface IChunkNoiseSampler {
+
+    int getStartBlockX();
+
+    int getStartBlockY();
+
+    int getStartBlockZ();
+
+    int getHorizontalCellBlockCount();
+
+    int getVerticalCellBlockCount();
+
+    boolean getIsInInterpolationLoop();
+
+    boolean getIsSamplingForCaches();
+
+    int getStartBiomeX();
+
+    int getStartBiomeZ();
+
+    int getHorizontalCellCount();
+
+    int getVerticalCellCount();
+
+    int getMinimumCellY();
+
+    int getCellBlockX();
+
+    int getCellBlockY();
+
+    int getCellBlockZ();
+
+    BlockState invokeSampleBlockState();
+
+    int getHorizontalBiomeEnd();
+
+    DensityFunctions.BeardifierOrMarker getBeardifying();
+
+    int getStartCellX();
+
+    int getStartCellZ();
+
+    Blender getBlender();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/base/mixin/access/IChunkNoiseSamplerDensityInterpolator.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/base/mixin/access/IChunkNoiseSamplerDensityInterpolator.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.base.mixin.access;
+
+public interface IChunkNoiseSamplerDensityInterpolator {
+
+    void invokeInterpolateX(double deltaX);
+
+    void invokeInterpolateY(double deltaY);
+
+    void invokeInterpolateZ(double deltaZ);
+
+    void invokeSwapBuffers();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/allocs/CachedOrNewBitsGetter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/allocs/CachedOrNewBitsGetter.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN ANY ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.allocs;
+
+import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
+import java.util.BitSet;
+import java.util.function.IntFunction;
+
+public final class CachedOrNewBitsGetter {
+    private static final IntFunction<BitSet> BITSET_CONSTRUCTOR = BitSet::new;
+    private static final ThreadLocal<Int2ObjectOpenHashMap<BitSet>> BITSETS = ThreadLocal.withInitial(Int2ObjectOpenHashMap::new);
+
+    private CachedOrNewBitsGetter() {
+    }
+
+    public static BitSet getCachedOrNewBitSet(final int bits) {
+        final BitSet bitSet = BITSETS.get().computeIfAbsent(bits, BITSET_CONSTRUCTOR);
+        bitSet.clear();
+        return bitSet;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/AstEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/AstEmitter.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast;
+
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public interface AstEmitter<T extends DensityFunction> {
+
+    AstNode toAst(T f);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/AstNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/AstNode.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast;
+
+public interface AstNode {
+
+    AstNode[] getChildren();
+
+    AstNode transform(AstTransformer transformer);
+
+    // data to be created as fields in generated code are only compared by class type
+    boolean relaxedEquals(AstNode o);
+
+    int relaxedHashCode();
+
+    default ReturnType getReturnType() {
+        return ReturnType.F64;
+    }
+
+    public enum ReturnType {
+        F64,
+        F32,
+        ;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/AstTransformer.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/AstTransformer.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast;
+
+public interface AstTransformer {
+
+    AstNode transform(AstNode astNode);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/EvalType.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/EvalType.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast;
+
+import com.ishland.c2me.opts.dfc.common.gen.jvm.vif.EachApplierVanillaInterface;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.NoiseChunk;
+
+public enum EvalType {
+    NORMAL, INTERPOLATION;
+
+    public static EvalType from(DensityFunction.FunctionContext pos) {
+        return pos instanceof NoiseChunk ? INTERPOLATION : NORMAL;
+    }
+
+    public static EvalType from(DensityFunction.ContextProvider applier) {
+        if (applier instanceof EachApplierVanillaInterface vif) {
+            return vif.getType();
+        }
+        return applier instanceof NoiseChunk ? INTERPOLATION : NORMAL;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/FrontendRegistry.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/FrontendRegistry.java
@@ -1,0 +1,72 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast;
+
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+import java.lang.invoke.VarHandle;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class FrontendRegistry<E extends AstEmitter<? extends DensityFunction>> {
+
+    private final Reference2ReferenceOpenHashMap<Class<? extends DensityFunction>, E> exactMatches = new Reference2ReferenceOpenHashMap<>();
+    private volatile boolean frozen = false;
+
+    public <N extends DensityFunction, E1 extends AstEmitter<N>> void registerExactMatch(Class<N> clazz, E1 emitter) {
+        if (!this.frozen) {
+            synchronized (this) {
+                if (!this.frozen) {
+                    VarHandle.fullFence();
+                    if (this.exactMatches.containsKey(clazz)) {
+                        throw new IllegalArgumentException("Already registered");
+                    }
+                    this.exactMatches.put(clazz, (E) emitter);
+                    VarHandle.fullFence();
+                    return;
+                }
+            }
+        }
+
+        throw new IllegalStateException("Already frozen");
+    }
+
+    public <N extends DensityFunction, E1 extends AstEmitter<N>> E1 getOptional(Class<N> clazz) {
+        if (!this.frozen) {
+            synchronized (this) {
+                if (!this.frozen) {
+                    this.frozen = true;
+                }
+            }
+            VarHandle.fullFence();
+        }
+
+        E exactMatch = this.exactMatches.get(clazz);
+        if (exactMatch != null) {
+            return (E1) exactMatch;
+        }
+
+        return null;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/McToAst.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/McToAst.java
@@ -1,0 +1,222 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast;
+
+import com.ishland.c2me.opts.dfc.common.ast.binary.AddNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.DivNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MaxNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MaxShortNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MinNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MinShortNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MulNode;
+import com.ishland.c2me.opts.dfc.common.ast.conversion.ToF64Node;
+import com.ishland.c2me.opts.dfc.common.ast.misc.BeardifierNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CacheLikeNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantF32Node;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CoordinateNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.DelegateNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.EndIslandsNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.FindTopSurfaceNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.InterpolatedNoiseSamplerNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.IntervalSelectNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.Multi2SingleNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.RangeChoiceNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.YClampedGradientNode;
+import com.ishland.c2me.opts.dfc.common.ast.noise.GenericShiftedNoiseNode;
+import com.ishland.c2me.opts.dfc.common.ast.spline.SplineNormalNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.AbsNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.CubeNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.NegMulNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.SquareNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.SqueezeNode;
+import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import net.minecraft.util.CubicSpline;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+import net.minecraft.world.level.levelgen.NoiseChunk;
+import net.minecraft.world.level.levelgen.synth.BlendedNoise;
+
+public class McToAst {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(McToAst.class);
+    public static final FrontendRegistry<AstEmitter<? extends DensityFunction>> REGISTRY = new FrontendRegistry<>();
+    private static final ConcurrentHashMap<Class<?>, AtomicLong> delegateStatistics = new ConcurrentHashMap<>();
+
+    static {
+        REGISTRY.registerExactMatch(NoiseChunk.BlendAlpha.class, f -> new ConstantNode(1.0));
+        REGISTRY.registerExactMatch(NoiseChunk.BlendOffset.class, f -> new ConstantNode(0.0));
+        REGISTRY.registerExactMatch(DensityFunctions.BlendAlpha.class, f -> new ConstantNode(1.0));
+        REGISTRY.registerExactMatch(DensityFunctions.BlendOffset.class, f -> new ConstantNode(0.0));
+
+        {
+            AstEmitter<? extends DensityFunctions.TwoArgumentSimpleFunction> emitter = f -> {
+                return switch (f.type()) {
+                    case ADD -> new AddNode(toAst(f.argument1()), toAst(f.argument2()));
+                    case MUL -> new MulNode(toAst(f.argument1()), toAst(f.argument2()));
+                    case MIN -> {
+                        double rightMin = f.argument2().minValue();
+                        if (f.argument1().minValue() < rightMin) {
+                            yield new MinShortNode(toAst(f.argument1()), toAst(f.argument2()), rightMin);
+                        } else {
+                            yield new MinNode(toAst(f.argument1()), toAst(f.argument2()));
+                        }
+                    }
+                    case MAX -> {
+                        double rightMax = f.argument2().maxValue();
+                        if (f.argument1().maxValue() > rightMax) {
+                            yield new MaxShortNode(toAst(f.argument1()), toAst(f.argument2()), rightMax);
+                        } else {
+                            yield new MaxNode(toAst(f.argument1()), toAst(f.argument2()));
+                        }
+                    }
+                };
+            };
+            REGISTRY.registerExactMatch(DensityFunctions.Ap2.class, (AstEmitter<DensityFunctions.Ap2>) emitter);
+            REGISTRY.registerExactMatch(DensityFunctions.MulOrAdd.class, (AstEmitter<DensityFunctions.MulOrAdd>) emitter);
+        }
+
+        REGISTRY.registerExactMatch(DensityFunctions.Clamp.class, f -> new MaxNode(new ConstantNode(f.minValue()), new MinNode(new ConstantNode(f.maxValue()), toAst(f.input()))));
+        REGISTRY.registerExactMatch(DensityFunctions.Constant.class, f -> new ConstantNode(f.value()));
+        REGISTRY.registerExactMatch(DensityFunctions.HolderHolder.class, f -> toAst(f.function().value()));
+        REGISTRY.registerExactMatch(DensityFunctions.Mapped.class, f -> {
+            return switch (f.type()) {
+                case ABS -> new AbsNode(toAst(f.input()));
+                case SQUARE -> new SquareNode(toAst(f.input()));
+                case CUBE -> new CubeNode(toAst(f.input()));
+                case HALF_NEGATIVE -> new NegMulNode(toAst(f.input()), 0.5);
+                case QUARTER_NEGATIVE -> new NegMulNode(toAst(f.input()), 0.25);
+                case INVERT -> new DivNode(new ConstantNode(1.0), toAst(f.input()));
+                case SQUEEZE -> new SqueezeNode(toAst(f.input()));
+            };
+        });
+        REGISTRY.registerExactMatch(DensityFunctions.RangeChoice.class, f -> new RangeChoiceNode(toAst(f.input()), f.minInclusive(), f.maxExclusive(), toAst(f.whenInRange()), toAst(f.whenOutOfRange())));
+
+        {
+            AstEmitter<? extends IFastCacheLike> emitter = f -> {
+                if ((Object) f instanceof DensityFunctions.Marker wrapping && wrapping.type() == DensityFunctions.Marker.Type.BlendDensity) {
+                    return toAst(f.c2me$getDelegate());
+                }
+                return new CacheLikeNode(f, toAst(f.c2me$getDelegate()));
+            };
+            REGISTRY.registerExactMatch(DensityFunctions.Marker.class, (AstEmitter<DensityFunctions.Marker>) (Object) emitter);
+            REGISTRY.registerExactMatch(NoiseChunk.Cache2D.class, (AstEmitter<NoiseChunk.Cache2D>) (Object) emitter);
+            REGISTRY.registerExactMatch(NoiseChunk.CacheOnce.class, (AstEmitter<NoiseChunk.CacheOnce>) (Object) emitter);
+            REGISTRY.registerExactMatch(NoiseChunk.NoiseInterpolator.class, (AstEmitter<NoiseChunk.NoiseInterpolator>) (Object) emitter);
+            REGISTRY.registerExactMatch(NoiseChunk.FlatCache.class, (AstEmitter<NoiseChunk.FlatCache>) (Object) emitter);
+        }
+
+        REGISTRY.registerExactMatch(DensityFunctions.ShiftedNoise.class, f -> {
+            return new GenericShiftedNoiseNode(
+                    new AddNode(new MulNode(CoordinateNode.AXIS_X, new ConstantNode(f.xzScale())), toAst(f.shiftX())),
+                    new AddNode(new MulNode(CoordinateNode.AXIS_Y, new ConstantNode(f.yScale())), toAst(f.shiftY())),
+                    new AddNode(new MulNode(CoordinateNode.AXIS_Z, new ConstantNode(f.xzScale())), toAst(f.shiftZ())),
+                    f.noise()
+            );
+        });
+        REGISTRY.registerExactMatch(DensityFunctions.Noise.class, f -> {
+            return new GenericShiftedNoiseNode(
+                    new MulNode(CoordinateNode.AXIS_X, new ConstantNode(f.xzScale())),
+                    new MulNode(CoordinateNode.AXIS_Y, new ConstantNode(f.yScale())),
+                    new MulNode(CoordinateNode.AXIS_Z, new ConstantNode(f.xzScale())),
+                    f.noise()
+            );
+        });
+        REGISTRY.registerExactMatch(DensityFunctions.Shift.class, f -> {
+            return new MulNode(
+                    new GenericShiftedNoiseNode(
+                            new MulNode(CoordinateNode.AXIS_X, new ConstantNode(0.25)),
+                            new MulNode(CoordinateNode.AXIS_Y, new ConstantNode(0.25)),
+                            new MulNode(CoordinateNode.AXIS_Z, new ConstantNode(0.25)),
+                            f.offsetNoise()
+                    ),
+                    new ConstantNode(4.0)
+            );
+        });
+        REGISTRY.registerExactMatch(DensityFunctions.ShiftA.class, f -> {
+            return new MulNode(
+                    new GenericShiftedNoiseNode(
+                            new MulNode(CoordinateNode.AXIS_X, new ConstantNode(0.25)),
+                            new ConstantNode(0.0),
+                            new MulNode(CoordinateNode.AXIS_Z, new ConstantNode(0.25)),
+                            f.offsetNoise()
+                    ),
+                    new ConstantNode(4.0)
+            );
+        });
+        REGISTRY.registerExactMatch(DensityFunctions.ShiftB.class, f -> {
+            return new MulNode(
+                    new GenericShiftedNoiseNode(
+                            new MulNode(CoordinateNode.AXIS_Z, new ConstantNode(0.25)),
+                            new MulNode(CoordinateNode.AXIS_X, new ConstantNode(0.25)),
+                            new ConstantNode(0.0),
+                            f.offsetNoise()
+                    ),
+                    new ConstantNode(4.0)
+            );
+        });
+        REGISTRY.registerExactMatch(DensityFunctions.YClampedGradient.class, f -> new YClampedGradientNode(f.fromY(), f.toY(), f.fromValue(), f.toValue()));
+        REGISTRY.registerExactMatch(DensityFunctions.IntervalSelect.class, f -> new IntervalSelectNode(toAst(f.input()), f.thresholds().toDoubleArray(), f.functions().stream().map(McToAst::toAst).toArray(AstNode[]::new)));
+        REGISTRY.registerExactMatch(DensityFunctions.Spline.class, f -> new Multi2SingleNode(new ToF64Node(toAst(f.spline()))));
+        REGISTRY.registerExactMatch(DensityFunctions.FindTopSurface.class, f -> new FindTopSurfaceNode(toAst(f.density()), toAst(f.upperBound()), new ConstantNode(f.lowerBound()), f.cellHeight()));
+
+        // Nodes intentionally handled by the delegate emitter on the JVM backend.
+        REGISTRY.registerExactMatch(DensityFunctions.EndIslandDensityFunction.class, EndIslandsNode::new);
+        REGISTRY.registerExactMatch(BlendedNoise.class, InterpolatedNoiseSamplerNode::new);
+        REGISTRY.registerExactMatch(DensityFunctions.BeardifierMarker.class, BeardifierNode::new);
+
+    }
+
+    public static AstNode toAst(CubicSpline<DensityFunctions.Spline.Coordinate> spline) {
+        return switch (spline) {
+            case CubicSpline.Constant<DensityFunctions.Spline.Coordinate> f -> new ConstantF32Node(f.value());
+            case CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> f -> new SplineNormalNode(
+                    toAst(f.coordinate().function()),
+                    f.locations().clone(),
+                    f.values().stream().map(McToAst::toAst).toArray(AstNode[]::new),
+                    f.derivatives().clone()
+            );
+        };
+    }
+
+    public static <T extends DensityFunction> AstNode toAst(T df) {
+        AstEmitter<T> emitter = (AstEmitter<T>) REGISTRY.getOptional(df.getClass());
+        if (emitter != null) {
+            return emitter.toAst(df);
+        } else {
+            long known = delegateStatistics.computeIfAbsent(df.getClass(), unused -> new AtomicLong(0L)).getAndIncrement();
+            if (known == 0) {
+                LOGGER.warn("warn_once: Generating DelegateNode for type: {}", df.getClass().toString());
+            }
+            return new DelegateNode(df);
+        }
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/AbstractBinaryNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/AbstractBinaryNode.java
@@ -1,0 +1,106 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public abstract class AbstractBinaryNode implements AstNode {
+
+    public final AstNode left;
+    public final AstNode right;
+
+    public AbstractBinaryNode(AstNode left, AstNode right) {
+        this.left = Objects.requireNonNull(left);
+        this.right = Objects.requireNonNull(right);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[]{left, right};
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbstractBinaryNode that = (AbstractBinaryNode) o;
+        return Objects.equals(left, that.left) && Objects.equals(right, that.right);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + left.hashCode();
+        result = 31 * result + right.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbstractBinaryNode that = (AbstractBinaryNode) o;
+        return left.relaxedEquals(that.left) && right.relaxedEquals(that.right);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + left.relaxedHashCode();
+        result = 31 * result + right.relaxedHashCode();
+
+        return result;
+    }
+
+    protected abstract AstNode newInstance(AstNode left, AstNode right);
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode left = this.left.transform(transformer);
+        AstNode right = this.right.transform(transformer);
+        if (left == this.left && right == this.right) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(newInstance(left, right));
+        }
+    }
+
+    public AstNode swapOperands() {
+        return newInstance(this.right, this.left);
+    }
+
+    public boolean canSwapOperandsSafely() {
+        return true;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/AddNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/AddNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class AddNode extends AbstractBinaryNode {
+
+    public AddNode(AstNode left, AstNode right) {
+        super(left, right);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode left, AstNode right) {
+        return new AddNode(left, right);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/DivNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/DivNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class DivNode extends AbstractBinaryNode {
+
+    public DivNode(AstNode left, AstNode right) {
+        super(left, right);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode left, AstNode right) {
+        return new DivNode(left, right);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MaxNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MaxNode.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class MaxNode extends AbstractBinaryNode {
+
+    public MaxNode(AstNode left, AstNode right) {
+        super(left, right);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode left, AstNode right) {
+        return new MaxNode(left, right);
+    }
+
+    @Override
+    public boolean canSwapOperandsSafely() {
+        return false;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MaxShortNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MaxShortNode.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class MaxShortNode extends AbstractBinaryNode {
+
+    public final double rightMax;
+
+    public MaxShortNode(AstNode left, AstNode right, double rightMax) {
+        super(left, right);
+        this.rightMax = rightMax;
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode left, AstNode right) {
+        return new MaxShortNode(left, right, this.rightMax);
+    }
+
+    @Override
+    public boolean canSwapOperandsSafely() {
+        return false;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MinNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MinNode.java
@@ -1,0 +1,45 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class MinNode extends AbstractBinaryNode {
+
+    public MinNode(AstNode left, AstNode right) {
+        super(left, right);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode left, AstNode right) {
+        return new MinNode(left, right);
+    }
+
+    @Override
+    public boolean canSwapOperandsSafely() {
+        return false;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MinShortNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MinShortNode.java
@@ -1,0 +1,48 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class MinShortNode extends AbstractBinaryNode {
+
+    public final double rightMin;
+
+    public MinShortNode(AstNode left, AstNode right, double rightMin) {
+        super(left, right);
+        this.rightMin = rightMin;
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode left, AstNode right) {
+        return new MinShortNode(left, right, this.rightMin);
+    }
+
+    @Override
+    public boolean canSwapOperandsSafely() {
+        return false;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MulNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/binary/MulNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.binary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class MulNode extends AbstractBinaryNode {
+
+    public MulNode(AstNode left, AstNode right) {
+        super(left, right);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode left, AstNode right) {
+        return new MulNode(left, right);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/conversion/ToF32Node.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/conversion/ToF32Node.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.conversion;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public class ToF32Node implements AstNode {
+
+    public final AstNode next;
+
+    public ToF32Node(AstNode next) {
+        this.next = Objects.requireNonNull(next);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[] { this.next };
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode next = this.next.transform(transformer);
+        if (next == this.next) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new ToF32Node(next));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ToF32Node that = (ToF32Node) o;
+        return Objects.equals(next, that.next);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ToF32Node that = (ToF32Node) o;
+        return next.relaxedEquals(that.next);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.relaxedHashCode();
+
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/conversion/ToF64Node.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/conversion/ToF64Node.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.conversion;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public class ToF64Node implements AstNode {
+
+    public final AstNode next;
+
+    public ToF64Node(AstNode next) {
+        this.next = Objects.requireNonNull(next);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[] { this.next };
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode next = this.next.transform(transformer);
+        if (next == this.next) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new ToF64Node(next));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ToF64Node that = (ToF64Node) o;
+        return Objects.equals(next, that.next);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ToF64Node that = (ToF64Node) o;
+        return next.relaxedEquals(that.next);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.relaxedHashCode();
+
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/BeardifierNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/BeardifierNode.java
@@ -1,0 +1,38 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.flowsched.util.Assertions;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+
+public class BeardifierNode extends DelegateNode {
+
+    public BeardifierNode(DensityFunction densityFunction) {
+        super(densityFunction);
+        Assertions.assertTrue(densityFunction == DensityFunctions.BeardifierMarker.INSTANCE);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/CacheLikeNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/CacheLikeNode.java
@@ -1,0 +1,135 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+
+public class CacheLikeNode implements AstNode {
+
+    private final IFastCacheLike cacheLike;
+    private final AstNode delegate;
+
+    public CacheLikeNode(IFastCacheLike cacheLike, AstNode delegate) {
+        this.cacheLike = cacheLike;
+        this.delegate = Objects.requireNonNull(delegate);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[]{this.delegate};
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode delegate = this.delegate.transform(transformer);
+        if (this.delegate == delegate) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new CacheLikeNode(this.cacheLike, delegate));
+        }
+    }
+
+    public IFastCacheLike getCacheLike() {
+        return cacheLike;
+    }
+
+    public AstNode getDelegate() {
+        return delegate;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CacheLikeNode that = (CacheLikeNode) o;
+        return equals(cacheLike, that.cacheLike) && Objects.equals(delegate, that.delegate);
+    }
+
+    private static boolean equals(IFastCacheLike a, IFastCacheLike b) {
+        if ((Object) a instanceof DensityFunctions.Marker wrappingA && (Object) b instanceof DensityFunctions.Marker wrappingB) {
+            return wrappingA.type() == wrappingB.type();
+        } else {
+            return a.equals(b);
+        }
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + hashCode(cacheLike);
+        result = 31 * result + delegate.hashCode();
+
+        return result;
+    }
+
+    private static int hashCode(IFastCacheLike o) {
+        if ((Object) o instanceof DensityFunctions.Marker wrapping) {
+            return wrapping.type().hashCode();
+        } else {
+            return o.hashCode();
+        }
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        CacheLikeNode that = (CacheLikeNode) o;
+        return relaxedEquals(cacheLike, that.cacheLike) && delegate.relaxedEquals(that.delegate);
+    }
+
+    private static boolean relaxedEquals(IFastCacheLike a, IFastCacheLike b) {
+        if ((Object) a instanceof DensityFunctions.Marker wrappingA && (Object) b instanceof DensityFunctions.Marker wrappingB) {
+            return wrappingA.type() == wrappingB.type();
+        } else {
+            return a.getClass() == b.getClass();
+        }
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + relaxedHashCode(this.cacheLike);
+        result = 31 * result + delegate.relaxedHashCode();
+
+        return result;
+    }
+
+    private static int relaxedHashCode(IFastCacheLike o) {
+        if ((Object) o instanceof DensityFunctions.Marker wrapping) {
+            return wrapping.type().hashCode();
+        } else {
+            return o.getClass().hashCode();
+        }
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/ConstantF32Node.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/ConstantF32Node.java
@@ -1,0 +1,86 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF32;
+
+public class ConstantF32Node implements ConstantNodeLike {
+
+    private final float value;
+
+    public ConstantF32Node(float value) {
+        this.value = value;
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[0];
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        return transformer.transform(this);
+    }
+
+    public float getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConstantF32Node that = (ConstantF32Node) o;
+        return Float.compare(value, that.value) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Float.hashCode(this.value);
+    }
+
+    @Override
+    public ReturnType getReturnType() {
+        return ReturnType.F32;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        return this.equals(o);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        return this.hashCode();
+    }
+
+    @Override
+    public ValuesMethodDef getDef() {
+        return new ValuesMethodDefF32(this.value);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/ConstantNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/ConstantNode.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+
+public class ConstantNode implements ConstantNodeLike {
+
+    private final double value;
+
+    public ConstantNode(double value) {
+        this.value = value;
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[0];
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        return transformer.transform(this);
+    }
+
+    public double getValue() {
+        return this.value;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        ConstantNode that = (ConstantNode) o;
+        return Double.compare(value, that.value) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        return Double.hashCode(this.value);
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        return this.equals(o);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        return this.hashCode();
+    }
+
+    @Override
+    public ValuesMethodDef getDef() {
+        return new ValuesMethodDefF64(this.value);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/ConstantNodeLike.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/ConstantNodeLike.java
@@ -1,0 +1,34 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+
+public interface ConstantNodeLike extends AstNode {
+
+    ValuesMethodDef getDef();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/CoordinateNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/CoordinateNode.java
@@ -1,0 +1,81 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public class CoordinateNode implements AstNode {
+    public static final CoordinateNode AXIS_X = new CoordinateNode(Axis.X);
+    public static final CoordinateNode AXIS_Y = new CoordinateNode(Axis.Y);
+    public static final CoordinateNode AXIS_Z = new CoordinateNode(Axis.Z);
+
+    public final Axis axis;
+
+    public CoordinateNode(Axis axis) {
+        this.axis = Objects.requireNonNull(axis);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[0];
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        return transformer.transform(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        CoordinateNode that = (CoordinateNode) o;
+        return axis == that.axis;
+    }
+
+    @Override
+    public int hashCode() {
+        return axis.hashCode();
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        return this.equals(o);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        return this.hashCode();
+    }
+
+    public enum Axis {
+        X,
+        Y,
+        Z,
+        ;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/DelegateNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/DelegateNode.java
@@ -1,0 +1,92 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class DelegateNode implements AstNode {
+
+//    private static final ConcurrentHashMap<Class<?>, LongAdder> statistics = new ConcurrentHashMap<>();
+
+    private final DensityFunction densityFunction;
+
+    public DelegateNode(DensityFunction densityFunction) {
+        this.densityFunction = Objects.requireNonNull(densityFunction);
+//        statistics.computeIfAbsent(densityFunction.getClass(), unused -> new LongAdder()).increment();
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[0];
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        return transformer.transform(this);
+    }
+
+    public DensityFunction getDelegate() {
+        return this.densityFunction;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DelegateNode that = (DelegateNode) o;
+        return Objects.equals(densityFunction, that.densityFunction);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + Objects.hashCode(this.getClass());
+        result = 31 * result + Objects.hashCode(densityFunction);
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        DelegateNode that = (DelegateNode) o;
+        return densityFunction.getClass() == that.densityFunction.getClass();
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + Objects.hashCode(this.getClass());
+        result = 31 * result + Objects.hashCode(densityFunction.getClass());
+
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/EndIslandsNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/EndIslandsNode.java
@@ -1,0 +1,57 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+
+public class EndIslandsNode extends DelegateNode {
+
+    public final DensityFunctions.EndIslandDensityFunction endIslands;
+
+    public EndIslandsNode(DensityFunctions.EndIslandDensityFunction endIslands) {
+        super(endIslands);
+        this.endIslands = endIslands;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        EndIslandsNode that = (EndIslandsNode) object;
+        return Objects.equals(endIslands, that.endIslands);
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        return this.equals(o);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        return this.hashCode();
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/FindTopSurfaceNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/FindTopSurfaceNode.java
@@ -1,0 +1,102 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public class FindTopSurfaceNode implements AstNode {
+
+    public final AstNode density;
+    public final AstNode upperBound;
+    public final AstNode lowerBound;
+    public final int cellHeight;
+
+    public FindTopSurfaceNode(AstNode density, AstNode upperBound, AstNode lowerBound, int cellHeight) {
+        this.density = Objects.requireNonNull(density);
+        this.upperBound = Objects.requireNonNull(upperBound);
+        this.lowerBound = Objects.requireNonNull(lowerBound);
+        this.cellHeight = cellHeight;
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[] {this.density, this.upperBound, this.lowerBound};
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode density = this.density.transform(transformer);
+        AstNode upperBound = this.upperBound.transform(transformer);
+        AstNode lowerBound = this.lowerBound.transform(transformer);
+        if (density == this.density && upperBound == this.upperBound && lowerBound == this.lowerBound) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new FindTopSurfaceNode(density, upperBound, lowerBound, this.cellHeight));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        FindTopSurfaceNode that = (FindTopSurfaceNode) o;
+        return cellHeight == that.cellHeight && Objects.equals(density, that.density) && Objects.equals(upperBound, that.upperBound) && Objects.equals(lowerBound, that.lowerBound);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + this.density.hashCode();
+        result = 31 * result + this.upperBound.hashCode();
+        result = 31 * result + this.lowerBound.hashCode();
+        result = 31 * result + Integer.hashCode(cellHeight);
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        FindTopSurfaceNode that = (FindTopSurfaceNode) o;
+        return cellHeight == that.cellHeight && this.density.relaxedEquals(that.density) && this.upperBound.relaxedEquals(that.upperBound) && this.lowerBound.relaxedEquals(that.lowerBound);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + this.density.relaxedHashCode();
+        result = 31 * result + this.upperBound.relaxedHashCode();
+        result = 31 * result + this.lowerBound.relaxedHashCode();
+        result = 31 * result + Integer.hashCode(cellHeight);
+
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/InterpolatedNoiseSamplerNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/InterpolatedNoiseSamplerNode.java
@@ -1,0 +1,58 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.synth.BlendedNoise;
+
+public class InterpolatedNoiseSamplerNode extends DelegateNode {
+
+    public final BlendedNoise sampler;
+
+    public InterpolatedNoiseSamplerNode(BlendedNoise sampler) {
+        super(sampler);
+        this.sampler = sampler;
+    }
+
+    @Override
+    public boolean equals(Object object) {
+        if (this == object) return true;
+        if (object == null || getClass() != object.getClass()) return false;
+        InterpolatedNoiseSamplerNode that = (InterpolatedNoiseSamplerNode) object;
+        return Objects.equals(sampler, that.sampler);
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        return this.equals(o);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        return this.hashCode();
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/IntervalSelectNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/IntervalSelectNode.java
@@ -1,0 +1,138 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Arrays;
+
+public class IntervalSelectNode implements AstNode {
+
+    public final AstNode input;
+    public final double[] thresholds;
+    public final AstNode[] functions;
+
+    public IntervalSelectNode(AstNode input, double[] thresholds, AstNode[] functions) {
+        this.input = input;
+        this.thresholds = thresholds;
+        this.functions = functions;
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        AstNode[] nodes = new AstNode[this.functions.length + 1];
+        nodes[0] = this.input;
+        System.arraycopy(this.functions, 0, nodes, 1, this.functions.length);
+        return nodes;
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        boolean changed = false;
+
+        AstNode transformedInput = this.input.transform(transformer);
+        if (transformedInput != this.input) changed |= true;
+
+        AstNode[] transformedFunctions = this.functions.clone();
+        for (int i = 0, transformedFunctionsLength = transformedFunctions.length; i < transformedFunctionsLength; i++) {
+            AstNode transformedFunction = transformedFunctions[i];
+            transformedFunctions[i] = transformedFunction.transform(transformer);
+            if (transformedFunctions[i] != transformedFunction) changed |= true;
+        }
+
+        if (!changed) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new IntervalSelectNode(transformedInput, this.thresholds.clone(), transformedFunctions));
+        }
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        IntervalSelectNode that = (IntervalSelectNode) o;
+        if (!this.input.relaxedEquals(that.input) || !Arrays.equals(this.thresholds, that.thresholds)) return false;
+        if (this.functions == that.functions)
+            return true;
+        if (this.functions == null || that.functions == null)
+            return false;
+        int length = this.functions.length;
+        if (that.functions.length != length)
+            return false;
+
+        for (int i = 0; i < length; i++) {
+            AstNode e1 = this.functions[i];
+            AstNode e2 = that.functions[i];
+            if (!e1.relaxedEquals(e2))
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+        result = 31 * result + input.relaxedHashCode();
+        result = 31 * result + Arrays.hashCode(thresholds);
+        for (AstNode function : functions) {
+            result = 31 * result + function.relaxedHashCode();
+        }
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        IntervalSelectNode that = (IntervalSelectNode) o;
+        if (!this.input.equals(that.input) || !Arrays.equals(this.thresholds, that.thresholds)) return false;
+        if (this.functions == that.functions)
+            return true;
+        if (this.functions == null || that.functions == null)
+            return false;
+        int length = this.functions.length;
+        if (that.functions.length != length)
+            return false;
+
+        for (int i = 0; i < length; i++) {
+            AstNode e1 = this.functions[i];
+            AstNode e2 = that.functions[i];
+            if (!e1.equals(e2))
+                return false;
+        }
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + input.hashCode();
+        result = 31 * result + Arrays.hashCode(thresholds);
+        for (AstNode function : functions) {
+            result = 31 * result + function.hashCode();
+        }
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/Multi2SingleNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/Multi2SingleNode.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public class Multi2SingleNode implements AstNode {
+
+    public final AstNode next;
+
+    public Multi2SingleNode(AstNode next) {
+        this.next = Objects.requireNonNull(next);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[] { this.next };
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode next = this.next.transform(transformer);
+        if (next == this.next) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new Multi2SingleNode(next));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Multi2SingleNode that = (Multi2SingleNode) o;
+        return Objects.equals(next, that.next);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        Multi2SingleNode that = (Multi2SingleNode) o;
+        return next.relaxedEquals(that.next);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.relaxedHashCode();
+
+        return result;
+    }
+
+    @Override
+    public ReturnType getReturnType() {
+        return this.next.getReturnType();
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/RangeChoiceNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/RangeChoiceNode.java
@@ -1,0 +1,108 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public class RangeChoiceNode implements AstNode {
+
+    public final AstNode input;
+    public final double minInclusive;
+    public final double maxExclusive;
+    public final AstNode whenInRange;
+    public final AstNode whenOutOfRange;
+
+    public RangeChoiceNode(AstNode input, double minInclusive, double maxExclusive, AstNode whenInRange, AstNode whenOutOfRange) {
+        this.input = Objects.requireNonNull(input);
+        this.minInclusive = minInclusive;
+        this.maxExclusive = maxExclusive;
+        this.whenInRange = Objects.requireNonNull(whenInRange);
+        this.whenOutOfRange = Objects.requireNonNull(whenOutOfRange);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[]{this.input, this.whenInRange, this.whenOutOfRange};
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode input = this.input.transform(transformer);
+        AstNode whenInRange = this.whenInRange.transform(transformer);
+        AstNode whenOutOfRange = this.whenOutOfRange.transform(transformer);
+        if (this.input == input && this.whenInRange == whenInRange && this.whenOutOfRange == whenOutOfRange) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new RangeChoiceNode(input, minInclusive, maxExclusive, whenInRange, whenOutOfRange));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RangeChoiceNode that = (RangeChoiceNode) o;
+        return Double.compare(minInclusive, that.minInclusive) == 0 && Double.compare(maxExclusive, that.maxExclusive) == 0 && Objects.equals(input, that.input) && Objects.equals(whenInRange, that.whenInRange) && Objects.equals(whenOutOfRange, that.whenOutOfRange);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + this.input.hashCode();
+        result = 31 * result + Double.hashCode(this.minInclusive);
+        result = 31 * result + Double.hashCode(this.maxExclusive);
+        result = 31 * result + this.whenInRange.hashCode();
+        result = 31 * result + this.whenOutOfRange.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RangeChoiceNode that = (RangeChoiceNode) o;
+        return Double.compare(minInclusive, that.minInclusive) == 0 && Double.compare(maxExclusive, that.maxExclusive) == 0 && input.relaxedEquals(that.input) && whenInRange.relaxedEquals(that.whenInRange) && whenOutOfRange.relaxedEquals(that.whenOutOfRange);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + this.input.relaxedHashCode();
+        result = 31 * result + Double.hashCode(this.minInclusive);
+        result = 31 * result + Double.hashCode(this.maxExclusive);
+        result = 31 * result + this.whenInRange.relaxedHashCode();
+        result = 31 * result + this.whenOutOfRange.relaxedHashCode();
+
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/RootNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/RootNode.java
@@ -1,0 +1,90 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public class RootNode implements AstNode {
+
+    public final AstNode next;
+
+    public RootNode(AstNode next) {
+        this.next = Objects.requireNonNull(next);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[]{next};
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode next = this.next.transform(transformer);
+        if (next == this.next) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new RootNode(next));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RootNode that = (RootNode) o;
+        return Objects.equals(next, that.next);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        RootNode that = (RootNode) o;
+        return next.relaxedEquals(that.next);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + next.relaxedHashCode();
+
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/YClampedGradientNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/misc/YClampedGradientNode.java
@@ -1,0 +1,84 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+public class YClampedGradientNode implements AstNode {
+
+    public final double fromY;
+    public final double toY;
+    public final double fromValue;
+    public final double toValue;
+
+    public YClampedGradientNode(double fromY, double toY, double fromValue, double toValue) {
+        this.fromY = fromY;
+        this.toY = toY;
+        this.fromValue = fromValue;
+        this.toValue = toValue;
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[0];
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        return transformer.transform(this);
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        YClampedGradientNode that = (YClampedGradientNode) o;
+        return Double.compare(fromY, that.fromY) == 0 && Double.compare(toY, that.toY) == 0 && Double.compare(fromValue, that.fromValue) == 0 && Double.compare(toValue, that.toValue) == 0;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + Double.hashCode(fromY);
+        result = 31 * result + Double.hashCode(toY);
+        result = 31 * result + Double.hashCode(fromValue);
+        result = 31 * result + Double.hashCode(toValue);
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        return this.equals(o);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        return this.hashCode();
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/noise/GenericShiftedNoiseNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/noise/GenericShiftedNoiseNode.java
@@ -1,0 +1,95 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.noise;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class GenericShiftedNoiseNode implements AstNode {
+    public final AstNode inputX;
+    public final AstNode inputY;
+    public final AstNode inputZ;
+    public final DensityFunction.NoiseHolder noise;
+
+    public GenericShiftedNoiseNode(AstNode inputX, AstNode inputY, AstNode inputZ, DensityFunction.NoiseHolder noise) {
+        this.inputX = Objects.requireNonNull(inputX);
+        this.inputY = Objects.requireNonNull(inputY);
+        this.inputZ = Objects.requireNonNull(inputZ);
+        this.noise = Objects.requireNonNull(noise);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[] { this.inputX, this.inputY, this.inputZ };
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode inputX = this.inputX.transform(transformer);
+        AstNode inputY = this.inputY.transform(transformer);
+        AstNode inputZ = this.inputZ.transform(transformer);
+        if (inputX == this.inputX && inputY == this.inputY && inputZ == this.inputZ) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new GenericShiftedNoiseNode(inputX, inputY, inputZ, this.noise));
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericShiftedNoiseNode that = (GenericShiftedNoiseNode) o;
+        return inputX.equals(that.inputX) && inputY.equals(that.inputY) && inputZ.equals(that.inputZ) && noise.equals(that.noise);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + inputX.hashCode();
+        result = 31 * result + inputY.hashCode();
+        result = 31 * result + inputZ.hashCode();
+        result = 31 * result + noise.hashCode();
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        GenericShiftedNoiseNode that = (GenericShiftedNoiseNode) o;
+        return inputX.relaxedEquals(that.inputX) && inputY.relaxedEquals(that.inputY) && inputZ.relaxedEquals(that.inputZ) && noise.equals(that.noise);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+        result = 31 * result + inputX.relaxedHashCode();
+        result = 31 * result + inputY.relaxedHashCode();
+        result = 31 * result + inputZ.relaxedHashCode();
+        result = 31 * result + noise.hashCode();
+        return result;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/OptoPasses.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/OptoPasses.java
@@ -1,0 +1,83 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.opto;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.ast.opto.passes.BranchElimination;
+import com.ishland.c2me.opts.dfc.common.ast.opto.passes.CacheElimination;
+import com.ishland.c2me.opts.dfc.common.ast.opto.passes.FoldConstants;
+import com.ishland.c2me.opts.dfc.common.ast.opto.passes.TreeNormalization;
+import org.jspecify.annotations.NonNull;
+import org.jspecify.annotations.Nullable;
+
+public class OptoPasses {
+
+    private static final AstTransformer[] PASSES = new AstTransformer[] {
+            TreeNormalization.INSTANCE,
+            FoldConstants.INSTANCE,
+            BranchElimination.INSTANCE,
+    };
+
+    private static final AstTransformer[] PASSES_OCL = new AstTransformer[] {
+            CacheElimination.INSTANCE,
+            TreeNormalization.INSTANCE,
+            FoldConstants.INSTANCE,
+            BranchElimination.INSTANCE,
+    };
+
+    public static AstPair optimize(AstNode astNode) {
+        return optimize0(astNode, PASSES);
+    }
+
+    public static AstPair optimizeOCL(AstNode astNode) {
+        return optimize0(astNode, PASSES_OCL);
+    }
+
+    private static @NonNull AstPair optimize0(AstNode astNode, AstTransformer[] passes) {
+        AstNode unoptimized = astNode;
+        AstNode res = astNode;
+        do {
+            astNode = res;
+            for (AstTransformer pass : passes) {
+                res = res.transform(pass);
+            }
+        } while (res != astNode);
+        return new AstPair(unoptimized, res);
+    }
+
+    public record AstPair(@Nullable AstNode unoptimized, @NonNull AstNode optimized) {
+
+        public static AstPair ofOptimizedOnly(AstNode optimized) {
+            return new AstPair(null, optimized);
+        }
+
+        public AstNode tryUnoptimized() {
+            return this.unoptimized != null ? this.unoptimized : this.optimized;
+        }
+
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/BranchElimination.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/BranchElimination.java
@@ -1,0 +1,61 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.opto.passes;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.RangeChoiceNode;
+
+public class BranchElimination implements AstTransformer {
+
+    public static final BranchElimination INSTANCE = new BranchElimination();
+
+    private BranchElimination() {
+    }
+
+    @Override
+    public AstNode transform(AstNode astNode) {
+        return switch (astNode) {
+            case RangeChoiceNode rangeChoiceNode -> {
+                if (rangeChoiceNode.input instanceof ConstantNode c) {
+                    if (c.getValue() >= rangeChoiceNode.minInclusive && c.getValue() < rangeChoiceNode.maxExclusive) {
+                        yield rangeChoiceNode.whenInRange;
+                    } else {
+                        yield rangeChoiceNode.whenOutOfRange;
+                    }
+                }
+
+                if (rangeChoiceNode.whenInRange.equals(rangeChoiceNode.whenOutOfRange)) {
+                    yield rangeChoiceNode.whenInRange;
+                }
+
+                yield rangeChoiceNode;
+            }
+            default -> astNode;
+        };
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/CacheElimination.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/CacheElimination.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.opto.passes;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CacheLikeNode;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+
+public class CacheElimination implements AstTransformer {
+
+    public static final CacheElimination INSTANCE = new CacheElimination();
+
+    private CacheElimination() {
+    }
+
+    @Override
+    public AstNode transform(AstNode astNode) {
+        if (astNode instanceof CacheLikeNode cacheLikeNode && (Object) cacheLikeNode.getCacheLike() instanceof DensityFunctions.Marker wrapping) {
+            if (wrapping.type() == DensityFunctions.Marker.Type.FlatCache) {
+                AstNode transformed = cacheLikeNode.getDelegate().transform(CacheLikeStripper.INSTANCE);
+                if (transformed != cacheLikeNode.getDelegate()) {
+                    return new CacheLikeNode(cacheLikeNode.getCacheLike(), transformed);
+                }
+            }
+        }
+
+        return astNode;
+    }
+
+
+    private static class CacheLikeStripper implements AstTransformer {
+        private static CacheLikeStripper INSTANCE = new CacheLikeStripper();
+
+        @Override
+        public AstNode transform(AstNode astNode) {
+            if (astNode instanceof CacheLikeNode cacheLikeNode) {
+                return cacheLikeNode.getDelegate();
+            }
+
+            return astNode;
+        }
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/FoldConstants.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/FoldConstants.java
@@ -1,0 +1,198 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.opto.passes;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.ast.binary.AddNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MaxNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MaxShortNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MinNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MinShortNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MulNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CacheLikeNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.*;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.ZeroUtils;
+import net.minecraft.util.Mth;
+
+public class FoldConstants implements AstTransformer {
+
+    public static final FoldConstants INSTANCE = new FoldConstants();
+
+    private FoldConstants() {
+    }
+
+    @Override
+    public AstNode transform(AstNode astNode) {
+        return switch (astNode) {
+            case AddNode addNode -> {
+                if (addNode.left instanceof ConstantNode c1 && addNode.right instanceof ConstantNode c2) {
+                    yield new ConstantNode(c1.getValue() + c2.getValue());
+                }
+
+                // TreeNormalization: const left
+                if (addNode.left instanceof ConstantNode c && c.getValue() == 0.0 && !ZeroUtils.isPositiveZero(c.getValue())) {
+                    yield addNode.right;
+                }
+
+                yield addNode;
+            }
+            case MulNode mulNode -> {
+                if (mulNode.left instanceof ConstantNode c1 && mulNode.right instanceof ConstantNode c2) {
+                    yield new ConstantNode(c1.getValue() * c2.getValue());
+                }
+
+                if (mulNode.left instanceof ConstantNode c && c.getValue() == 0.0) { // special case defined in vanilla
+                    yield new ConstantNode(0.0);
+                }
+
+                // TreeNormalization: const left
+                if (mulNode.left instanceof ConstantNode c && c.getValue() == 1.0) {
+                    yield mulNode.right;
+                }
+
+                yield mulNode;
+            }
+            case MaxNode maxNode -> {
+                if (maxNode.left instanceof ConstantNode c1 && maxNode.right instanceof ConstantNode c2) {
+                    yield new ConstantNode(Math.max(c1.getValue(), c2.getValue()));
+                }
+
+                yield maxNode;
+            }
+            case MaxShortNode maxShortNode -> {
+                if (maxShortNode.left instanceof ConstantNode c1 && c1.getValue() >= maxShortNode.rightMax) {
+                    yield c1;
+                }
+
+                if (maxShortNode.left instanceof ConstantNode || maxShortNode.right instanceof ConstantNode) {
+                    yield new MaxNode(maxShortNode.left, maxShortNode.right);
+                }
+
+                yield maxShortNode;
+            }
+            case MinNode minNode -> {
+                if (minNode.left instanceof ConstantNode c1 && minNode.right instanceof ConstantNode c2) {
+                    yield new ConstantNode(Math.min(c1.getValue(), c2.getValue()));
+                }
+
+                yield minNode;
+            }
+            case MinShortNode minShortNode -> {
+                if (minShortNode.left instanceof ConstantNode c1 && c1.getValue() <= minShortNode.rightMin) {
+                    yield c1;
+                }
+
+                if (minShortNode.left instanceof ConstantNode || minShortNode.right instanceof ConstantNode) {
+                    yield new MinNode(minShortNode.left, minShortNode.right);
+                }
+
+                yield minShortNode;
+            }
+            case AbsNode absNode -> {
+                if (absNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(Math.abs(c.getValue()));
+                }
+
+                yield absNode;
+            }
+            case CeilNode ceilNode -> {
+                if (ceilNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(Math.ceil(c.getValue()));
+                }
+
+                yield ceilNode;
+            }
+            case CosNode cosNode -> {
+                if (cosNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(Math.cos(c.getValue()));
+                }
+
+                yield cosNode;
+            }
+            case CubeNode cubeNode -> {
+                if (cubeNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(c.getValue() * c.getValue() * c.getValue());
+                }
+
+                yield cubeNode;
+            }
+            case FloorNode floorNode -> {
+                if (floorNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(Math.floor(c.getValue()));
+                }
+
+                yield floorNode;
+            }
+            case NegMulNode negMulNode -> {
+                if (negMulNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(c.getValue() > 0.0 ? c.getValue() : c.getValue() * negMulNode.negMul);
+                }
+
+                yield negMulNode;
+            }
+            case SinNode sinNode -> {
+                if (sinNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(Math.sin(c.getValue()));
+                }
+
+                yield sinNode;
+            }
+            case SqrtNode sqrtNode -> {
+                if (sqrtNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(Math.sqrt(c.getValue()));
+                }
+
+                yield sqrtNode;
+            }
+            case SquareNode squareNode -> {
+                if (squareNode.operand instanceof ConstantNode c) {
+                    yield new ConstantNode(c.getValue() * c.getValue());
+                }
+
+                yield squareNode;
+            }
+            case SqueezeNode squeezeNode -> {
+                if (squeezeNode.operand instanceof ConstantNode c) {
+                    double v = Mth.clamp(c.getValue(), -1.0, 1.0);
+                    yield new ConstantNode(v / 2.0 - v * v * v / 24.0);
+                }
+
+                yield squeezeNode;
+            }
+            case CacheLikeNode cacheLikeNode -> {
+                if (cacheLikeNode.getCacheLike().c2me$isActualCache() && cacheLikeNode.getDelegate() instanceof ConstantNode c) {
+                    yield c;
+                }
+
+                yield cacheLikeNode;
+            }
+            case null -> throw new NullPointerException();
+            default -> astNode;
+        };
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/TreeNormalization.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/opto/passes/TreeNormalization.java
@@ -1,0 +1,50 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.opto.passes;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.ast.binary.AbstractBinaryNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+
+public class TreeNormalization implements AstTransformer {
+
+    public static final TreeNormalization INSTANCE = new TreeNormalization();
+
+    private TreeNormalization() {
+    }
+
+    @Override
+    public AstNode transform(AstNode astNode) {
+        if (astNode instanceof AbstractBinaryNode binaryNode && binaryNode.canSwapOperandsSafely()) {
+            if (binaryNode.right instanceof ConstantNode && !(binaryNode.left instanceof ConstantNode)) {
+                // fp add, mul, max, min are commutative
+                return binaryNode.swapOperands();
+            }
+        }
+
+        return astNode;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/spline/SplineAstNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/spline/SplineAstNode.java
@@ -1,0 +1,232 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.spline;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+import com.ishland.c2me.opts.dfc.common.ast.McToAst;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+import java.util.Arrays;
+import java.util.Map;
+import net.minecraft.util.CubicSpline;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+
+public class SplineAstNode implements AstNode {
+
+    public final CubicSpline<DensityFunctions.Spline.Coordinate> spline;
+    public final Reference2ReferenceOpenHashMap<DensityFunctions.Spline.Coordinate, AstNode> children = new Reference2ReferenceOpenHashMap<>();
+
+    public SplineAstNode(CubicSpline<DensityFunctions.Spline.Coordinate> spline) {
+        this.spline = spline;
+        this.populateChildrenMap(this.spline);
+    }
+
+    private SplineAstNode(CubicSpline<DensityFunctions.Spline.Coordinate> spline, Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> children) {
+        this.spline = spline;
+        this.children.putAll(children);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return this.children.values().toArray(AstNode[]::new);
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        boolean isModified = false;
+        Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> modified = new Reference2ReferenceOpenHashMap<>(this.children);
+        for (Map.Entry<DensityFunctions.Spline.Coordinate, AstNode> entry : modified.entrySet()) {
+            AstNode node = entry.getValue();
+            AstNode transformed = node.transform(transformer);
+            if (node != transformed) {
+                isModified = true;
+                entry.setValue(transformed);
+            }
+        }
+        if (isModified) {
+            return transformer.transform(new SplineAstNode(this.spline, modified));
+        } else {
+            return transformer.transform(this);
+        }
+    }
+
+    public static AstNode needOptimizeSameLocationFunction(SplineAstNode node, CubicSpline<DensityFunctions.Spline.Coordinate>... splines) {
+        if (splines.length == 0) return null;
+
+        AstNode a1Ast;
+        if (splines[0] instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> spline0) {
+            a1Ast = node.children.get(spline0.coordinate());
+            if (a1Ast instanceof ConstantNode) {
+                return null;
+            }
+        } else {
+            return null;
+        }
+
+        for (int i = 1, splinesLength = splines.length; i < splinesLength; i++) {
+            CubicSpline<DensityFunctions.Spline.Coordinate> b = splines[i];
+            if (b instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> b1) {
+                AstNode b1Ast = node.children.get(b1.coordinate());
+                if (!a1Ast.equals(b1Ast)) {
+                    return null;
+                }
+            } else {
+                return null;
+            }
+        }
+
+        return a1Ast;
+    }
+
+    private void populateChildrenMap(CubicSpline<DensityFunctions.Spline.Coordinate> a) {
+        if (a instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> a1) {
+            for (CubicSpline<DensityFunctions.Spline.Coordinate> spline : a1.values()) {
+                populateChildrenMap(spline);
+            }
+            DensityFunctions.Spline.Coordinate locationFunction = a1.coordinate();
+            this.children.put(locationFunction, McToAst.toAst(locationFunction.function()));
+        }
+    }
+
+    private static boolean deepEquals(CubicSpline<DensityFunctions.Spline.Coordinate> a,
+                                      Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> childrenA,
+                                      CubicSpline<DensityFunctions.Spline.Coordinate> b,
+                                      Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> childrenB) {
+        if (a instanceof CubicSpline.Constant<DensityFunctions.Spline.Coordinate> a1 &&
+                b instanceof CubicSpline.Constant<DensityFunctions.Spline.Coordinate> b1) {
+            return a1.value() == b1.value();
+        } else if (a instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> a1 &&
+                b instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> b1) {
+            boolean equals1 = Arrays.equals(a1.derivatives(), b1.derivatives()) &&
+                    Arrays.equals(a1.locations(), b1.locations()) &&
+                    a1.values().size() == b1.values().size() &&
+                    childrenA.get(a1.coordinate()).equals(childrenB.get(b1.coordinate()));
+            if (!equals1) return false;
+            int size = a1.values().size();
+            for (int i = 0; i < size; i++) {
+                if (!deepEquals(a1.values().get(i), childrenA, b1.values().get(i), childrenB)) {
+                    return false;
+                }
+            }
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static boolean deepRelaxedEquals(CubicSpline<DensityFunctions.Spline.Coordinate> a,
+                                             Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> childrenA,
+                                             CubicSpline<DensityFunctions.Spline.Coordinate> b,
+                                             Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> childrenB) {
+        if (a instanceof CubicSpline.Constant<DensityFunctions.Spline.Coordinate> a1 &&
+                b instanceof CubicSpline.Constant<DensityFunctions.Spline.Coordinate> b1) {
+            return a1.value() == b1.value();
+        } else if (a instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> a1 &&
+                b instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> b1) {
+            boolean equals1 = Arrays.equals(a1.derivatives(), b1.derivatives()) &&
+                    Arrays.equals(a1.locations(), b1.locations()) &&
+                    a1.values().size() == b1.values().size() &&
+                    childrenA.get(a1.coordinate()).relaxedEquals(childrenB.get(b1.coordinate()));
+            if (!equals1) return false;
+            int size = a1.values().size();
+            for (int i = 0; i < size; i++) {
+                if (!deepRelaxedEquals(a1.values().get(i), childrenA, b1.values().get(i), childrenB)) {
+                    return false;
+                }
+            }
+
+            return true;
+        } else {
+            return false;
+        }
+    }
+
+    private static int deepHashcode(CubicSpline<DensityFunctions.Spline.Coordinate> a, Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> childrenA) {
+        if (a instanceof CubicSpline.Constant<DensityFunctions.Spline.Coordinate> a1) {
+            return Float.hashCode(a1.value());
+        } else if (a instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> a1) {
+            int result = 1;
+
+            result = 31 * result + Arrays.hashCode(a1.derivatives());
+            result = 31 * result + Arrays.hashCode(a1.locations());
+            for (CubicSpline<DensityFunctions.Spline.Coordinate> spline : a1.values()) {
+                result = 31 * result + deepHashcode(spline, childrenA);
+            }
+            result = 31 * result + childrenA.get(a1.coordinate()).hashCode();
+
+            return result;
+        } else {
+            return a.hashCode();
+        }
+    }
+
+    private static int deepRelaxedHashcode(CubicSpline<DensityFunctions.Spline.Coordinate> a, Reference2ReferenceMap<DensityFunctions.Spline.Coordinate, AstNode> childrenA) {
+        if (a instanceof CubicSpline.Constant<DensityFunctions.Spline.Coordinate> a1) {
+            return Float.hashCode(a1.value());
+        } else if (a instanceof CubicSpline.Multipoint<DensityFunctions.Spline.Coordinate> a1) {
+            int result = 1;
+
+            result = 31 * result + Arrays.hashCode(a1.derivatives());
+            result = 31 * result + Arrays.hashCode(a1.locations());
+            for (CubicSpline<DensityFunctions.Spline.Coordinate> spline : a1.values()) {
+                result = 31 * result + deepRelaxedHashcode(spline, childrenA);
+            }
+            result = 31 * result + childrenA.get(a1.coordinate()).relaxedHashCode();
+
+            return result;
+        } else {
+            return a.hashCode();
+        }
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SplineAstNode that = (SplineAstNode) o;
+        return deepEquals(this.spline, this.children, that.spline, that.children);
+    }
+
+    @Override
+    public int hashCode() {
+        return deepHashcode(this.spline, this.children);
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        SplineAstNode that = (SplineAstNode) o;
+        return deepRelaxedEquals(this.spline, this.children, that.spline, that.children);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        return deepRelaxedHashcode(this.spline, this.children);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/spline/SplineNormalNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/spline/SplineNormalNode.java
@@ -1,0 +1,148 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.spline;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Arrays;
+import java.util.Objects;
+
+public class SplineNormalNode implements AstNode {
+
+    public final AstNode locationFunction;
+    public final float[] locations;
+    public final AstNode[] values;
+    public final float[] derivatives;
+
+    public SplineNormalNode(AstNode locationFunction, float[] locations, AstNode[] values, float[] derivatives) {
+        this.locationFunction = Objects.requireNonNull(locationFunction);
+        this.locations = Objects.requireNonNull(locations);
+        this.values = Objects.requireNonNull(values);
+        this.derivatives = Objects.requireNonNull(derivatives);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        AstNode[] nodes = new AstNode[this.values.length + 1];
+        nodes[0] = this.locationFunction;
+        System.arraycopy(this.values, 0, nodes, 1, this.values.length);
+        return nodes;
+    }
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        boolean changed = false;
+
+        AstNode transformedLocationFunction = this.locationFunction.transform(transformer);
+        if (transformedLocationFunction != this.locationFunction) changed |= true;
+
+        AstNode[] transformedValues = this.values.clone();
+        for (int i = 0, transformedValuesLength = transformedValues.length; i < transformedValuesLength; i++) {
+            AstNode transformedFunction = transformedValues[i];
+            transformedValues[i] = transformedFunction.transform(transformer);
+            if (transformedValues[i] != transformedFunction) changed |= true;
+        }
+
+        if (!changed) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(new SplineNormalNode(transformedLocationFunction, this.locations.clone(), transformedValues, this.derivatives.clone()));
+        }
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        SplineNormalNode that = (SplineNormalNode) o;
+        if (!locationFunction.relaxedEquals(that.locationFunction)) return false;
+        if (!Arrays.equals(locations, that.locations)) return false;
+
+        int length = this.values.length;
+        if (that.values.length != length)
+            return false;
+        for (int i = 0; i < length; i++) {
+            AstNode e1 = this.values[i];
+            AstNode e2 = that.values[i];
+            if (!e1.relaxedEquals(e2))
+                return false;
+        }
+
+        if (!Arrays.equals(derivatives, that.derivatives)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+        result = 31 * result + locationFunction.relaxedHashCode();
+        result = 31 * result + Arrays.hashCode(locations);
+        for (AstNode value : values) {
+            result = 31 * result + value.relaxedHashCode();
+        }
+        result = 31 * result + Arrays.hashCode(derivatives);
+        return result;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (o == null || getClass() != o.getClass()) return false;
+        SplineNormalNode that = (SplineNormalNode) o;
+        if (!locationFunction.equals(that.locationFunction)) return false;
+        if (!Arrays.equals(locations, that.locations)) return false;
+
+        int length = this.values.length;
+        if (that.values.length != length)
+            return false;
+        for (int i = 0; i < length; i++) {
+            AstNode e1 = this.values[i];
+            AstNode e2 = that.values[i];
+            if (!e1.equals(e2))
+                return false;
+        }
+
+        if (!Arrays.equals(derivatives, that.derivatives)) return false;
+
+        return true;
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+        result = 31 * result + locationFunction.hashCode();
+        result = 31 * result + Arrays.hashCode(locations);
+        for (AstNode value : values) {
+            result = 31 * result + value.hashCode();
+        }
+        result = 31 * result + Arrays.hashCode(derivatives);
+        return result;
+    }
+
+    @Override
+    public ReturnType getReturnType() {
+        return ReturnType.F32;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/AbsNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/AbsNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class AbsNode extends AbstractUnaryNode {
+
+    public AbsNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new AbsNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/AbstractUnaryNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/AbstractUnaryNode.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.AstTransformer;
+
+import java.util.Objects;
+
+public abstract class AbstractUnaryNode implements AstNode {
+
+    public final AstNode operand;
+
+    public AbstractUnaryNode(AstNode operand) {
+        this.operand = Objects.requireNonNull(operand);
+    }
+
+    @Override
+    public AstNode[] getChildren() {
+        return new AstNode[]{operand};
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbstractUnaryNode that = (AbstractUnaryNode) o;
+        return Objects.equals(operand, that.operand);
+    }
+
+    @Override
+    public int hashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + operand.hashCode();
+
+        return result;
+    }
+
+    @Override
+    public boolean relaxedEquals(AstNode o) {
+        if (this == o) return true;
+        if (o == null || getClass() != o.getClass()) return false;
+        AbstractUnaryNode that = (AbstractUnaryNode) o;
+        return operand.relaxedEquals(that.operand);
+    }
+
+    @Override
+    public int relaxedHashCode() {
+        int result = 1;
+
+        result = 31 * result + this.getClass().hashCode();
+        result = 31 * result + operand.relaxedHashCode();
+
+        return result;
+    }
+
+    protected abstract AstNode newInstance(AstNode operand);
+
+    @Override
+    public AstNode transform(AstTransformer transformer) {
+        AstNode operand = this.operand.transform(transformer);
+        if (this.operand == operand) {
+            return transformer.transform(this);
+        } else {
+            return transformer.transform(newInstance(operand));
+        }
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/CeilNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/CeilNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class CeilNode extends AbstractUnaryNode {
+
+    public CeilNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new CeilNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/CosNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/CosNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class CosNode extends AbstractUnaryNode {
+
+    public CosNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new CosNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/CubeNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/CubeNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class CubeNode extends AbstractUnaryNode {
+
+    public CubeNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new CubeNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/FloorNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/FloorNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class FloorNode extends AbstractUnaryNode {
+
+    public FloorNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new FloorNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/NegMulNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/NegMulNode.java
@@ -1,0 +1,43 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class NegMulNode extends AbstractUnaryNode {
+
+    public final double negMul;
+
+    public NegMulNode(AstNode operand, double negMul) {
+        super(operand);
+        this.negMul = negMul;
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new NegMulNode(operand, this.negMul);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SinNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SinNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class SinNode extends AbstractUnaryNode {
+
+    public SinNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new SinNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SqrtNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SqrtNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class SqrtNode extends AbstractUnaryNode {
+
+    public SqrtNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new SqrtNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SquareNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SquareNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class SquareNode extends AbstractUnaryNode {
+
+    public SquareNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new SquareNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SqueezeNode.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ast/unary/SqueezeNode.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ast.unary;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public class SqueezeNode extends AbstractUnaryNode {
+
+    public SqueezeNode(AstNode operand) {
+        super(operand);
+    }
+
+    @Override
+    protected AstNode newInstance(AstNode operand) {
+        return new SqueezeNode(operand);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IBlendingAwareVisitor.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IBlendingAwareVisitor.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ducks;
+
+public interface IBlendingAwareVisitor {
+
+    boolean c2me$isBlendingEnabled();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/ICompiledCachingAwareVisitor.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/ICompiledCachingAwareVisitor.java
@@ -1,0 +1,47 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ducks;
+
+import com.ishland.c2me.opts.dfc.common.gen.jvm.CompiledEntry;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ArgumentVisitor;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public interface ICompiledCachingAwareVisitor {
+
+    CompiledEntry c2me$visitIfAbsent(CompiledEntry entry, ArgumentVisitor visitor);
+
+    public static ArgumentVisitor c2me$getArgumentVisitor(DensityFunction.Visitor visitor) {
+        return next -> {
+            if (next instanceof DensityFunction df) {
+                return df.mapAll(visitor);
+            }
+            if (next instanceof DensityFunction.NoiseHolder noise) {
+                return visitor.visitNoise(noise);
+            }
+            return next;
+        };
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/ICoordinatesFilling.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/ICoordinatesFilling.java
@@ -1,0 +1,31 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ducks;
+
+public interface ICoordinatesFilling {
+
+    void c2me$fillCoordinates(int[] x, int[] y, int[] z);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IDfcObjectCacheCapable.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IDfcObjectCacheCapable.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ducks;
+
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+
+public interface IDfcObjectCacheCapable {
+
+    DfcObjectCache c2me$getDfcObjectCache();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IFastCacheLike.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IFastCacheLike.java
@@ -1,0 +1,51 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ducks;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public interface IFastCacheLike extends DensityFunction {
+
+    public static final long CACHE_MISS_NAN_BITS = 0x7ffddb972d486a4fL;
+
+    double c2me$getCached(int x, int y, int z, EvalType evalType);
+
+    boolean c2me$getCached(double[] res, int[] x, int[] y, int[] z, EvalType evalType);
+
+    void c2me$cache(int x, int y, int z, EvalType evalType, double cached);
+
+    void c2me$cache(double[] res, int[] x, int[] y, int[] z, EvalType evalType);
+
+    boolean c2me$isActualCache();
+
+    String c2me$describeCacheLike();
+
+    DensityFunction c2me$getDelegate();
+
+    // called by generated code
+    DensityFunction c2me$withDelegate(DensityFunction delegate);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IPreloadedCoordinates.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/IPreloadedCoordinates.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ducks;
+
+public interface IPreloadedCoordinates {
+
+    int[] c2me$getXArray();
+
+    int[] c2me$getYArray();
+
+    int[] c2me$getZArray();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/NoiseRouterExtension.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/ducks/NoiseRouterExtension.java
@@ -1,0 +1,40 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.ducks;
+
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.NoiseRouter;
+
+public interface NoiseRouterExtension {
+
+    DensityFunction c2me$getFinalFinalDensity();
+
+    void c2me$setFinalFinalDensity(DensityFunction densityFunction);
+
+    void c2me$setOriginalNoiseRouter(NoiseRouter originalNoiseRouter);
+
+    NoiseRouter c2me$getOriginalNoiseRouter();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/CodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/CodeEmitter.java
@@ -1,0 +1,30 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public interface CodeEmitter<T extends AstNode> {
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/CodeGenRegistry.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/CodeGenRegistry.java
@@ -1,0 +1,73 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceOpenHashMap;
+
+import java.lang.invoke.VarHandle;
+
+public class CodeGenRegistry<E extends CodeEmitter<? extends AstNode>> {
+
+    private final Reference2ReferenceOpenHashMap<Class<? extends AstNode>, E> exactMatches = new Reference2ReferenceOpenHashMap<>();
+    private volatile boolean frozen = false;
+
+    public <N extends AstNode, E1 extends CodeEmitter<N>> void registerExactMatch(Class<N> clazz, E1 emitter) {
+        if (!this.frozen) {
+            synchronized (this) {
+                if (!this.frozen) {
+                    VarHandle.fullFence();
+                    if (this.exactMatches.containsKey(clazz)) {
+                        throw new IllegalArgumentException("Already registered");
+                    }
+                    this.exactMatches.put(clazz, (E) emitter);
+                    VarHandle.fullFence();
+                    return;
+                }
+            }
+        }
+
+        throw new IllegalStateException("Already frozen");
+    }
+
+    public <N extends AstNode, E1 extends CodeEmitter<N>> E1 get(Class<N> clazz) {
+        if (!this.frozen) {
+            synchronized (this) {
+                if (!this.frozen) {
+                    this.frozen = true;
+                }
+            }
+            VarHandle.fullFence();
+        }
+
+        E exactMatch = this.exactMatches.get(clazz);
+        if (exactMatch != null) {
+            return (E1) exactMatch;
+        }
+
+        throw new UnsupportedOperationException("Unknown class %s".formatted(clazz));
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/DelegatingBlendingCachingAwareVisitor.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/DelegatingBlendingCachingAwareVisitor.java
@@ -1,0 +1,66 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen;
+
+import com.ishland.c2me.opts.dfc.common.ducks.IBlendingAwareVisitor;
+import com.ishland.c2me.opts.dfc.common.ducks.ICompiledCachingAwareVisitor;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.CompiledEntry;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ArgumentVisitor;
+import java.util.Map;
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class DelegatingBlendingCachingAwareVisitor implements IBlendingAwareVisitor, ICompiledCachingAwareVisitor, DensityFunction.Visitor {
+
+    private final DensityFunction.Visitor delegate;
+    private final Map<CompiledEntry, CompiledEntry> backingCache;
+    private final boolean blendingEnabled;
+
+    public DelegatingBlendingCachingAwareVisitor(DensityFunction.Visitor delegate, Map<CompiledEntry, CompiledEntry> backingCache, boolean blendingEnabled) {
+        this.delegate = Objects.requireNonNull(delegate);
+        this.backingCache = Objects.requireNonNull(backingCache);
+        this.blendingEnabled = blendingEnabled;
+    }
+
+    @Override
+    public DensityFunction apply(DensityFunction densityFunction) {
+        return this.delegate.apply(densityFunction);
+    }
+
+    @Override
+    public DensityFunction.NoiseHolder visitNoise(DensityFunction.NoiseHolder noiseDensityFunction) {
+        return this.delegate.visitNoise(noiseDensityFunction);
+    }
+
+    @Override
+    public boolean c2me$isBlendingEnabled() {
+        return this.blendingEnabled;
+    }
+
+    @Override
+    public CompiledEntry c2me$visitIfAbsent(CompiledEntry entry, ArgumentVisitor visitor) {
+        return this.backingCache.computeIfAbsent(entry, compiledEntry -> compiledEntry.newInstance(compiledEntry.getArgs(), visitor));
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/AbstractCompiledDensityFunction.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/AbstractCompiledDensityFunction.java
@@ -1,0 +1,166 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.google.common.base.Suppliers;
+import com.ishland.c2me.base.mixin.access.IChunkNoiseSampler;
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ducks.IBlendingAwareVisitor;
+import com.ishland.c2me.opts.dfc.common.ducks.ICoordinatesFilling;
+import com.ishland.c2me.opts.dfc.common.ducks.IDfcObjectCacheCapable;
+import com.ishland.c2me.opts.dfc.common.ducks.IPreloadedCoordinates;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.IMultiMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ISingleMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.vif.EachApplierVanillaInterface;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.function.Supplier;
+import net.minecraft.util.KeyDispatchDataCodec;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.NoiseChunk;
+
+public abstract class AbstractCompiledDensityFunction implements DensityFunction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(AbstractCompiledDensityFunction.class);
+
+    protected final Supplier<DensityFunction> blendingFallback;
+
+    public AbstractCompiledDensityFunction(DensityFunction blendingFallback) {
+        this(unwrapFallback(blendingFallback));
+    }
+
+    public AbstractCompiledDensityFunction(Supplier<DensityFunction> blendingFallback) {
+        this.blendingFallback = blendingFallback;
+    }
+
+    protected static Supplier<DensityFunction> unwrapFallback(DensityFunction densityFunction) {
+        if (densityFunction instanceof AbstractCompiledDensityFunction scdf) {
+            return scdf.blendingFallback;
+        } else {
+            return densityFunction != null ? Suppliers.ofInstance(densityFunction) : null;
+        }
+    }
+
+    public abstract ISingleMethod getSingleMethod();
+
+    public abstract IMultiMethod getMultiMethod();
+
+    @Override
+    public double compute(FunctionContext pos) {
+        ISingleMethod singleMethod1 = this.getSingleMethod();
+        if (singleMethod1 == null || (pos instanceof NoiseChunk sampler && !((IChunkNoiseSampler) sampler).getBlender().isEmpty())) {
+            DensityFunction fallback = this.getFallback();
+            if (fallback == null) {
+                throw new IllegalStateException("blendingFallback is no more");
+            }
+            return fallback.compute(pos);
+        }
+        DfcObjectCache cache = pos instanceof IDfcObjectCacheCapable cacheCapable ? cacheCapable.c2me$getDfcObjectCache() : DfcObjectCache.Noop.INSTANCE;
+        return singleMethod1.evalSingle(pos.blockX(), pos.blockY(), pos.blockZ(), EvalType.from(pos), cache);
+    }
+
+    @Override
+    public void fillArray(double[] densities, ContextProvider applier) {
+        IMultiMethod multiMethod1 = this.getMultiMethod();
+        if (multiMethod1 == null || (applier instanceof NoiseChunk sampler && !((IChunkNoiseSampler) sampler).getBlender().isEmpty())) {
+            DensityFunction fallback = this.getFallback();
+            if (fallback == null) {
+                throw new IllegalStateException("blendingFallback is no more");
+            }
+            fallback.fillArray(densities, applier);
+            return;
+        }
+        if (applier instanceof EachApplierVanillaInterface vanillaInterface) {
+            multiMethod1.evalMulti(densities, vanillaInterface.getX(), vanillaInterface.getY(), vanillaInterface.getZ(), EvalType.from(applier), vanillaInterface.c2me$getDfcObjectCache());
+            return;
+        }
+
+        DfcObjectCache cache = applier instanceof IDfcObjectCacheCapable cacheCapable ? cacheCapable.c2me$getDfcObjectCache() : DfcObjectCache.Noop.INSTANCE;
+        int[] x;
+        int[] y;
+        int[] z;
+        boolean allocatedOnDemand;
+        if (applier instanceof IPreloadedCoordinates preloadedCoordinates) {
+            x = preloadedCoordinates.c2me$getXArray();
+            y = preloadedCoordinates.c2me$getYArray();
+            z = preloadedCoordinates.c2me$getZArray();
+            allocatedOnDemand = false;
+        } else {
+            x = cache.getIntArray(densities.length, false);
+            y = cache.getIntArray(densities.length, false);
+            z = cache.getIntArray(densities.length, false);
+            if (applier instanceof ICoordinatesFilling coordinatesFilling) {
+                coordinatesFilling.c2me$fillCoordinates(x, y, z);
+            } else {
+                for (int i = 0; i < densities.length; i ++) {
+                    FunctionContext pos = applier.forIndex(i);
+                    x[i] = pos.blockX();
+                    y[i] = pos.blockY();
+                    z[i] = pos.blockZ();
+                }
+            }
+            allocatedOnDemand = true;
+        }
+        try {
+            multiMethod1.evalMulti(densities, x, y, z, EvalType.from(applier), cache);
+        } finally {
+            if (allocatedOnDemand) {
+                cache.recycle(x);
+                cache.recycle(y);
+                cache.recycle(z);
+            }
+        }
+    }
+
+    @Override
+    public abstract DensityFunction mapChildren(Visitor visitor);
+
+    @Override
+    public abstract DensityFunction mapAll(Visitor visitor);
+
+    @Override
+    public double minValue() {
+        DensityFunction fallback = this.getFallback();
+        return fallback != null ? fallback.minValue() : Double.NEGATIVE_INFINITY;
+    }
+
+    @Override
+    public double maxValue() {
+        DensityFunction fallback = this.getFallback();
+        return fallback != null ? fallback.maxValue() : Double.POSITIVE_INFINITY;
+    }
+
+    @Override
+    public KeyDispatchDataCodec<? extends DensityFunction> codec() {
+        throw new UnsupportedOperationException();
+    }
+
+    protected DensityFunction getFallback() {
+        return this.blendingFallback != null ? this.blendingFallback.get() : null;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeEmitter.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.gen.CodeEmitter;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public interface BytecodeEmitter<T extends AstNode> extends CodeEmitter<T> {
+
+    void doBytecodeGenSingle(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer);
+
+    void doBytecodeGenMulti(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGen.java
@@ -1,0 +1,894 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ast.McToAst;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CacheLikeNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNodeLike;
+import com.ishland.c2me.opts.dfc.common.ast.conversion.ToF64Node;
+import com.ishland.c2me.opts.dfc.common.ast.misc.YClampedGradientNode;
+import com.ishland.c2me.opts.dfc.common.ast.opto.OptoPasses;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ArgumentVisitor;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.IMultiMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ISingleMethod;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF32;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import com.ishland.flowsched.util.Assertions;
+import it.unimi.dsi.fastutil.Hash;
+import it.unimi.dsi.fastutil.Pair;
+import it.unimi.dsi.fastutil.ints.IntObjectPair;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceMap;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceMaps;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenCustomHashMap;
+import it.unimi.dsi.fastutil.objects.Object2ReferenceOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2ObjectOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceLinkedOpenHashMap;
+import it.unimi.dsi.fastutil.objects.Reference2ReferenceMap;
+import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
+import org.objectweb.asm.ClassWriter;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.AnalyzerAdapter;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+import java.lang.reflect.InvocationTargetException;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Comparator;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.function.Consumer;
+import java.util.function.IntConsumer;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import net.minecraft.world.level.levelgen.DensityFunctions;
+
+public class BytecodeGen {
+
+    private static final AtomicLong ordinal = new AtomicLong();
+
+    public static final Hash.Strategy<AstNode> RELAXED_STRATEGY = new Hash.Strategy<>() {
+        @Override
+        public int hashCode(AstNode o) {
+            return o.relaxedHashCode();
+        }
+
+        @Override
+        public boolean equals(AstNode a, AstNode b) {
+            return a.relaxedEquals(b);
+        }
+    };
+    private static final Object2ReferenceMap<AstNode, Class<?>> compilationCache = Object2ReferenceMaps.synchronize(new Object2ReferenceOpenCustomHashMap<>(RELAXED_STRATEGY));
+
+//    public static DensityFunction compile(String name, DensityFunction densityFunction, Reference2ReferenceMap<DensityFunction, OptoPasses.AstPair> optoCache, Reference2ReferenceMap<DensityFunction, DensityFunction> tempCache) {
+//        DensityFunction cached = tempCache.get(densityFunction);
+//        if (cached != null) {
+//            return cached;
+//        }
+//        OptoPasses.AstPair pair = optoCache.computeIfAbsent(densityFunction, (DensityFunction df) -> OptoPasses.optimize(McToAst.toAst(df)));
+//        if (pair.optimized() instanceof ConstantNode constantNode) {
+//            return DensityFunctions.constant(constantNode.getValue());
+//        } else if (pair.optimized() instanceof YClampedGradientNode) {
+//            return densityFunction;
+//        }
+//        CompiledDensityFunction compiled = new CompiledDensityFunction(compile0(name, pair), densityFunction);
+//        tempCache.put(densityFunction, compiled);
+//        return compiled;
+//    }
+
+    public static Context initContext() {
+        ClassWriter writer = new ClassWriter(ClassWriter.COMPUTE_MAXS | ClassWriter.COMPUTE_FRAMES);
+        String name = String.format("DfcCompiled_%d", ordinal.getAndIncrement());
+        writer.visit(Opcodes.V21, Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL, name, null, Type.getInternalName(Object.class), new String[]{Type.getInternalName(CompiledEntry.class)});
+        return new Context(writer, name);
+    }
+
+    public static CompiledEntry finalizeCompilation(Context genContext) {
+        Object[] args = genContext.args.entrySet().stream()
+                .sorted(Comparator.comparingInt(o -> o.getValue().ordinal()))
+                .map(Map.Entry::getKey)
+                .toArray(Object[]::new);
+
+        genConstructor(genContext);
+        genGetArgs(genContext);
+        genNewInstance(genContext);
+        genGetRootsUnsafe(genContext);
+
+        byte[] bytes = genContext.classWriter.toByteArray();
+        Class<?> defined = defineClass(genContext.className, bytes);
+//        compilationCache.put(node, defined);
+
+        CompiledEntry compiledEntry;
+        try {
+            compiledEntry = (CompiledEntry) defined.getConstructor(Object[].class, ArgumentVisitor.class).newInstance(new Object[]{args, ArgumentVisitor.IDENTITY});
+        } catch (InstantiationException | IllegalAccessException | InvocationTargetException | NoSuchMethodException e) {
+            throw new RuntimeException(e);
+        }
+
+        for (CompiledDensityFunction delayedInit : genContext.delayedInits) {
+            delayedInit.initFrom(compiledEntry);
+        }
+        genContext.delayedInits.clear();
+
+        return compiledEntry;
+    }
+
+    private static void genConstructor(Context context) {
+        InstructionAdapter m = new InstructionAdapter(
+                new AnalyzerAdapter(
+                        context.className,
+                        Opcodes.ACC_PUBLIC,
+                        "<init>",
+                        Context.CONSTRUCTOR_DESC,
+                        context.classWriter.visitMethod(
+                                Opcodes.ACC_PUBLIC,
+                                "<init>",
+                                Context.CONSTRUCTOR_DESC,
+                                null,
+                                null
+                        )
+                )
+        );
+
+        Label start = new Label();
+        Label end = new Label();
+        m.visitLabel(start);
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.invokespecial(Type.getInternalName(Object.class), "<init>", Type.getMethodDescriptor(Type.VOID_TYPE), false);
+
+        for (Map.Entry<Object, Context.FieldRecord> entry : context.args.entrySet().stream().sorted(Comparator.comparingInt(o -> o.getValue().ordinal())).toList()) {
+            String name = entry.getValue().name();
+            Class<?> type = entry.getValue().type();
+            int ordinal = entry.getValue().ordinal();
+            String postProcessMethod = entry.getValue().postProcessMethod;
+
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+
+            {
+                m.load(2, InstructionAdapter.OBJECT_TYPE);
+
+                {
+                    if (postProcessMethod != null) {
+                        m.load(0, InstructionAdapter.OBJECT_TYPE);
+                    }
+
+                    {
+                        m.load(1, InstructionAdapter.OBJECT_TYPE);
+                        m.iconst(ordinal);
+                        m.aload(InstructionAdapter.OBJECT_TYPE);
+                        m.checkcast(Type.getType(type));
+                    }
+
+                    if (postProcessMethod != null) {
+                        m.invokevirtual(context.className, postProcessMethod, Context.POSTPROCESSING_DESC, false);
+                        m.checkcast(Type.getType(type));
+                    }
+                }
+
+                m.invokeinterface(Type.getInternalName(ArgumentVisitor.class), "apply", Type.getMethodDescriptor(Type.getType(Object.class), Type.getType(Object.class)));
+                m.checkcast(Type.getType(type));
+            }
+
+            m.putfield(context.className, name, Type.getDescriptor(type));
+        }
+
+        {
+            context.classWriter.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL, "roots", Type.getDescriptor(SubCompiledDensityFunction[].class), null, null);
+
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+
+            {
+                m.iconst(context.roots.size());
+                m.newarray(Type.getType(SubCompiledDensityFunction.class));
+
+                ReferenceArrayList<Context.MethodPair> roots = context.roots;
+                for (int i = 0, rootsSize = roots.size(); i < rootsSize; i++) {
+                    Context.MethodPair root = roots.get(i);
+                    m.dup();
+                    m.iconst(i);
+
+                    {
+                        m.anew(Type.getType(SubCompiledDensityFunction.class));
+                        m.dup();
+
+                        m.load(0, InstructionAdapter.OBJECT_TYPE);
+                        m.invokedynamic(
+                                "evalSingle",
+                                Type.getMethodDescriptor(Type.getType(ISingleMethod.class), Type.getType(context.classDesc)),
+                                new Handle(
+                                        Opcodes.H_INVOKESTATIC,
+                                        "java/lang/invoke/LambdaMetafactory",
+                                        "metafactory",
+                                        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                                        false
+                                ),
+                                new Object[]{
+                                        Type.getMethodType(Context.SINGLE_DESC_F64),
+                                        new Handle(
+                                                Opcodes.H_INVOKEVIRTUAL,
+                                                context.className,
+                                                root.single(),
+                                                Context.SINGLE_DESC_F64,
+                                                false
+                                        ),
+                                        Type.getMethodType(Context.SINGLE_DESC_F64)
+                                }
+                        );
+
+                        m.load(0, InstructionAdapter.OBJECT_TYPE);
+                        m.invokedynamic(
+                                "evalMulti",
+                                Type.getMethodDescriptor(Type.getType(IMultiMethod.class), Type.getType(context.classDesc)),
+                                new Handle(
+                                        Opcodes.H_INVOKESTATIC,
+                                        "java/lang/invoke/LambdaMetafactory",
+                                        "metafactory",
+                                        "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                                        false
+                                ),
+                                new Object[]{
+                                        Type.getMethodType(Context.MULTI_DESC_F64),
+                                        new Handle(
+                                                Opcodes.H_INVOKEVIRTUAL,
+                                                context.className,
+                                                root.multi(),
+                                                Context.MULTI_DESC_F64,
+                                                false
+                                        ),
+                                        Type.getMethodType(Context.MULTI_DESC_F64)
+                                }
+                        );
+
+                        m.aconst(null);
+                        m.checkcast(Type.getType(DensityFunction.class));
+
+                        m.invokespecial(
+                                Type.getInternalName(SubCompiledDensityFunction.class),
+                                "<init>",
+                                Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(ISingleMethod.class), Type.getType(IMultiMethod.class), Type.getType(DensityFunction.class)),
+                                false
+                        );
+
+                        m.checkcast(Type.getType(SubCompiledDensityFunction.class));
+                    }
+
+                    m.astore(Type.getType(SubCompiledDensityFunction.class));
+                }
+            }
+
+            m.putfield(context.className, "roots", Type.getDescriptor(SubCompiledDensityFunction[].class));
+        }
+
+        m.areturn(Type.VOID_TYPE);
+        m.visitLabel(end);
+        m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
+        m.visitLocalVariable("args", Type.getDescriptor(Object[].class), null, start, end, 1);
+        m.visitLocalVariable("visitor", Type.getDescriptor(ArgumentVisitor.class), null, start, end, 2);
+        m.visitMaxs(0, 0);
+    }
+
+    private static void genGetArgs(Context context) {
+        InstructionAdapter m = new InstructionAdapter(
+                new AnalyzerAdapter(
+                        context.className,
+                        Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                        "getArgs",
+                        Type.getMethodDescriptor(Type.getType(Object[].class)),
+                        context.classWriter.visitMethod(
+                                Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                                "getArgs",
+                                Type.getMethodDescriptor(Type.getType(Object[].class)),
+                                null,
+                                null
+                        )
+                )
+        );
+
+        Label start = new Label();
+        Label end = new Label();
+        m.visitLabel(start);
+
+        m.iconst(context.args.size());
+        m.newarray(InstructionAdapter.OBJECT_TYPE);
+
+        int index = 0;
+        for (Map.Entry<Object, Context.FieldRecord> entry : context.args.entrySet().stream().sorted(Comparator.comparingInt(o -> o.getValue().ordinal())).toList()) {
+            String name = entry.getValue().name();
+            Class<?> type = entry.getValue().type();
+
+            m.dup();
+            m.iconst(index ++);
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(context.className, name, Type.getDescriptor(type));
+            m.astore(InstructionAdapter.OBJECT_TYPE);
+        }
+
+        m.areturn(InstructionAdapter.OBJECT_TYPE);
+        m.visitLabel(end);
+        m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
+        m.visitLocalVariable("args", Type.getDescriptor(Object[].class), null, start, end, 1);
+        m.visitMaxs(0, 0);
+    }
+
+    private static void genNewInstance(Context context) {
+        InstructionAdapter m = new InstructionAdapter(
+                new AnalyzerAdapter(
+                        context.className,
+                        Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                        "newInstance",
+                        Type.getMethodDescriptor(Type.getType(CompiledEntry.class), Type.getType(Object[].class), Type.getType(ArgumentVisitor.class)),
+                        context.classWriter.visitMethod(
+                                Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                                "newInstance",
+                                Type.getMethodDescriptor(Type.getType(CompiledEntry.class), Type.getType(Object[].class), Type.getType(ArgumentVisitor.class)),
+                                null,
+                                null
+                        )
+                )
+        );
+        Label start = new Label();
+        Label end = new Label();
+        m.visitLabel(start);
+
+        m.anew(Type.getType(context.classDesc));
+        m.dup();
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.load(2, InstructionAdapter.OBJECT_TYPE);
+        m.invokespecial(context.className, "<init>", Context.CONSTRUCTOR_DESC, false);
+        m.areturn(InstructionAdapter.OBJECT_TYPE);
+
+        m.visitLabel(end);
+        m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
+        m.visitLocalVariable("args", Type.getDescriptor(Object[].class), null, start, end, 1);
+        m.visitLocalVariable("visitor", Type.getDescriptor(ArgumentVisitor.class), null, start, end, 2);
+        m.visitMaxs(0, 0);
+    }
+
+    private static void genGetRootsUnsafe(Context context) {
+        InstructionAdapter m = new InstructionAdapter(
+                new AnalyzerAdapter(
+                        context.className,
+                        Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                        "getRootsUnsafe",
+                        Type.getMethodDescriptor(Type.getType(SubCompiledDensityFunction[].class)),
+                        context.classWriter.visitMethod(
+                                Opcodes.ACC_PUBLIC | Opcodes.ACC_FINAL,
+                                "getRootsUnsafe",
+                                Type.getMethodDescriptor(Type.getType(SubCompiledDensityFunction[].class)),
+                                null,
+                                null
+                        )
+                )
+        );
+        Label start = new Label();
+        Label end = new Label();
+        m.visitLabel(start);
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, "roots", Type.getDescriptor(SubCompiledDensityFunction[].class));
+        m.areturn(InstructionAdapter.OBJECT_TYPE);
+
+        m.visitLabel(end);
+        m.visitLocalVariable("this", context.classDesc, null, start, end, 0);
+        m.visitMaxs(0, 0);
+    }
+
+//    private static void genFields(Context context) {
+//        for (Map.Entry<Object, Context.FieldRecord> entry : context.args.entrySet().stream().sorted(Comparator.comparingInt(o -> o.getValue().ordinal())).toList()) {
+//            String name = entry.getValue().name();
+//            Class<?> type = entry.getValue().type();
+//
+//            context.classWriter.visitField(
+//                    Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL,
+//                    name,
+//                    Type.getDescriptor(type),
+//                    null,
+//                    null
+//            );
+//        }
+//    }
+
+    private static Class<?> defineClass(String className, byte[] bytes) {
+        ClassLoader classLoader = new ClassLoader(BytecodeGen.class.getClassLoader()) {
+            @Override
+            public Class<?> loadClass(String name) throws ClassNotFoundException {
+                if (name.equals(className)) {
+                    return super.defineClass(name, bytes, 0, bytes.length);
+                }
+
+                return super.loadClass(name);
+            }
+        };
+
+        try {
+            return classLoader.loadClass(className);
+        } catch (ClassNotFoundException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    public static class Context {
+        public static final String SINGLE_DESC_F64 = Type.getMethodDescriptor(Type.getType(double.class), Type.getType(int.class), Type.getType(int.class), Type.getType(int.class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class));
+        public static final String SINGLE_DESC_F32 = Type.getMethodDescriptor(Type.getType(float.class), Type.getType(int.class), Type.getType(int.class), Type.getType(int.class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class));
+        public static final String MULTI_DESC_F64 = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class));
+        public static final String MULTI_DESC_F32 = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(float[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class));
+        public static final String POSTPROCESSING_DESC = Type.getMethodDescriptor(Type.getType(Object.class), Type.getType(Object.class));
+        public static final String CONSTRUCTOR_DESC = Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(Object[].class), Type.getType(ArgumentVisitor.class));
+        public final ClassWriter classWriter;
+        public final String className;
+        public final String classDesc;
+        private int methodIdx = 0;
+        private final Object2ReferenceOpenHashMap<AstNode, String> singleMethods = new Object2ReferenceOpenHashMap<>();
+        private final Object2ReferenceOpenHashMap<AstNode, String> multiMethods = new Object2ReferenceOpenHashMap<>();
+        private final Reference2ObjectOpenHashMap<Object, FieldRecord> args = new Reference2ObjectOpenHashMap<>();
+        private final ReferenceArrayList<MethodPair> roots = new ReferenceArrayList<>();
+        private final ReferenceArrayList<CompiledDensityFunction> delayedInits = new ReferenceArrayList<>();
+        private final Reference2ReferenceMap<DensityFunction, OptoPasses.AstPair> optoCache = new Reference2ReferenceLinkedOpenHashMap<>();
+
+        public Context(ClassWriter classWriter, String className) {
+            this.classWriter = Objects.requireNonNull(classWriter);
+            this.className = Objects.requireNonNull(className);
+            this.classDesc = String.format("L%s;", this.className);
+        }
+
+        private static String getSingleDesc(AstNode.ReturnType returnType) {
+            return switch (returnType) {
+                case F64 -> SINGLE_DESC_F64;
+                case F32 -> SINGLE_DESC_F32;
+            };
+        }
+
+        private static String getMultiDesc(AstNode.ReturnType returnType) {
+            return switch (returnType) {
+                case F64 -> MULTI_DESC_F64;
+                case F32 -> MULTI_DESC_F32;
+            };
+        }
+
+        private static ValuesMethodDef makeValuesMethodDef(String name, AstNode.ReturnType returnType) {
+            return switch (returnType) {
+                case F64 -> new ValuesMethodDefF64(name);
+                case F32 -> new ValuesMethodDefF32(name);
+            };
+        }
+
+        public String nextMethodName() {
+            return String.format("method_%d", methodIdx++);
+        }
+
+        public String nextMethodName(String suffix) {
+            return String.format("method_%d_%s", methodIdx++, suffix);
+        }
+
+        public String nextMethodName(AstNode node) {
+            StringBuilder b = new StringBuilder();
+            b.append(node.getClass().getSimpleName());
+            if (node instanceof CacheLikeNode cacheLikeNode && (Object) cacheLikeNode.getCacheLike() instanceof DensityFunctions.Marker wrapping) {
+                b.append('_').append(wrapping.type().getSerializedName());
+            }
+            return nextMethodName(b.toString());
+        }
+
+        private void validateNodeType(AstNode node, AstNode.ReturnType returnType) {
+            if (node.getReturnType() != returnType) {
+                throw new IllegalArgumentException("Invalid descriptor: tried to store %s into %s".formatted(node.getReturnType(), returnType));
+            }
+        }
+
+        public ValuesMethodDef newSingleMethod(AstNode node) {
+            if (node instanceof ConstantNodeLike constantNodeLike) {
+                return constantNodeLike.getDef();
+            } else {
+                String generated = this.newSingleMethodUnoptimized(node);
+                return makeValuesMethodDef(generated, node.getReturnType());
+            }
+        }
+
+        public ValuesMethodDefF64 newSingleMethodF64(AstNode node) {
+            validateNodeType(node, AstNode.ReturnType.F64);
+            return (ValuesMethodDefF64) this.newSingleMethod(node);
+        }
+
+        public ValuesMethodDefF32 newSingleMethodF32(AstNode node) {
+            validateNodeType(node, AstNode.ReturnType.F32);
+            return (ValuesMethodDefF32) this.newSingleMethod(node);
+        }
+
+        public String newSingleMethodUnoptimized(AstNode node) {
+            return this.singleMethods.computeIfAbsent(node, (AstNode node1) -> {
+                String name = nextMethodName(node1);
+                this.newSingleMethod0(node1, name, false);
+                return name;
+            });
+        }
+
+        private void newSingleMethod0(AstNode node, String name, boolean isPublic) {
+            InstructionAdapter adapter = new InstructionAdapter(
+                    new AnalyzerAdapter(
+                            this.className,
+                            (isPublic ? Opcodes.ACC_PUBLIC : Opcodes.ACC_PRIVATE) | Opcodes.ACC_FINAL,
+                            name,
+                            getSingleDesc(node.getReturnType()),
+                            classWriter.visitMethod(
+                                    (isPublic ? Opcodes.ACC_PUBLIC : Opcodes.ACC_PRIVATE) | Opcodes.ACC_FINAL,
+                                    name,
+                                    getSingleDesc(node.getReturnType()),
+                                    null,
+                                    null
+                            )
+                    )
+            );
+            List<IntObjectPair<Pair<String, String>>> extraLocals = new ArrayList<>();
+            Label start = new Label();
+            Label end = new Label();
+            adapter.visitLabel(start);
+            LocalVarConsumer localVarConsumer = (localName, localDesc) -> {
+                int ordinal = extraLocals.size() + 6;
+                extraLocals.add(IntObjectPair.of(ordinal, Pair.of(localName, localDesc)));
+                return ordinal;
+            };
+            BytecodeGenRegistry.doBytecodeGenSingle(node, this, adapter, localVarConsumer);
+            adapter.visitLabel(end);
+            adapter.visitLocalVariable("this", this.classDesc, null, start, end, 0);
+            adapter.visitLocalVariable("x", Type.INT_TYPE.getDescriptor(), null, start, end, 1);
+            adapter.visitLocalVariable("y", Type.INT_TYPE.getDescriptor(), null, start, end, 2);
+            adapter.visitLocalVariable("z", Type.INT_TYPE.getDescriptor(), null, start, end, 3);
+            adapter.visitLocalVariable("evalType", Type.getType(EvalType.class).getDescriptor(), null, start, end, 4);
+            adapter.visitLocalVariable("dfcObjectCache", Type.getType(DfcObjectCache.class).getDescriptor(), null, start, end, 5);
+            for (IntObjectPair<Pair<String, String>> local : extraLocals) {
+                adapter.visitLocalVariable(local.right().left(), local.right().right(), null, start, end, local.leftInt());
+            }
+            adapter.visitMaxs(0, 0);
+        }
+
+        public ValuesMethodDef newMultiMethod(AstNode node) {
+            if (node instanceof ConstantNode constantNode) {
+                return constantNode.getDef();
+            } else {
+                String generated = newMultiMethodUnoptimized(node);
+                return makeValuesMethodDef(generated, node.getReturnType());
+            }
+        }
+
+        public ValuesMethodDefF64 newMultiMethodF64(AstNode node) {
+            validateNodeType(node, AstNode.ReturnType.F64);
+            return (ValuesMethodDefF64) this.newMultiMethod(node);
+        }
+
+        public ValuesMethodDefF32 newMultiMethodF32(AstNode node) {
+            validateNodeType(node, AstNode.ReturnType.F32);
+            return (ValuesMethodDefF32) this.newMultiMethod(node);
+        }
+
+
+        public String newMultiMethodUnoptimized(AstNode node) {
+            return this.multiMethods.computeIfAbsent(node, (AstNode node1) -> {
+                String name = nextMethodName(node1);
+                this.newMultiMethod0(node1, name, false);
+                return name;
+            });
+        }
+
+        private void newMultiMethod0(AstNode node, String name, boolean isPublic) {
+            InstructionAdapter adapter = new InstructionAdapter(
+                    new AnalyzerAdapter(
+                            this.className,
+                            (isPublic ? Opcodes.ACC_PUBLIC : Opcodes.ACC_PRIVATE) | Opcodes.ACC_FINAL,
+                            name,
+                            getMultiDesc(node.getReturnType()),
+                            classWriter.visitMethod(
+                                    (isPublic ? Opcodes.ACC_PUBLIC : Opcodes.ACC_PRIVATE) | Opcodes.ACC_FINAL,
+                                    name,
+                                    getMultiDesc(node.getReturnType()),
+                                    null,
+                                    null
+                            )
+                    )
+            );
+            List<IntObjectPair<Pair<String, String>>> extraLocals = new ArrayList<>();
+            Label start = new Label();
+            Label end = new Label();
+            adapter.visitLabel(start);
+            LocalVarConsumer localVarConsumer = (localName, localDesc) -> {
+                int ordinal = extraLocals.size() + 8;
+                extraLocals.add(IntObjectPair.of(ordinal, Pair.of(localName, localDesc)));
+                return ordinal;
+            };
+            BytecodeGenRegistry.doBytecodeGenMulti(node, this, adapter, localVarConsumer);
+            adapter.visitLabel(end);
+            adapter.visitLocalVariable("this", this.classDesc, null, start, end, 0);
+            adapter.visitLocalVariable("res", Type.getType(double[].class).getDescriptor(), null, start, end, 1);
+            adapter.visitLocalVariable("x", Type.getType(double[].class).getDescriptor(), null, start, end, 2);
+            adapter.visitLocalVariable("y", Type.getType(double[].class).getDescriptor(), null, start, end, 3);
+            adapter.visitLocalVariable("z", Type.getType(double[].class).getDescriptor(), null, start, end, 4);
+            adapter.visitLocalVariable("evalType", Type.getType(EvalType.class).getDescriptor(), null, start, end, 5);
+            adapter.visitLocalVariable("dfcObjectCache", Type.getType(DfcObjectCache.class).getDescriptor(), null, start, end, 6);
+            for (IntObjectPair<Pair<String, String>> local : extraLocals) {
+                adapter.visitLocalVariable(local.right().left(), local.right().right(), null, start, end, local.leftInt());
+            }
+            adapter.visitMaxs(0, 0);
+        }
+
+        private void emitInvokeSingle(InstructionAdapter m, ValuesMethodDef target) {
+            if (target.isConst()) {
+                switch (target) {
+                    case ValuesMethodDefF64 f64 -> m.dconst(f64.constValue());
+                    case ValuesMethodDefF32 f32 -> m.fconst(f32.constValue());
+                    default -> throw new IllegalStateException("Unexpected type: " + target.getClass().getName());
+                }
+            } else {
+                m.invokevirtual(this.className, target.generatedMethod(), getSingleDesc(target.returnType()), false);
+            }
+        }
+
+        private void validateTarget(ValuesMethodDef target, AstNode.ReturnType returnType) {
+            if (target.returnType() != returnType) {
+                throw new IllegalArgumentException("Invalid descriptor: tried to store %s into %s".formatted(target.returnType(), returnType));
+            }
+        }
+
+        public void callDelegateSingle(InstructionAdapter m, ValuesMethodDef target, AstNode.ReturnType returnType) {
+            validateTarget(target, returnType);
+            if (target.isConst()) {
+                emitInvokeSingle(m, target);
+            } else {
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.load(1, Type.INT_TYPE);
+                m.load(2, Type.INT_TYPE);
+                m.load(3, Type.INT_TYPE);
+                m.load(4, InstructionAdapter.OBJECT_TYPE);
+                m.load(5, InstructionAdapter.OBJECT_TYPE);
+                emitInvokeSingle(m, target);
+            }
+        }
+
+        public void callDelegateSingle(InstructionAdapter m, ValuesMethodDefF64 target) {
+            this.callDelegateSingle(m, target, AstNode.ReturnType.F64);
+        }
+
+        public void callDelegateSingle(InstructionAdapter m, ValuesMethodDefF32 target) {
+            this.callDelegateSingle(m, target, AstNode.ReturnType.F32);
+        }
+
+        public void callDelegateSingleFromMulti(InstructionAdapter m, ValuesMethodDef target, int indexLocal, AstNode.ReturnType returnType) {
+            validateTarget(target, returnType);
+            if (target.isConst()) {
+                emitInvokeSingle(m, target);
+            } else {
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.load(2, InstructionAdapter.OBJECT_TYPE);
+                m.load(indexLocal, Type.INT_TYPE);
+                m.aload(Type.INT_TYPE);
+                m.load(3, InstructionAdapter.OBJECT_TYPE);
+                m.load(indexLocal, Type.INT_TYPE);
+                m.aload(Type.INT_TYPE);
+                m.load(4, InstructionAdapter.OBJECT_TYPE);
+                m.load(indexLocal, Type.INT_TYPE);
+                m.aload(Type.INT_TYPE);
+                m.load(5, InstructionAdapter.OBJECT_TYPE);
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+
+                emitInvokeSingle(m, target);
+            }
+        }
+
+        public void callDelegateSingleFromMulti(InstructionAdapter m, ValuesMethodDefF64 target, int indexLocal) {
+            this.callDelegateSingleFromMulti(m, target, indexLocal, AstNode.ReturnType.F64);
+        }
+
+        public void callDelegateSingleFromMulti(InstructionAdapter m, ValuesMethodDefF32 target, int indexLocal) {
+            this.callDelegateSingleFromMulti(m, target, indexLocal, AstNode.ReturnType.F32);
+        }
+
+        public void callDelegateMulti(InstructionAdapter m, ValuesMethodDef target, AstNode.ReturnType returnType) {
+            callDelegateMulti(m, target, 1, returnType);
+        }
+
+        public void callDelegateMulti(InstructionAdapter m, ValuesMethodDefF64 target) {
+            callDelegateMulti(m, target, AstNode.ReturnType.F64);
+        }
+
+        public void callDelegateMulti(InstructionAdapter m, ValuesMethodDefF32 target) {
+            callDelegateMulti(m, target, AstNode.ReturnType.F32);
+        }
+
+        public void callDelegateMulti(InstructionAdapter m, ValuesMethodDef target, int arrayLocalIndex, AstNode.ReturnType returnType) {
+            validateTarget(target, returnType);
+            if (target.isConst()) {
+                m.load(arrayLocalIndex, InstructionAdapter.OBJECT_TYPE);
+                switch (target) {
+                    case ValuesMethodDefF64 f64 -> {
+                        m.dconst(f64.constValue());
+                        m.invokestatic(Type.getInternalName(Arrays.class), "fill", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class), Type.DOUBLE_TYPE), false);
+                    }
+                    case ValuesMethodDefF32 f32 -> {
+                        m.fconst(f32.constValue());
+                        m.invokestatic(Type.getInternalName(Arrays.class), "fill", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(float[].class), Type.FLOAT_TYPE), false);
+                    }
+                    default -> throw new IllegalStateException("Unexpected type: " + target.getClass().getName());
+                }
+            } else {
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.load(arrayLocalIndex, InstructionAdapter.OBJECT_TYPE);
+                m.load(2, InstructionAdapter.OBJECT_TYPE);
+                m.load(3, InstructionAdapter.OBJECT_TYPE);
+                m.load(4, InstructionAdapter.OBJECT_TYPE);
+                m.load(5, InstructionAdapter.OBJECT_TYPE);
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+                m.invokevirtual(this.className, target.generatedMethod(), getMultiDesc(target.returnType()), false);
+            }
+        }
+
+        public void callDelegateMulti(InstructionAdapter m, ValuesMethodDefF64 target, int arrayLocalIndex) {
+            this.callDelegateMulti(m, target, arrayLocalIndex, AstNode.ReturnType.F64);
+        }
+
+        public void callDelegateMulti(InstructionAdapter m, ValuesMethodDefF32 target, int arrayLocalIndex) {
+            this.callDelegateMulti(m, target, arrayLocalIndex, AstNode.ReturnType.F32);
+        }
+
+        public <T> String newField(Class<T> type, T data) {
+            return this.newField(type, data, null);
+        }
+
+        public <T> String newField(Class<T> type, T data, Consumer<InstructionAdapter> generator) {
+            FieldRecord existing = this.args.get(data);
+            if (existing != null) {
+                return existing.name();
+            }
+            int size = this.args.size();
+            String name = String.format("field_%d", size);
+            classWriter.visitField(Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL, name, Type.getDescriptor(type), null, null);
+
+            String postprocessMethod;
+            if (generator != null) {
+                postprocessMethod = String.format("postprocess_field_%d", size);
+                InstructionAdapter adapter = new InstructionAdapter(
+                        new AnalyzerAdapter(
+                                this.className,
+                                Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL,
+                                postprocessMethod,
+                                POSTPROCESSING_DESC,
+                                classWriter.visitMethod(
+                                        Opcodes.ACC_PRIVATE | Opcodes.ACC_FINAL,
+                                        postprocessMethod,
+                                        POSTPROCESSING_DESC,
+                                        null,
+                                        null
+                                )
+                        )
+                );
+                Label start = new Label();
+                Label end = new Label();
+                adapter.visitLabel(start);
+                generator.accept(adapter);
+                adapter.visitLabel(end);
+                adapter.visitMaxs(0, 0);
+                adapter.visitLocalVariable("this", this.classDesc, null, start, end, 0);
+                adapter.visitLocalVariable("operand", Type.getDescriptor(Object.class), null, start, end, 0);
+            } else {
+                postprocessMethod = null;
+            }
+
+            this.args.put(data, new FieldRecord(name, size, type, postprocessMethod));
+            return name;
+        }
+
+        public void doCountedLoop(InstructionAdapter m, LocalVarConsumer localVarConsumer, IntConsumer bodyGenerator) {
+            int loopIdx = localVarConsumer.createLocalVariable("loopIdx", Type.INT_TYPE.getDescriptor());
+            m.iconst(0);
+            m.store(loopIdx, Type.INT_TYPE);
+
+            Label start = new Label();
+            Label end = new Label();
+
+            m.visitLabel(start);
+            m.load(loopIdx, Type.INT_TYPE);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.arraylength();
+            m.ificmpge(end);
+
+            bodyGenerator.accept(loopIdx);
+
+            m.iinc(loopIdx, 1);
+            m.goTo(start);
+            m.visitLabel(end);
+        }
+
+        public void delegateAllToSingle(InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer, AstNode current) {
+            ValuesMethodDef singleMethod = this.newSingleMethod(current);
+            Assertions.assertTrue(singleMethod.returnType() == current.getReturnType());
+            this.doCountedLoop(m, localVarConsumer, idx -> {
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+
+                this.callDelegateSingleFromMulti(m, singleMethod, idx, singleMethod.returnType());
+
+                switch (singleMethod.returnType()) {
+                    case F64 -> m.astore(Type.DOUBLE_TYPE);
+                    case F32 -> m.astore(Type.FLOAT_TYPE);
+                }
+            });
+        }
+
+        private OptoPasses.AstPair optimizeCached(DensityFunction densityFunction) {
+            return optoCache.computeIfAbsent(densityFunction, (DensityFunction df) -> OptoPasses.optimize(McToAst.toAst(df)));
+        }
+
+        public int registerRoot(String suffix, AstNode node) {
+            int index = this.roots.size();
+            String single = String.format("evalSingle_%d_%s", index, suffix);
+            String multi = String.format("evalMulti_%d_%s", index, suffix);
+            ToF64Node rootNode = new ToF64Node(node);
+            this.newSingleMethod0(rootNode, single, true);
+            this.newMultiMethod0(rootNode, multi, true);
+            this.roots.add(new MethodPair(single, multi));
+            return index;
+        }
+
+        public DensityFunction compileDelayed(String suffix, DensityFunction df) {
+            OptoPasses.AstPair pair = optimizeCached(df);
+            if (pair.optimized() instanceof ConstantNode constantNode) {
+                return DensityFunctions.constant(constantNode.getValue());
+            } else if (pair.optimized() instanceof YClampedGradientNode) {
+                return df;
+            }
+            int index = this.registerRoot(suffix, pair.optimized());
+            CompiledDensityFunction compiled = new CompiledDensityFunction(index, df);
+            this.delayedInits.add(compiled);
+            return compiled;
+        }
+
+        public static interface LocalVarConsumer {
+            int createLocalVariable(String name, String descriptor);
+        }
+
+        private static record FieldRecord(String name, int ordinal, Class<?> type, String postProcessMethod) {
+        }
+
+        private static record MethodPair(String single, String multi) {
+        }
+    }
+
+    @FunctionalInterface
+    public interface EvalSingleInterface {
+        double evalSingle(int x, int y, int z, EvalType type);
+    }
+
+    @FunctionalInterface
+    public interface EvalMultiInterface {
+        void evalMulti(double[] res, int[] x, int[] y, int[] z, EvalType type);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGenRegistry.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/BytecodeGenRegistry.java
@@ -1,0 +1,107 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.conversion.ToF32Node;
+import com.ishland.c2me.opts.dfc.common.ast.conversion.ToF64Node;
+import com.ishland.c2me.opts.dfc.common.ast.misc.BeardifierNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CacheLikeNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantF32Node;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CoordinateNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.DelegateNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.EndIslandsNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.FindTopSurfaceNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.InterpolatedNoiseSamplerNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.IntervalSelectNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.Multi2SingleNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.RangeChoiceNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.RootNode;
+import com.ishland.c2me.opts.dfc.common.ast.misc.YClampedGradientNode;
+import com.ishland.c2me.opts.dfc.common.ast.noise.GenericShiftedNoiseNode;
+import com.ishland.c2me.opts.dfc.common.ast.spline.SplineNormalNode;
+import com.ishland.c2me.opts.dfc.common.gen.CodeGenRegistry;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.BinaryNodeBytecodeEmitters;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.UnaryNodeBytecodeEmitters;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.conversion.ToF32NodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.conversion.ToF64NodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.CacheLikeNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.ConstantF32NodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.ConstantNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.CoordinateNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.DelegateNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.FindTopSurfaceNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.GenericShiftedNoiseNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.IntervalSelectNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.Multi2SingleNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.RangeChoiceNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.RootNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.SplineNormalNodeBytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc.YClampedGradientNodeBytecodeEmitter;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class BytecodeGenRegistry {
+
+    public static final CodeGenRegistry<BytecodeEmitter<? extends AstNode>> REGISTRY = new CodeGenRegistry<>();
+
+    static {
+        BinaryNodeBytecodeEmitters.register(REGISTRY);
+        UnaryNodeBytecodeEmitters.register(REGISTRY);
+
+        REGISTRY.registerExactMatch(ToF32Node.class, ToF32NodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(ToF64Node.class, ToF64NodeBytecodeEmitter.INSTANCE);
+
+        REGISTRY.registerExactMatch(CacheLikeNode.class, CacheLikeNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(ConstantNode.class, ConstantNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(ConstantF32Node.class, ConstantF32NodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(CoordinateNode.class, CoordinateNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(FindTopSurfaceNode.class, FindTopSurfaceNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(GenericShiftedNoiseNode.class, GenericShiftedNoiseNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(RangeChoiceNode.class, RangeChoiceNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(RootNode.class, RootNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(YClampedGradientNode.class, YClampedGradientNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(IntervalSelectNode.class, IntervalSelectNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(Multi2SingleNode.class, Multi2SingleNodeBytecodeEmitter.INSTANCE);
+        REGISTRY.registerExactMatch(SplineNormalNode.class, SplineNormalNodeBytecodeEmitter.INSTANCE);
+//        REGISTRY.registerExactMatch(SplineAstNode.class, SplineAstNodeBytecodeEmitter.INSTANCE);
+
+        REGISTRY.registerExactMatch(DelegateNode.class, DelegateNodeBytecodeEmitter.instance());
+        REGISTRY.registerExactMatch(BeardifierNode.class, DelegateNodeBytecodeEmitter.instance());
+        REGISTRY.registerExactMatch(EndIslandsNode.class, DelegateNodeBytecodeEmitter.instance());
+        REGISTRY.registerExactMatch(InterpolatedNoiseSamplerNode.class, DelegateNodeBytecodeEmitter.instance());
+    }
+
+    public static <T extends AstNode> void doBytecodeGenSingle(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        BytecodeEmitter<T> emitter = (BytecodeEmitter<T>) REGISTRY.get(node.getClass());
+        emitter.doBytecodeGenSingle(node, context, m, localVarConsumer);
+    }
+
+    public static <T extends AstNode> void doBytecodeGenMulti(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        BytecodeEmitter<T> emitter = (BytecodeEmitter<T>) REGISTRY.get(node.getClass());
+        emitter.doBytecodeGenMulti(node, context, m, localVarConsumer);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledDensityFunction.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledDensityFunction.java
@@ -1,0 +1,135 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.google.common.base.Suppliers;
+import com.ishland.c2me.opts.dfc.common.ducks.IBlendingAwareVisitor;
+import com.ishland.c2me.opts.dfc.common.ducks.ICompiledCachingAwareVisitor;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.IMultiMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ISingleMethod;
+import java.util.Objects;
+import java.util.function.Supplier;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class CompiledDensityFunction extends AbstractCompiledDensityFunction {
+
+    private final int compiledIndex;
+    private CompiledEntry compiledEntry = null;
+    private ISingleMethod singleMethod = null;
+    private IMultiMethod multiMethod = null;
+
+    CompiledDensityFunction(int compiledIndex, DensityFunction blendingFallback) {
+        this(compiledIndex, unwrapFallback(blendingFallback));
+    }
+
+    private CompiledDensityFunction(int compiledIndex, Supplier<DensityFunction> blendingFallback) {
+        super(blendingFallback);
+        this.compiledIndex = compiledIndex;
+    }
+
+    @Override
+    public ISingleMethod getSingleMethod() {
+        return this.singleMethod;
+    }
+
+    @Override
+    public IMultiMethod getMultiMethod() {
+        return this.multiMethod;
+    }
+
+    public synchronized void initFrom(CompiledEntry entry) {
+        if (this.compiledEntry != null) {
+            throw new IllegalStateException("Already initialized");
+        }
+
+        Objects.requireNonNull(entry);
+        SubCompiledDensityFunction method = entry.getRootsUnsafe()[this.compiledIndex];
+        this.compiledEntry = entry;
+        this.singleMethod = Objects.requireNonNull(method.singleMethod);
+        this.multiMethod = Objects.requireNonNull(method.multiMethod);
+    }
+
+    @Override
+    public DensityFunction mapChildren(Visitor visitor) {
+        if (visitor instanceof IBlendingAwareVisitor blendingAwareVisitor && blendingAwareVisitor.c2me$isBlendingEnabled()) {
+            DensityFunction fallback1 = this.getFallback();
+            if (fallback1 == null) {
+                throw new IllegalStateException("blendingFallback is no more");
+            }
+            return visitor.apply(fallback1);
+        }
+        CompiledEntry compiledEntry = this.compiledEntry;
+        ISingleMethod singleMethod = this.singleMethod;
+        IMultiMethod multiMethod = this.multiMethod;
+        if (compiledEntry == null || singleMethod == null || multiMethod == null) {
+            throw new IllegalStateException("Attempted to apply a incomplete compiled df");
+        }
+
+        Supplier<DensityFunction> fallback = this.blendingFallback != null ? Suppliers.memoize(() -> {
+            DensityFunction densityFunction = this.blendingFallback.get();
+            return densityFunction != null ? visitor.apply(densityFunction) : null;
+        }) : null;
+        CompiledDensityFunction function = new CompiledDensityFunction(this.compiledIndex, fallback);
+        CompiledEntry initializedEntry;
+        if (visitor instanceof ICompiledCachingAwareVisitor compiledCachingAwareVisitor) {
+            initializedEntry = compiledCachingAwareVisitor.c2me$visitIfAbsent(compiledEntry, ICompiledCachingAwareVisitor.c2me$getArgumentVisitor(visitor));
+        } else {
+            initializedEntry = this.compiledEntry.newInstance(compiledEntry.getArgs(), ICompiledCachingAwareVisitor.c2me$getArgumentVisitor(visitor));
+        }
+        function.initFrom(initializedEntry);
+        return function;
+    }
+
+    @Override
+    public DensityFunction mapAll(Visitor visitor) {
+        if (visitor instanceof IBlendingAwareVisitor blendingAwareVisitor && blendingAwareVisitor.c2me$isBlendingEnabled()) {
+            DensityFunction fallback1 = this.getFallback();
+            if (fallback1 == null) {
+                throw new IllegalStateException("blendingFallback is no more");
+            }
+            return fallback1.mapAll(visitor);
+        }
+        CompiledEntry compiledEntry = this.compiledEntry;
+        ISingleMethod singleMethod = this.singleMethod;
+        IMultiMethod multiMethod = this.multiMethod;
+        if (compiledEntry == null || singleMethod == null || multiMethod == null) {
+            throw new IllegalStateException("Attempted to apply a incomplete compiled df");
+        }
+        Supplier<DensityFunction> fallback = this.blendingFallback != null ? Suppliers.memoize(() -> {
+            DensityFunction densityFunction = this.blendingFallback.get();
+            return densityFunction != null ? visitor.apply(densityFunction) : null;
+        }) : null;
+        CompiledDensityFunction function = new CompiledDensityFunction(this.compiledIndex, fallback);
+        CompiledEntry initializedEntry;
+        if (visitor instanceof ICompiledCachingAwareVisitor compiledCachingAwareVisitor) {
+            initializedEntry = compiledCachingAwareVisitor.c2me$visitIfAbsent(compiledEntry, ICompiledCachingAwareVisitor.c2me$getArgumentVisitor(visitor));
+        } else {
+            initializedEntry = this.compiledEntry.newInstance(compiledEntry.getArgs(), ICompiledCachingAwareVisitor.c2me$getArgumentVisitor(visitor));
+        }
+        function.initFrom(initializedEntry);
+        return function;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledEntry.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/CompiledEntry.java
@@ -1,0 +1,41 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ArgumentVisitor;
+
+public interface CompiledEntry {
+
+    default SubCompiledDensityFunction[] getRoots() {
+        return this.getRootsUnsafe().clone();
+    }
+
+    SubCompiledDensityFunction[] getRootsUnsafe();
+
+    CompiledEntry newInstance(Object[] args, ArgumentVisitor visitor);
+
+    Object[] getArgs();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/InvocationShim.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/InvocationShim.java
@@ -1,0 +1,59 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import net.minecraft.util.Mth;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+/**
+ * All called from generated code
+ */
+public class InvocationShim {
+
+    public static double invokeDensityFunctionSample(DensityFunction densityFunction, DensityFunction.FunctionContext pos) {
+        return densityFunction.compute(pos);
+    }
+
+    public static void invokeDensityFunctionFill(DensityFunction densityFunction, double[] densities, DensityFunction.ContextProvider applier) {
+        densityFunction.fillArray(densities, applier);
+    }
+
+    public static double invokeMathHelperClampedMap(double value, double oldStart, double oldEnd, double newStart, double newEnd) {
+        return Mth.clampedMap(value, oldStart, oldEnd, newStart, newEnd);
+    }
+
+    public static double invokeDensityFunctionNoiseSample(DensityFunction.NoiseHolder noise, double x, double y, double z) {
+        return noise.getValue(x, y, z);
+    }
+
+    public static float invokeMathHelperLerp(float delta, float start, float end) {
+        return Mth.lerp(delta, start, end);
+    }
+
+    public static int invokeFloor(double value) {
+        return Mth.floor(value);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/SplineSupport.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/SplineSupport.java
@@ -1,0 +1,52 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+public class SplineSupport {
+
+    public static int findRangeForLocation(float[] locations, float x) {
+        int min = 0;
+        int i = locations.length;
+
+        while (i > 0) {
+            int j = i / 2;
+            int k = min + j;
+            if (x < locations[k]) {
+                i = j;
+            } else {
+                min = k + 1;
+                i -= j + 1;
+            }
+        }
+
+        return min - 1;
+    }
+
+    public static float sampleOutsideRange(float point, float[] locations, float value, float[] derivatives, int i) {
+        float f = derivatives[i];
+        return f == 0.0F ? value : value + f * (point - locations[i]);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/SubCompiledDensityFunction.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/SubCompiledDensityFunction.java
@@ -1,0 +1,130 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm;
+
+import com.google.common.base.Suppliers;
+import com.ishland.c2me.base.mixin.access.IChunkNoiseSampler;
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ducks.IDfcObjectCacheCapable;
+import com.ishland.c2me.opts.dfc.common.ducks.IBlendingAwareVisitor;
+import com.ishland.c2me.opts.dfc.common.ducks.ICoordinatesFilling;
+import com.ishland.c2me.opts.dfc.common.ducks.IPreloadedCoordinates;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.IMultiMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ISingleMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.vif.EachApplierVanillaInterface;
+import org.jspecify.annotations.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+import java.util.Objects;
+import java.util.function.Supplier;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class SubCompiledDensityFunction extends AbstractCompiledDensityFunction {
+
+    private static final Logger LOGGER = LoggerFactory.getLogger(SubCompiledDensityFunction.class);
+
+    protected final ISingleMethod singleMethod;
+    protected final IMultiMethod multiMethod;
+    protected final Supplier<DensityFunction> blendingFallback;
+
+    // also called from generated code
+    public SubCompiledDensityFunction(ISingleMethod singleMethod, IMultiMethod multiMethod, DensityFunction blendingFallback) {
+        this(singleMethod, multiMethod, unwrapFallback(blendingFallback));
+    }
+
+    protected SubCompiledDensityFunction(ISingleMethod singleMethod, IMultiMethod multiMethod, Supplier<DensityFunction> blendingFallback) {
+        super(blendingFallback);
+        this.singleMethod = Objects.requireNonNull(singleMethod);
+        this.multiMethod = Objects.requireNonNull(multiMethod);
+        this.blendingFallback = blendingFallback;
+    }
+
+    @Override
+    public ISingleMethod getSingleMethod() {
+        return this.singleMethod;
+    }
+
+    @Override
+    public IMultiMethod getMultiMethod() {
+        return this.multiMethod;
+    }
+
+    @Override
+    public DensityFunction mapChildren(Visitor visitor) {
+        if (this.getClass() != SubCompiledDensityFunction.class) {
+            throw new AbstractMethodError();
+        }
+        if (visitor instanceof IBlendingAwareVisitor blendingAwareVisitor && blendingAwareVisitor.c2me$isBlendingEnabled()) {
+            DensityFunction fallback1 = this.getFallback();
+            if (fallback1 == null) {
+                throw new IllegalStateException("blendingFallback is no more");
+            }
+            return visitor.apply(fallback1);
+        }
+        boolean modified = false;
+        Supplier<DensityFunction> fallback = this.blendingFallback != null ? Suppliers.memoize(() -> {
+            DensityFunction densityFunction = this.blendingFallback.get();
+            return densityFunction != null ? visitor.apply(densityFunction) : null;
+        }) : null;
+        if (fallback != this.blendingFallback) {
+            modified = true;
+        }
+        if (modified) {
+            return new SubCompiledDensityFunction(this.singleMethod, this.multiMethod, fallback);
+        } else {
+            return this;
+        }
+    }
+
+    @Override
+    public DensityFunction mapAll(Visitor visitor) {
+        if (this.getClass() != SubCompiledDensityFunction.class) {
+            throw new AbstractMethodError();
+        }
+        if (visitor instanceof IBlendingAwareVisitor blendingAwareVisitor && blendingAwareVisitor.c2me$isBlendingEnabled()) {
+            DensityFunction fallback1 = this.getFallback();
+            if (fallback1 == null) {
+                throw new IllegalStateException("blendingFallback is no more");
+            }
+            return fallback1.mapAll(visitor);
+        }
+        boolean modified = false;
+        Supplier<DensityFunction> fallback = this.blendingFallback != null ? Suppliers.memoize(() -> {
+            DensityFunction densityFunction = this.blendingFallback.get();
+            return densityFunction != null ? densityFunction.mapAll(visitor) : null;
+        }) : null;
+        if (fallback != this.blendingFallback) {
+            modified = true;
+        }
+        if (modified) {
+            return new SubCompiledDensityFunction(this.singleMethod, this.multiMethod, fallback);
+        } else {
+            return this;
+        }
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/BinaryNodeBytecodeEmitters.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/BinaryNodeBytecodeEmitters.java
@@ -1,0 +1,427 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters;
+
+import com.ishland.c2me.opts.dfc.common.ast.binary.AbstractBinaryNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.AddNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.DivNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MaxNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MaxShortNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MinNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MinShortNode;
+import com.ishland.c2me.opts.dfc.common.ast.binary.MulNode;
+import com.ishland.c2me.opts.dfc.common.gen.CodeGenRegistry;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class BinaryNodeBytecodeEmitters {
+    public abstract static class AbstractGenericBinaryNodeBytecodeEmitter<T extends AbstractBinaryNode> implements BytecodeEmitter<T> {
+        @Override
+        public final void doBytecodeGenSingle(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newSingleMethodF64(node.left);
+            ValuesMethodDefF64 rightMethod = context.newSingleMethodF64(node.right);
+
+            context.callDelegateSingle(m, leftMethod);
+            context.callDelegateSingle(m, rightMethod);
+
+            this.bytecodeGenSingleBody(node, m);
+        }
+
+        @Override
+        public final void doBytecodeGenMulti(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newMultiMethodF64(node.left);
+            ValuesMethodDefF64 rightMethod = context.newMultiMethodF64(node.right);
+
+            if (leftMethod.isConst()) {
+                context.callDelegateMulti(m, rightMethod);
+                context.doCountedLoop(m, localVarConsumer, idx -> bytecodeGenConstMultiBody(node, m, idx, leftMethod.constValue()));
+            } else {
+                int res1 = localVarConsumer.createLocalVariable("res1", Type.getDescriptor(double[].class));
+
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.arraylength();
+                m.iconst(0);
+                m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "getDoubleArray", Type.getMethodDescriptor(Type.getType(double[].class), Type.INT_TYPE, Type.BOOLEAN_TYPE));
+                m.store(res1, InstructionAdapter.OBJECT_TYPE);
+                context.callDelegateMulti(m, leftMethod);
+                context.callDelegateMulti(m, rightMethod, res1);
+
+                context.doCountedLoop(m, localVarConsumer, idx -> bytecodeGenMultiBody(node, m, idx, res1));
+
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+                m.load(res1, InstructionAdapter.OBJECT_TYPE);
+                m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "recycle", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class)));
+            }
+
+            m.areturn(Type.VOID_TYPE);
+        }
+
+        protected abstract void bytecodeGenInstruction(InstructionAdapter m);
+
+        protected void bytecodeGenSingleBody(T node, InstructionAdapter m) {
+            this.bytecodeGenInstruction(m);
+            m.areturn(Type.DOUBLE_TYPE);
+        }
+
+        protected void bytecodeGenMultiBody(T node, InstructionAdapter m, int idx, int res1) {
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+            m.dup2();
+            m.aload(Type.DOUBLE_TYPE);
+            m.load(res1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+            m.aload(Type.DOUBLE_TYPE);
+            this.bytecodeGenInstruction(m);
+            m.astore(Type.DOUBLE_TYPE);
+        }
+
+        protected void bytecodeGenConstMultiBody(T node, InstructionAdapter m, int idx, double constLeft) {
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+            m.dconst(constLeft);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+            m.aload(Type.DOUBLE_TYPE);
+            this.bytecodeGenInstruction(m);
+            m.astore(Type.DOUBLE_TYPE);
+        }
+
+    }
+
+    public static class AddNodeEmitter extends AbstractGenericBinaryNodeBytecodeEmitter<AddNode> {
+        public static final AddNodeEmitter INSTANCE = new AddNodeEmitter();
+
+        private AddNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(InstructionAdapter m) {
+            m.add(Type.DOUBLE_TYPE);
+        }
+    }
+
+    public static class DivNodeEmitter extends AbstractGenericBinaryNodeBytecodeEmitter<DivNode> {
+        public static final DivNodeEmitter INSTANCE = new DivNodeEmitter();
+
+        private DivNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(InstructionAdapter m) {
+            m.div(Type.DOUBLE_TYPE);
+        }
+    }
+
+    public static class MaxNodeEmitter extends AbstractGenericBinaryNodeBytecodeEmitter<MaxNode> {
+        public static final MaxNodeEmitter INSTANCE = new MaxNodeEmitter();
+
+        private MaxNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(InstructionAdapter m) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "max",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class MinNodeEmitter extends AbstractGenericBinaryNodeBytecodeEmitter<MinNode> {
+        public static final MinNodeEmitter INSTANCE = new MinNodeEmitter();
+
+        private MinNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(InstructionAdapter m) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "min",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class MaxShortNodeEmitter implements BytecodeEmitter<MaxShortNode> {
+        public static final MaxShortNodeEmitter INSTANCE = new MaxShortNodeEmitter();
+
+        private MaxShortNodeEmitter() {
+        }
+
+        @Override
+        public void doBytecodeGenSingle(MaxShortNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newSingleMethodF64(node.left);
+            ValuesMethodDefF64 rightMethod = context.newSingleMethodF64(node.right);
+
+            Label minLabel = new Label();
+
+            context.callDelegateSingle(m, leftMethod);
+            m.dup2();
+            m.dconst(node.rightMax);
+            m.cmpl(Type.DOUBLE_TYPE);
+            m.ifle(minLabel);
+            m.areturn(Type.DOUBLE_TYPE);
+
+            m.visitLabel(minLabel);
+            context.callDelegateSingle(m, rightMethod);
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "max",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+            m.areturn(Type.DOUBLE_TYPE);
+        }
+
+        @Override
+        public void doBytecodeGenMulti(MaxShortNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newMultiMethodF64(node.left);
+            ValuesMethodDefF64 rightMethodSingle = context.newSingleMethodF64(node.right);
+            context.callDelegateMulti(m, leftMethod);
+
+            context.doCountedLoop(m, localVarConsumer, idx -> {
+                Label minLabel = new Label();
+                Label end = new Label();
+
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+                m.aload(Type.DOUBLE_TYPE);
+
+                m.dup2();
+                m.dconst(node.rightMax);
+                m.cmpl(Type.DOUBLE_TYPE);
+                m.ifle(minLabel);
+                m.goTo(end);
+
+                m.visitLabel(minLabel);
+                context.callDelegateSingleFromMulti(m, rightMethodSingle, idx);
+                m.invokestatic(
+                        Type.getInternalName(Math.class),
+                        "max",
+                        Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                        false
+                );
+
+                m.visitLabel(end);
+                m.astore(Type.DOUBLE_TYPE);
+            });
+
+            m.areturn(Type.VOID_TYPE);
+        }
+    }
+
+    public static class MinShortNodeEmitter implements BytecodeEmitter<MinShortNode> {
+        public static final MinShortNodeEmitter INSTANCE = new MinShortNodeEmitter();
+
+        private MinShortNodeEmitter() {
+        }
+
+        @Override
+        public void doBytecodeGenSingle(MinShortNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newSingleMethodF64(node.left);
+            ValuesMethodDefF64 rightMethod = context.newSingleMethodF64(node.right);
+
+            Label minLabel = new Label();
+
+            context.callDelegateSingle(m, leftMethod);
+            m.dup2();
+            m.dconst(node.rightMin);
+            m.cmpg(Type.DOUBLE_TYPE);
+            m.ifge(minLabel);
+            m.areturn(Type.DOUBLE_TYPE);
+
+            m.visitLabel(minLabel);
+            context.callDelegateSingle(m, rightMethod);
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "min",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+            m.areturn(Type.DOUBLE_TYPE);
+        }
+
+        @Override
+        public void doBytecodeGenMulti(MinShortNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newMultiMethodF64(node.left);
+            ValuesMethodDefF64 rightMethodSingle = context.newSingleMethodF64(node.right);
+            context.callDelegateMulti(m, leftMethod);
+
+            context.doCountedLoop(m, localVarConsumer, idx -> {
+                Label minLabel = new Label();
+                Label end = new Label();
+
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+                m.aload(Type.DOUBLE_TYPE);
+
+                m.dup2();
+                m.dconst(node.rightMin);
+                m.cmpg(Type.DOUBLE_TYPE);
+                m.ifge(minLabel);
+                m.goTo(end);
+
+                m.visitLabel(minLabel);
+                context.callDelegateSingleFromMulti(m, rightMethodSingle, idx);
+                m.invokestatic(
+                        Type.getInternalName(Math.class),
+                        "min",
+                        Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                        false
+                );
+
+                m.visitLabel(end);
+                m.astore(Type.DOUBLE_TYPE);
+            });
+
+            m.areturn(Type.VOID_TYPE);
+        }
+    }
+
+    public static class MulNodeEmitter implements BytecodeEmitter<MulNode> {
+        public static final MulNodeEmitter INSTANCE = new MulNodeEmitter();
+
+        private MulNodeEmitter() {
+        }
+
+        @Override
+        public void doBytecodeGenSingle(MulNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newSingleMethodF64(node.left);
+            ValuesMethodDefF64 rightMethod = context.newSingleMethodF64(node.right);
+
+            if (leftMethod.isConst()) {
+                if (leftMethod.constValue() == 0.0) {
+                    m.dconst(0.0);
+                } else {
+                    m.dconst(leftMethod.constValue());
+                    context.callDelegateSingle(m, rightMethod);
+                    m.mul(Type.DOUBLE_TYPE);
+                }
+            } else {
+                Label notZero = new Label();
+
+                context.callDelegateSingle(m, leftMethod);
+                m.dup2();
+                m.dconst(0.0);
+                m.cmpl(Type.DOUBLE_TYPE);
+                m.ifne(notZero);
+                m.dconst(0.0);
+                m.areturn(Type.DOUBLE_TYPE);
+
+                m.visitLabel(notZero);
+                context.callDelegateSingle(m, rightMethod);
+                m.mul(Type.DOUBLE_TYPE);
+            }
+
+            m.areturn(Type.DOUBLE_TYPE);
+        }
+
+        @Override
+        public void doBytecodeGenMulti(MulNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 leftMethod = context.newMultiMethodF64(node.left);
+            if (leftMethod.isConst()) {
+                if (leftMethod.constValue() == 0.0) {
+                    context.callDelegateMulti(m, leftMethod);
+                } else {
+                    ValuesMethodDefF64 rightMethod = context.newMultiMethodF64(node.right);
+
+                    context.callDelegateMulti(m, rightMethod);
+
+                    context.doCountedLoop(m, localVarConsumer, idx -> {
+                        m.load(1, InstructionAdapter.OBJECT_TYPE);
+                        m.load(idx, Type.INT_TYPE);
+
+                        m.dconst(leftMethod.constValue());
+                        m.load(1, InstructionAdapter.OBJECT_TYPE);
+                        m.load(idx, Type.INT_TYPE);
+                        m.aload(Type.DOUBLE_TYPE);
+                        m.mul(Type.DOUBLE_TYPE);
+
+                        m.astore(Type.DOUBLE_TYPE);
+                    });
+                }
+            } else {
+                ValuesMethodDefF64 rightMethodSingle = context.newSingleMethodF64(node.right);
+                context.callDelegateMulti(m, leftMethod);
+
+                context.doCountedLoop(m, localVarConsumer, idx -> {
+                    Label minLabel = new Label();
+                    Label end = new Label();
+
+                    m.load(1, InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+
+                    m.load(1, InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+                    m.aload(Type.DOUBLE_TYPE);
+
+                    m.dup2();
+                    m.dconst(0.0);
+                    m.cmpl(Type.DOUBLE_TYPE);
+                    m.ifne(minLabel);
+                    m.pop2();
+                    m.dconst(0.0);
+                    m.goTo(end);
+
+                    m.visitLabel(minLabel);
+                    context.callDelegateSingleFromMulti(m, rightMethodSingle, idx);
+                    m.mul(Type.DOUBLE_TYPE);
+
+                    m.visitLabel(end);
+                    m.astore(Type.DOUBLE_TYPE);
+                });
+            }
+
+            m.areturn(Type.VOID_TYPE);
+        }
+    }
+
+    public static void register(CodeGenRegistry<BytecodeEmitter<?>> registry) {
+        registry.registerExactMatch(AddNode.class, AddNodeEmitter.INSTANCE);
+        registry.registerExactMatch(DivNode.class, DivNodeEmitter.INSTANCE);
+        registry.registerExactMatch(MaxNode.class, MaxNodeEmitter.INSTANCE);
+        registry.registerExactMatch(MaxShortNode.class, MaxShortNodeEmitter.INSTANCE);
+        registry.registerExactMatch(MinNode.class, MinNodeEmitter.INSTANCE);
+        registry.registerExactMatch(MinShortNode.class, MinShortNodeEmitter.INSTANCE);
+        registry.registerExactMatch(MulNode.class, MulNodeEmitter.INSTANCE);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/UnaryNodeBytecodeEmitters.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/UnaryNodeBytecodeEmitters.java
@@ -1,0 +1,287 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters;
+
+import com.ishland.c2me.opts.dfc.common.ast.unary.AbsNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.AbstractUnaryNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.CeilNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.CosNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.CubeNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.FloorNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.NegMulNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.SinNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.SqrtNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.SquareNode;
+import com.ishland.c2me.opts.dfc.common.ast.unary.SqueezeNode;
+import com.ishland.c2me.opts.dfc.common.gen.CodeGenRegistry;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class UnaryNodeBytecodeEmitters {
+    public abstract static class AbstractGenericUnaryNodeBytecodeEmitter<T extends AbstractUnaryNode> implements BytecodeEmitter<T> {
+        @Override
+        public final void doBytecodeGenSingle(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 operandMethod = context.newSingleMethodF64(node.operand);
+            context.callDelegateSingle(m, operandMethod);
+            this.bytecodeGenInstruction(node, m, localVarConsumer);
+            m.areturn(Type.DOUBLE_TYPE);
+        }
+
+        @Override
+        public final void doBytecodeGenMulti(T node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            ValuesMethodDefF64 operandMethod = context.newMultiMethodF64(node.operand);
+            context.callDelegateMulti(m, operandMethod);
+            context.doCountedLoop(m, localVarConsumer, idx -> {
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+                m.dup2();
+                m.aload(Type.DOUBLE_TYPE);
+                this.bytecodeGenInstruction(node, m, localVarConsumer);
+                m.astore(Type.DOUBLE_TYPE);
+            });
+            m.areturn(Type.VOID_TYPE);
+        }
+
+        protected abstract void bytecodeGenInstruction(T node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer);
+    }
+
+    public static class AbsNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<AbsNode> {
+        public static final AbsNodeEmitter INSTANCE = new AbsNodeEmitter();
+
+        private AbsNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(AbsNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "abs",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class CeilNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<CeilNode> {
+        public static final CeilNodeEmitter INSTANCE = new CeilNodeEmitter();
+
+        private CeilNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(CeilNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "ceil",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class CosNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<CosNode> {
+        public static final CosNodeEmitter INSTANCE = new CosNodeEmitter();
+
+        private CosNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(CosNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "cos",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class CubeNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<CubeNode> {
+        public static final CubeNodeEmitter INSTANCE = new CubeNodeEmitter();
+
+        private CubeNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(CubeNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.dup2();
+            m.dup2();
+            m.mul(Type.DOUBLE_TYPE);
+            m.mul(Type.DOUBLE_TYPE);
+        }
+    }
+
+    public static class FloorNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<FloorNode> {
+        public static final FloorNodeEmitter INSTANCE = new FloorNodeEmitter();
+
+        private FloorNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(FloorNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "floor",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class NegMulNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<NegMulNode> {
+        public static final NegMulNodeEmitter INSTANCE = new NegMulNodeEmitter();
+
+        private NegMulNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(NegMulNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            int v = localVarConsumer.createLocalVariable("v", Type.DOUBLE_TYPE.getDescriptor());
+            m.store(v, Type.DOUBLE_TYPE);
+
+            Label negMulLabel = new Label();
+            Label end = new Label();
+
+            m.load(v, Type.DOUBLE_TYPE);
+            m.dconst(0.0);
+            m.cmpl(Type.DOUBLE_TYPE);
+            m.ifle(negMulLabel); // v <= 0.0
+            m.load(v, Type.DOUBLE_TYPE);
+            m.goTo(end);
+            m.visitLabel(negMulLabel);
+            m.load(v, Type.DOUBLE_TYPE);
+            m.dconst(node.negMul);
+            m.mul(Type.DOUBLE_TYPE);
+            m.visitLabel(end);
+        }
+    }
+
+    public static class SinNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<SinNode> {
+        public static final SinNodeEmitter INSTANCE = new SinNodeEmitter();
+
+        private SinNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(SinNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "sin",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class SqrtNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<SqrtNode> {
+        public static final SqrtNodeEmitter INSTANCE = new SqrtNodeEmitter();
+
+        private SqrtNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(SqrtNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "sqrt",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+        }
+    }
+
+    public static class SquareNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<SquareNode> {
+        public static final SquareNodeEmitter INSTANCE = new SquareNodeEmitter();
+
+        private SquareNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(SquareNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.dup2();
+            m.mul(Type.DOUBLE_TYPE);
+        }
+    }
+
+    public static class SqueezeNodeEmitter extends AbstractGenericUnaryNodeBytecodeEmitter<SqueezeNode> {
+        public static final SqueezeNodeEmitter INSTANCE = new SqueezeNodeEmitter();
+
+        private SqueezeNodeEmitter() {
+        }
+
+        @Override
+        protected void bytecodeGenInstruction(SqueezeNode node, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+            m.dconst(-1.0); // min
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "max",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+            m.dconst(1.0); // max
+            m.invokestatic(
+                    Type.getInternalName(Math.class),
+                    "min",
+                    Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                    false
+            );
+
+            int v = localVarConsumer.createLocalVariable("v", Type.DOUBLE_TYPE.getDescriptor());
+            m.store(v, Type.DOUBLE_TYPE);
+
+            m.load(v, Type.DOUBLE_TYPE);
+            m.dconst(2.0);
+            m.div(Type.DOUBLE_TYPE);
+
+            m.load(v, Type.DOUBLE_TYPE);
+            m.dup2();
+            m.dup2();
+            m.mul(Type.DOUBLE_TYPE);
+            m.mul(Type.DOUBLE_TYPE);
+            m.dconst(24.0);
+            m.div(Type.DOUBLE_TYPE);
+
+            m.sub(Type.DOUBLE_TYPE);
+        }
+    }
+
+    public static void register(CodeGenRegistry<BytecodeEmitter<?>> registry) {
+        registry.registerExactMatch(AbsNode.class, AbsNodeEmitter.INSTANCE);
+        registry.registerExactMatch(CeilNode.class, CeilNodeEmitter.INSTANCE);
+        registry.registerExactMatch(CosNode.class, CosNodeEmitter.INSTANCE);
+        registry.registerExactMatch(CubeNode.class, CubeNodeEmitter.INSTANCE);
+        registry.registerExactMatch(FloorNode.class, FloorNodeEmitter.INSTANCE);
+        registry.registerExactMatch(NegMulNode.class, NegMulNodeEmitter.INSTANCE);
+        registry.registerExactMatch(SinNode.class, SinNodeEmitter.INSTANCE);
+        registry.registerExactMatch(SqrtNode.class, SqrtNodeEmitter.INSTANCE);
+        registry.registerExactMatch(SquareNode.class, SquareNodeEmitter.INSTANCE);
+        registry.registerExactMatch(SqueezeNode.class, SqueezeNodeEmitter.INSTANCE);
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/conversion/ToF32NodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/conversion/ToF32NodeBytecodeEmitter.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.conversion;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.conversion.ToF32Node;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class ToF32NodeBytecodeEmitter implements BytecodeEmitter<ToF32Node> {
+    public static final ToF32NodeBytecodeEmitter INSTANCE = new ToF32NodeBytecodeEmitter();
+
+    private ToF32NodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(ToF32Node node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDef nextMethod = context.newSingleMethod(node.next);
+        context.callDelegateSingle(m, nextMethod, nextMethod.returnType());
+        switch (nextMethod.returnType()) {
+            case F32 -> {
+            }
+            case F64 -> m.cast(Type.DOUBLE_TYPE, Type.FLOAT_TYPE);
+        }
+        m.areturn(Type.FLOAT_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(ToF32Node node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDef nextMethod = context.newMultiMethod(node.next);
+
+        switch (nextMethod.returnType()) {
+            case F32 -> {
+                context.callDelegateMulti(m, nextMethod, AstNode.ReturnType.F32);
+            }
+            case F64 -> {
+                int res1 = localVarConsumer.createLocalVariable("res1", Type.getDescriptor(double[].class));
+
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.arraylength();
+                m.iconst(0);
+                m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "getDoubleArray", Type.getMethodDescriptor(Type.getType(double[].class), Type.INT_TYPE, Type.BOOLEAN_TYPE));
+                m.store(res1, InstructionAdapter.OBJECT_TYPE);
+
+                context.callDelegateMulti(m, nextMethod, res1, nextMethod.returnType());
+
+                context.doCountedLoop(m, localVarConsumer, idx -> {
+                    m.load(1, InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+
+                    m.load(res1, InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+                    m.aload(Type.DOUBLE_TYPE);
+
+                    m.cast(Type.DOUBLE_TYPE, Type.FLOAT_TYPE);
+                    m.astore(Type.FLOAT_TYPE);
+                });
+
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+                m.load(res1, InstructionAdapter.OBJECT_TYPE);
+                m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "recycle", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class)));
+            }
+        }
+
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/conversion/ToF64NodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/conversion/ToF64NodeBytecodeEmitter.java
@@ -1,0 +1,94 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.conversion;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.conversion.ToF64Node;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class ToF64NodeBytecodeEmitter implements BytecodeEmitter<ToF64Node> {
+    public static final ToF64NodeBytecodeEmitter INSTANCE = new ToF64NodeBytecodeEmitter();
+
+    private ToF64NodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(ToF64Node node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDef nextMethod = context.newSingleMethod(node.next);
+        context.callDelegateSingle(m, nextMethod, nextMethod.returnType());
+        switch (nextMethod.returnType()) {
+            case F64 -> {
+            }
+            case F32 -> m.cast(Type.FLOAT_TYPE, Type.DOUBLE_TYPE);
+        }
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(ToF64Node node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDef nextMethod = context.newMultiMethod(node.next);
+
+        switch (nextMethod.returnType()) {
+            case F64 -> {
+                context.callDelegateMulti(m, nextMethod, AstNode.ReturnType.F64);
+            }
+            case F32 -> {
+                int res1 = localVarConsumer.createLocalVariable("res1", Type.getDescriptor(float[].class));
+
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.arraylength();
+                m.iconst(0);
+                m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "getFloatArray", Type.getMethodDescriptor(Type.getType(float[].class), Type.INT_TYPE, Type.BOOLEAN_TYPE));
+                m.store(res1, InstructionAdapter.OBJECT_TYPE);
+
+                context.callDelegateMulti(m, nextMethod, res1, nextMethod.returnType());
+
+                context.doCountedLoop(m, localVarConsumer, idx -> {
+                    m.load(1, InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+
+                    m.load(res1, InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+                    m.aload(Type.FLOAT_TYPE);
+
+                    m.cast(Type.FLOAT_TYPE, Type.DOUBLE_TYPE);
+                    m.astore(Type.DOUBLE_TYPE);
+                });
+
+                m.load(6, InstructionAdapter.OBJECT_TYPE);
+                m.load(res1, InstructionAdapter.OBJECT_TYPE);
+                m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "recycle", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(float[].class)));
+            }
+        }
+
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CacheLikeNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CacheLikeNodeBytecodeEmitter.java
@@ -1,0 +1,232 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ast.misc.CacheLikeNode;
+import com.ishland.c2me.opts.dfc.common.ducks.IFastCacheLike;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.IMultiMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi.ISingleMethod;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.SubCompiledDensityFunction;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import org.objectweb.asm.Handle;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Opcodes;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class CacheLikeNodeBytecodeEmitter implements BytecodeEmitter<CacheLikeNode> {
+    public static final CacheLikeNodeBytecodeEmitter INSTANCE = new CacheLikeNodeBytecodeEmitter();
+
+    private CacheLikeNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(CacheLikeNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 delegateMethod = context.newSingleMethodF64(node.getDelegate());
+
+        String cacheLikeField = registerCache(node, context);
+
+        int eval = localVarConsumer.createLocalVariable("eval", Type.DOUBLE_TYPE.getDescriptor());
+
+        Label cacheExists = new Label();
+        Label cacheMiss = new Label();
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+        m.ifnonnull(cacheExists);
+        context.callDelegateSingle(m, delegateMethod);
+        m.areturn(Type.DOUBLE_TYPE);
+
+        m.visitLabel(cacheExists);
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+        m.load(1, Type.INT_TYPE);
+        m.load(2, Type.INT_TYPE);
+        m.load(3, Type.INT_TYPE);
+        m.load(4, InstructionAdapter.OBJECT_TYPE);
+        m.invokeinterface(Type.getInternalName(IFastCacheLike.class), "c2me$getCached", Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.INT_TYPE, Type.INT_TYPE, Type.INT_TYPE, Type.getType(EvalType.class)));
+        m.dup2();
+        m.invokestatic(Type.getInternalName(Double.class), "doubleToRawLongBits", Type.getMethodDescriptor(Type.LONG_TYPE, Type.DOUBLE_TYPE), false);
+        m.lconst(IFastCacheLike.CACHE_MISS_NAN_BITS);
+        m.lcmp();
+        m.ifeq(cacheMiss); // operand1 == operand2, branched with cache res
+        m.areturn(Type.DOUBLE_TYPE);
+
+        m.visitLabel(cacheMiss);
+        m.pop2();
+
+        context.callDelegateSingle(m, delegateMethod);
+        m.store(eval, Type.DOUBLE_TYPE);
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+        m.load(1, Type.INT_TYPE);
+        m.load(2, Type.INT_TYPE);
+        m.load(3, Type.INT_TYPE);
+        m.load(4, InstructionAdapter.OBJECT_TYPE);
+        m.load(eval, Type.DOUBLE_TYPE);
+        m.invokeinterface(Type.getInternalName(IFastCacheLike.class), "c2me$cache", Type.getMethodDescriptor(Type.VOID_TYPE, Type.INT_TYPE, Type.INT_TYPE, Type.INT_TYPE, Type.getType(EvalType.class), Type.DOUBLE_TYPE));
+
+        m.load(eval, Type.DOUBLE_TYPE);
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(CacheLikeNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 delegateMethod = context.newMultiMethodF64(node.getDelegate());
+
+        String cacheLikeField = registerCache(node, context);
+
+        Label cacheExists = new Label();
+        Label cacheMiss = new Label();
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+        m.ifnonnull(cacheExists);
+        context.callDelegateMulti(m, delegateMethod);
+        m.areturn(Type.VOID_TYPE);
+
+        m.visitLabel(cacheExists);
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.load(2, InstructionAdapter.OBJECT_TYPE);
+        m.load(3, InstructionAdapter.OBJECT_TYPE);
+        m.load(4, InstructionAdapter.OBJECT_TYPE);
+        m.load(5, InstructionAdapter.OBJECT_TYPE);
+        m.invokeinterface(Type.getInternalName(IFastCacheLike.class), "c2me$getCached", Type.getMethodDescriptor(Type.BOOLEAN_TYPE, Type.getType(double[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(EvalType.class)));
+        m.ifeq(cacheMiss);
+        m.areturn(Type.VOID_TYPE);
+
+        m.visitLabel(cacheMiss);
+        context.callDelegateMulti(m, delegateMethod);
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, cacheLikeField, Type.getDescriptor(IFastCacheLike.class));
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.load(2, InstructionAdapter.OBJECT_TYPE);
+        m.load(3, InstructionAdapter.OBJECT_TYPE);
+        m.load(4, InstructionAdapter.OBJECT_TYPE);
+        m.load(5, InstructionAdapter.OBJECT_TYPE);
+        m.invokeinterface(Type.getInternalName(IFastCacheLike.class), "c2me$cache", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(EvalType.class)));
+        m.areturn(Type.VOID_TYPE);
+    }
+
+    private String registerCache(CacheLikeNode node, BytecodeGen.Context context) {
+        // put here to ensure init order
+        String delegateSingle = context.newSingleMethodUnoptimized(node.getDelegate());
+        String delegateMulti = context.newMultiMethodUnoptimized(node.getDelegate());
+
+        String cacheLikeField = context.newField(IFastCacheLike.class, node.getCacheLike(), m -> {
+            Label cacheExists = new Label();
+
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.checkcast(Type.getType(DensityFunction.class));
+            m.dup();
+            m.ifnonnull(cacheExists);
+            m.areturn(InstructionAdapter.OBJECT_TYPE);
+
+            m.visitLabel(cacheExists);
+
+            {
+                m.anew(Type.getType(SubCompiledDensityFunction.class));
+                m.dup();
+
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.invokedynamic(
+                        "evalSingle",
+                        Type.getMethodDescriptor(Type.getType(ISingleMethod.class), Type.getType(context.classDesc)),
+                        new Handle(
+                                Opcodes.H_INVOKESTATIC,
+                                "java/lang/invoke/LambdaMetafactory",
+                                "metafactory",
+                                "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                                false
+                        ),
+                        new Object[]{
+                                Type.getMethodType(BytecodeGen.Context.SINGLE_DESC_F64),
+                                new Handle(
+                                        Opcodes.H_INVOKEVIRTUAL,
+                                        context.className,
+                                        delegateSingle,
+                                        BytecodeGen.Context.SINGLE_DESC_F64,
+                                        false
+                                ),
+                                Type.getMethodType(BytecodeGen.Context.SINGLE_DESC_F64)
+                        }
+                );
+
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.invokedynamic(
+                        "evalMulti",
+                        Type.getMethodDescriptor(Type.getType(IMultiMethod.class), Type.getType(context.classDesc)),
+                        new Handle(
+                                Opcodes.H_INVOKESTATIC,
+                                "java/lang/invoke/LambdaMetafactory",
+                                "metafactory",
+                                "(Ljava/lang/invoke/MethodHandles$Lookup;Ljava/lang/String;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodType;Ljava/lang/invoke/MethodHandle;Ljava/lang/invoke/MethodType;)Ljava/lang/invoke/CallSite;",
+                                false
+                        ),
+                        new Object[]{
+                                Type.getMethodType(BytecodeGen.Context.MULTI_DESC_F64),
+                                new Handle(
+                                        Opcodes.H_INVOKEVIRTUAL,
+                                        context.className,
+                                        delegateMulti,
+                                        BytecodeGen.Context.MULTI_DESC_F64,
+                                        false
+                                ),
+                                Type.getMethodType(BytecodeGen.Context.MULTI_DESC_F64)
+                        }
+                );
+
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.checkcast(Type.getType(DensityFunction.class));
+
+                m.invokespecial(
+                        Type.getInternalName(SubCompiledDensityFunction.class),
+                        "<init>",
+                        Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(ISingleMethod.class), Type.getType(IMultiMethod.class), Type.getType(DensityFunction.class)),
+                        false
+                );
+
+                m.checkcast(Type.getType(DensityFunction.class));
+            }
+
+            m.invokeinterface(
+                    Type.getInternalName(IFastCacheLike.class),
+                    "c2me$withDelegate",
+                    Type.getMethodDescriptor(Type.getType(DensityFunction.class), Type.getType(DensityFunction.class))
+            );
+
+            m.areturn(InstructionAdapter.OBJECT_TYPE);
+        });
+
+        return cacheLikeField;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/ConstantF32NodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/ConstantF32NodeBytecodeEmitter.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantF32Node;
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+import java.util.Arrays;
+
+public class ConstantF32NodeBytecodeEmitter implements BytecodeEmitter<ConstantF32Node> {
+    public static final ConstantF32NodeBytecodeEmitter INSTANCE = new ConstantF32NodeBytecodeEmitter();
+
+    private ConstantF32NodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(ConstantF32Node node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        m.fconst(node.getValue());
+        m.areturn(Type.FLOAT_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(ConstantF32Node node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.fconst(node.getValue());
+        m.invokestatic(Type.getInternalName(Arrays.class), "fill", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(float[].class), Type.FLOAT_TYPE), false);
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/ConstantNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/ConstantNodeBytecodeEmitter.java
@@ -1,0 +1,54 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.ConstantNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+import java.util.Arrays;
+
+public class ConstantNodeBytecodeEmitter implements BytecodeEmitter<ConstantNode> {
+    public static final ConstantNodeBytecodeEmitter INSTANCE = new ConstantNodeBytecodeEmitter();
+
+    private ConstantNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(ConstantNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        m.dconst(node.getValue());
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(ConstantNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.dconst(node.getValue());
+        m.invokestatic(Type.getInternalName(Arrays.class), "fill", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class), Type.DOUBLE_TYPE), false);
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CoordinateNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/CoordinateNodeBytecodeEmitter.java
@@ -1,0 +1,69 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.CoordinateNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class CoordinateNodeBytecodeEmitter implements BytecodeEmitter<CoordinateNode> {
+    public static final CoordinateNodeBytecodeEmitter INSTANCE = new CoordinateNodeBytecodeEmitter();
+
+    private CoordinateNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(CoordinateNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        switch (node.axis) {
+            case X -> m.load(1, Type.INT_TYPE);
+            case Y -> m.load(2, Type.INT_TYPE);
+            case Z -> m.load(3, Type.INT_TYPE);
+        }
+        m.cast(Type.INT_TYPE, Type.DOUBLE_TYPE);
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(CoordinateNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        context.doCountedLoop(m, localVarConsumer, idx -> {
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+
+            switch (node.axis) {
+                case X -> m.load(2, InstructionAdapter.OBJECT_TYPE);
+                case Y -> m.load(3, InstructionAdapter.OBJECT_TYPE);
+                case Z -> m.load(4, InstructionAdapter.OBJECT_TYPE);
+            }
+            m.load(idx, Type.INT_TYPE);
+            m.aload(Type.INT_TYPE);
+            m.cast(Type.INT_TYPE, Type.DOUBLE_TYPE);
+
+            m.astore(Type.DOUBLE_TYPE);
+        });
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/DelegateNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/DelegateNodeBytecodeEmitter.java
@@ -1,0 +1,151 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ast.misc.DelegateNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.InvocationShim;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.vif.EachApplierVanillaInterface;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.vif.NoisePosVanillaInterface;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class DelegateNodeBytecodeEmitter<E extends DelegateNode> implements BytecodeEmitter<E> {
+    private static final DelegateNodeBytecodeEmitter<DelegateNode> INSTANCE = new DelegateNodeBytecodeEmitter<>();
+
+    private DelegateNodeBytecodeEmitter() {
+    }
+
+    public static <E1 extends DelegateNode> DelegateNodeBytecodeEmitter<E1> instance() {
+        return (DelegateNodeBytecodeEmitter<E1>) INSTANCE;
+    }
+
+    @Override
+    public void doBytecodeGenSingle(DelegateNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        String newField = context.newField(DensityFunction.class, node.getDelegate());
+
+        int borrowedNoisePos = localVarConsumer.createLocalVariable("noisePos", Type.getDescriptor(NoisePosVanillaInterface.class));
+
+        m.load(5, InstructionAdapter.OBJECT_TYPE);
+        m.load(1, Type.INT_TYPE);
+        m.load(2, Type.INT_TYPE);
+        m.load(3, Type.INT_TYPE);
+        m.load(4, InstructionAdapter.OBJECT_TYPE);
+        m.load(5, InstructionAdapter.OBJECT_TYPE);
+        m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "getNoisePosVanillaInterface", DfcObjectCache.GET_NOISE_POS_VANILLA_INTERFACE_DESC);
+        m.store(borrowedNoisePos, InstructionAdapter.OBJECT_TYPE);
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, newField, Type.getDescriptor(DensityFunction.class));
+        m.load(borrowedNoisePos, InstructionAdapter.OBJECT_TYPE);
+        m.invokestatic(
+                Type.getInternalName(InvocationShim.class),
+                "invokeDensityFunctionSample",
+                Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.getType(DensityFunction.class), Type.getType(DensityFunction.FunctionContext.class)),
+                false
+        );
+
+        m.load(5, InstructionAdapter.OBJECT_TYPE);
+        m.load(borrowedNoisePos, InstructionAdapter.OBJECT_TYPE);
+        m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "recycle", Type.getMethodDescriptor(Type.getType(void.class), Type.getType(NoisePosVanillaInterface.class)));
+
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(DelegateNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        String newField = context.newField(DensityFunction.class, node.getDelegate());
+
+        int borrowedNoisePos = localVarConsumer.createLocalVariable("noisePos", Type.getDescriptor(NoisePosVanillaInterface.class));
+
+        Label moreThanTwoLabel = new Label();
+
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.arraylength();
+        m.iconst(1);
+        m.ificmpgt(moreThanTwoLabel);
+
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.iconst(0);
+
+        m.load(6, InstructionAdapter.OBJECT_TYPE);
+        m.load(2, InstructionAdapter.OBJECT_TYPE);
+        m.iconst(0);
+        m.aload(Type.INT_TYPE);
+        m.load(3, InstructionAdapter.OBJECT_TYPE);
+        m.iconst(0);
+        m.aload(Type.INT_TYPE);
+        m.load(4, InstructionAdapter.OBJECT_TYPE);
+        m.iconst(0);
+        m.aload(Type.INT_TYPE);
+        m.load(5, InstructionAdapter.OBJECT_TYPE);
+        m.load(6, InstructionAdapter.OBJECT_TYPE);
+        m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "getNoisePosVanillaInterface", DfcObjectCache.GET_NOISE_POS_VANILLA_INTERFACE_DESC);
+        m.store(borrowedNoisePos, InstructionAdapter.OBJECT_TYPE);
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, newField, Type.getDescriptor(DensityFunction.class));
+        m.load(borrowedNoisePos, InstructionAdapter.OBJECT_TYPE);
+        m.invokestatic(
+                Type.getInternalName(InvocationShim.class),
+                "invokeDensityFunctionSample",
+                Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.getType(DensityFunction.class), Type.getType(DensityFunction.FunctionContext.class)),
+                false
+        );
+
+        m.load(6, InstructionAdapter.OBJECT_TYPE);
+        m.load(borrowedNoisePos, InstructionAdapter.OBJECT_TYPE);
+        m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "recycle", Type.getMethodDescriptor(Type.getType(void.class), Type.getType(NoisePosVanillaInterface.class)));
+
+        m.astore(Type.DOUBLE_TYPE);
+        m.areturn(Type.VOID_TYPE);
+
+        m.visitLabel(moreThanTwoLabel);
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, newField, Type.getDescriptor(DensityFunction.class));
+        m.load(1, InstructionAdapter.OBJECT_TYPE);
+        m.anew(Type.getType(EachApplierVanillaInterface.class));
+        m.dup();
+        m.load(2, InstructionAdapter.OBJECT_TYPE);
+        m.load(3, InstructionAdapter.OBJECT_TYPE);
+        m.load(4, InstructionAdapter.OBJECT_TYPE);
+        m.load(5, InstructionAdapter.OBJECT_TYPE);
+        m.load(6, InstructionAdapter.OBJECT_TYPE);
+        m.invokespecial(Type.getInternalName(EachApplierVanillaInterface.class), "<init>", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(int[].class), Type.getType(int[].class), Type.getType(int[].class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class)), false);
+        m.invokestatic(
+                Type.getInternalName(InvocationShim.class),
+                "invokeDensityFunctionFill",
+                Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(DensityFunction.class), Type.getType(double[].class), Type.getType(DensityFunction.ContextProvider.class)),
+                false
+        );
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/FindTopSurfaceNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/FindTopSurfaceNodeBytecodeEmitter.java
@@ -1,0 +1,123 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ast.misc.FindTopSurfaceNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.InvocationShim;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class FindTopSurfaceNodeBytecodeEmitter implements BytecodeEmitter<FindTopSurfaceNode> {
+    public static final FindTopSurfaceNodeBytecodeEmitter INSTANCE = new FindTopSurfaceNodeBytecodeEmitter();
+
+    private FindTopSurfaceNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(FindTopSurfaceNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 densityMethod = context.newSingleMethodF64(node.density);
+        ValuesMethodDefF64 upperBoundMethod = context.newSingleMethodF64(node.upperBound);
+        ValuesMethodDefF64 lowerBoundMethod = context.newSingleMethodF64(node.lowerBound);
+
+        int topCellBlockY = localVarConsumer.createLocalVariable("topCellBlockY", Type.INT_TYPE.getDescriptor());
+        int lowerBoundEval = localVarConsumer.createLocalVariable("lowerBoundEval", Type.INT_TYPE.getDescriptor());
+        context.callDelegateSingle(m, upperBoundMethod);
+        m.dconst(node.cellHeight);
+        m.div(Type.DOUBLE_TYPE);
+        m.invokestatic(
+                Type.getInternalName(InvocationShim.class),
+                "invokeFloor",
+                "(D)I",
+                false
+        );
+        m.iconst(node.cellHeight);
+        m.mul(Type.INT_TYPE);
+        m.store(topCellBlockY, Type.INT_TYPE);
+
+        context.callDelegateSingle(m, lowerBoundMethod);
+        m.cast(Type.DOUBLE_TYPE, Type.INT_TYPE);
+        m.store(lowerBoundEval, Type.INT_TYPE);
+
+        Label loopStart = new Label();
+        Label loopEnd = new Label();
+
+        int y1 = localVarConsumer.createLocalVariable("y1", Type.INT_TYPE.getDescriptor());
+        m.load(topCellBlockY, Type.INT_TYPE);
+        m.store(y1, Type.INT_TYPE);
+
+        m.visitLabel(loopStart);
+
+        m.load(y1, Type.INT_TYPE);
+        m.load(lowerBoundEval, Type.INT_TYPE);
+        m.ificmple(loopEnd);
+        if (densityMethod.isConst()) {
+            m.dconst(densityMethod.constValue());
+        } else {
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.load(1, Type.INT_TYPE);
+            m.load(y1, Type.INT_TYPE);
+            m.load(3, Type.INT_TYPE);
+            m.getstatic(
+                    Type.getInternalName(EvalType.class),
+                    "NORMAL",
+                    Type.getDescriptor(EvalType.class)
+            );
+            m.load(5, InstructionAdapter.OBJECT_TYPE);
+            m.invokevirtual(context.className, densityMethod.generatedMethod(), BytecodeGen.Context.SINGLE_DESC_F64, false);
+        }
+        m.dconst(0.0);
+        m.cmpl(Type.DOUBLE_TYPE);
+
+        Label notSatisfied = new Label();
+        m.ifle(notSatisfied);
+        m.load(y1, Type.INT_TYPE);
+        m.cast(Type.INT_TYPE, Type.DOUBLE_TYPE);
+        m.areturn(Type.DOUBLE_TYPE);
+        m.visitLabel(notSatisfied);
+
+        m.load(y1, Type.INT_TYPE);
+        m.iconst(node.cellHeight);
+        m.sub(Type.INT_TYPE);
+        m.store(y1, Type.INT_TYPE);
+        m.goTo(loopStart);
+
+        m.visitLabel(loopEnd);
+
+        m.load(lowerBoundEval, Type.INT_TYPE);
+        m.cast(Type.INT_TYPE, Type.DOUBLE_TYPE);
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(FindTopSurfaceNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        context.delegateAllToSingle(m, localVarConsumer, node);
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/GenericShiftedNoiseNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/GenericShiftedNoiseNodeBytecodeEmitter.java
@@ -1,0 +1,168 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.noise.GenericShiftedNoiseNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.InvocationShim;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import net.minecraft.world.level.levelgen.DensityFunction;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class GenericShiftedNoiseNodeBytecodeEmitter implements BytecodeEmitter<GenericShiftedNoiseNode> {
+    public static final GenericShiftedNoiseNodeBytecodeEmitter INSTANCE = new GenericShiftedNoiseNodeBytecodeEmitter();
+
+    private GenericShiftedNoiseNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(GenericShiftedNoiseNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        String noiseField = context.newField(DensityFunction.NoiseHolder.class, node.noise);
+
+        ValuesMethodDefF64 inputXMethod = context.newSingleMethodF64(node.inputX);
+        ValuesMethodDefF64 inputYMethod = context.newSingleMethodF64(node.inputY);
+        ValuesMethodDefF64 inputZMethod = context.newSingleMethodF64(node.inputZ);
+
+        m.load(0, InstructionAdapter.OBJECT_TYPE);
+        m.getfield(context.className, noiseField, Type.getDescriptor(DensityFunction.NoiseHolder.class));
+
+        context.callDelegateSingle(m, inputXMethod);
+        context.callDelegateSingle(m, inputYMethod);
+        context.callDelegateSingle(m, inputZMethod);
+
+        m.invokestatic(
+                Type.getInternalName(InvocationShim.class),
+                "invokeDensityFunctionNoiseSample",
+                Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.getType(DensityFunction.NoiseHolder.class), Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                false
+        );
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(GenericShiftedNoiseNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        String noiseField = context.newField(DensityFunction.NoiseHolder.class, node.noise);
+
+        ValuesMethodDefF64 inputXMethod = context.newMultiMethodF64(node.inputX);
+        ValuesMethodDefF64 inputYMethod = context.newMultiMethodF64(node.inputY);
+        ValuesMethodDefF64 inputZMethod = context.newMultiMethodF64(node.inputZ);
+        boolean eliminatedX = inputXMethod.isConst();
+        boolean eliminatedY = inputYMethod.isConst();
+        boolean eliminatedZ = inputZMethod.isConst();
+        int arraysNeeded = (!eliminatedX ? 1 : 0) + (!eliminatedY ? 1 : 0) + (!eliminatedZ ? 1 : 0);
+
+        int[] arrays = new int[arraysNeeded];
+        if (arraysNeeded >= 1) {
+            arrays[0] = 1;
+        }
+        if (arraysNeeded >= 2) {
+            arrays[1] = localVarConsumer.createLocalVariable("res1", Type.getDescriptor(double[].class));
+            m.load(6, InstructionAdapter.OBJECT_TYPE);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.arraylength();
+            m.iconst(0);
+            m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "getDoubleArray", Type.getMethodDescriptor(Type.getType(double[].class), Type.INT_TYPE, Type.BOOLEAN_TYPE));
+            m.store(arrays[1], InstructionAdapter.OBJECT_TYPE);
+        }
+        if (arraysNeeded >= 3) {
+            arrays[2] = localVarConsumer.createLocalVariable("res2", Type.getDescriptor(double[].class));
+            m.load(6, InstructionAdapter.OBJECT_TYPE);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.arraylength();
+            m.iconst(0);
+            m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "getDoubleArray", Type.getMethodDescriptor(Type.getType(double[].class), Type.INT_TYPE, Type.BOOLEAN_TYPE));
+            m.store(arrays[2], InstructionAdapter.OBJECT_TYPE);
+        }
+
+        {
+            int arrIdx = 0;
+            if (!eliminatedX) {
+                context.callDelegateMulti(m, inputXMethod, arrays[arrIdx ++]);
+            }
+            if (!eliminatedY) {
+                context.callDelegateMulti(m, inputYMethod, arrays[arrIdx ++]);
+            }
+            if (!eliminatedZ) {
+                context.callDelegateMulti(m, inputZMethod, arrays[arrIdx ++]);
+            }
+        }
+
+        context.doCountedLoop(m, localVarConsumer, idx -> {
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+
+            {
+                m.load(0, InstructionAdapter.OBJECT_TYPE);
+                m.getfield(context.className, noiseField, Type.getDescriptor(DensityFunction.NoiseHolder.class));
+
+                int arrIdx = 0;
+                if (!eliminatedX) {
+                    m.load(arrays[arrIdx ++], InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+                    m.aload(Type.DOUBLE_TYPE);
+                } else {
+                    m.dconst(inputXMethod.constValue());
+                }
+
+                if (!eliminatedY) {
+                    m.load(arrays[arrIdx ++], InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+                    m.aload(Type.DOUBLE_TYPE);
+                } else {
+                    m.dconst(inputYMethod.constValue());
+                }
+
+                if (!eliminatedZ) {
+                    m.load(arrays[arrIdx ++], InstructionAdapter.OBJECT_TYPE);
+                    m.load(idx, Type.INT_TYPE);
+                    m.aload(Type.DOUBLE_TYPE);
+                } else {
+                    m.dconst(inputZMethod.constValue());
+                }
+
+                m.invokestatic(
+                        Type.getInternalName(InvocationShim.class),
+                        "invokeDensityFunctionNoiseSample",
+                        Type.getMethodDescriptor(Type.DOUBLE_TYPE, Type.getType(DensityFunction.NoiseHolder.class), Type.DOUBLE_TYPE, Type.DOUBLE_TYPE, Type.DOUBLE_TYPE),
+                        false
+                );
+            }
+
+            m.astore(Type.DOUBLE_TYPE);
+
+        });
+
+        for (int i = 1; i < arrays.length; i ++) {
+            m.load(6, InstructionAdapter.OBJECT_TYPE);
+            m.load(arrays[i], InstructionAdapter.OBJECT_TYPE);
+            m.invokeinterface(Type.getInternalName(DfcObjectCache.class), "recycle", Type.getMethodDescriptor(Type.VOID_TYPE, Type.getType(double[].class)));
+        }
+
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/IntervalSelectNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/IntervalSelectNodeBytecodeEmitter.java
@@ -1,0 +1,103 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.IntervalSelectNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import com.ishland.flowsched.util.Assertions;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+import java.util.Arrays;
+
+public class IntervalSelectNodeBytecodeEmitter implements BytecodeEmitter<IntervalSelectNode> {
+    public static final IntervalSelectNodeBytecodeEmitter INSTANCE = new IntervalSelectNodeBytecodeEmitter();
+
+    private IntervalSelectNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(IntervalSelectNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 inputMethod = context.newSingleMethodF64(node.input);
+
+        Label endLabel = new Label();
+
+        context.callDelegateSingle(m, inputMethod);
+        ValuesMethodDefF64[] delegates = Arrays.stream(node.functions).map(context::newSingleMethodF64).toArray(ValuesMethodDefF64[]::new);
+        genBinarySearch(
+                node.thresholds, delegates,
+                context, m, endLabel, 0, node.thresholds.length
+        );
+
+        for (ValuesMethodDefF64 delegate : delegates) {
+            Assertions.assertTrue(delegate == null);
+        }
+
+        m.visitLabel(endLabel);
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    private static void genBinarySearch(double[] thresholds, ValuesMethodDefF64[] delegates, BytecodeGen.Context context, InstructionAdapter m, Label endLabel, int fromIndex, int toIndex) {
+        Assertions.assertTrue(fromIndex < toIndex);
+
+        int mid = (fromIndex + toIndex - 1) >>> 1;
+        double midVal = thresholds[mid];
+
+        Label geLabel = new Label();
+        m.dup2();
+        m.dconst(midVal);
+        m.cmpg(Type.DOUBLE_TYPE);
+        m.ifge(geLabel);
+
+        if (fromIndex == mid) {
+            m.pop2();
+            context.callDelegateSingle(m, delegates[fromIndex]);
+            m.goTo(endLabel);
+            delegates[fromIndex] = null;
+        } else {
+            genBinarySearch(thresholds, delegates, context, m, endLabel, fromIndex, mid);
+        }
+
+        m.visitLabel(geLabel);
+
+        if (mid + 1 == toIndex) {
+            m.pop2();
+            context.callDelegateSingle(m, delegates[toIndex]);
+            m.goTo(endLabel);
+            delegates[toIndex] = null;
+        } else {
+            genBinarySearch(thresholds, delegates, context, m, endLabel, mid + 1, toIndex);
+        }
+    }
+
+    @Override
+    public void doBytecodeGenMulti(IntervalSelectNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        context.delegateAllToSingle(m, localVarConsumer, node);
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/Multi2SingleNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/Multi2SingleNodeBytecodeEmitter.java
@@ -1,0 +1,56 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.Multi2SingleNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDef;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class Multi2SingleNodeBytecodeEmitter implements BytecodeEmitter<Multi2SingleNode> {
+    public static final Multi2SingleNodeBytecodeEmitter INSTANCE = new Multi2SingleNodeBytecodeEmitter();
+
+    private Multi2SingleNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(Multi2SingleNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDef nextMethod = context.newSingleMethod(node.next);
+
+        context.callDelegateSingle(m, nextMethod, nextMethod.returnType());
+        switch (nextMethod.returnType()) {
+            case F64 -> m.areturn(Type.DOUBLE_TYPE);
+            case F32 -> m.areturn(Type.FLOAT_TYPE);
+        }
+    }
+
+    @Override
+    public void doBytecodeGenMulti(Multi2SingleNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        context.delegateAllToSingle(m, localVarConsumer, node);
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/RangeChoiceNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/RangeChoiceNodeBytecodeEmitter.java
@@ -1,0 +1,139 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.RangeChoiceNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class RangeChoiceNodeBytecodeEmitter implements BytecodeEmitter<RangeChoiceNode> {
+    public static final RangeChoiceNodeBytecodeEmitter INSTANCE = new RangeChoiceNodeBytecodeEmitter();
+
+    private RangeChoiceNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(RangeChoiceNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 inputMethod = context.newSingleMethodF64(node.input);
+        ValuesMethodDefF64 whenInRangeMethod = context.newSingleMethodF64(node.whenInRange);
+        ValuesMethodDefF64 whenOutOfRangeMethod = context.newSingleMethodF64(node.whenOutOfRange);
+
+        int inputValue = localVarConsumer.createLocalVariable("inputValue", Type.DOUBLE_TYPE.getDescriptor());
+        context.callDelegateSingle(m, inputMethod);
+        m.store(inputValue, Type.DOUBLE_TYPE);
+
+        Label whenOutOfRangeLabel = new Label();
+        Label end = new Label();
+
+        m.load(inputValue, Type.DOUBLE_TYPE);
+        m.dconst(node.minInclusive);
+        m.cmpl(Type.DOUBLE_TYPE);
+        m.iflt(whenOutOfRangeLabel); // inputValue < minInclusive
+        m.load(inputValue, Type.DOUBLE_TYPE);
+        m.dconst(node.maxExclusive);
+        m.cmpg(Type.DOUBLE_TYPE);
+        m.ifge(whenOutOfRangeLabel); // inputValue >= maxExclusive
+
+        if (whenInRangeMethod.equals(inputMethod)) {
+            m.load(inputValue, Type.DOUBLE_TYPE);
+        } else {
+            context.callDelegateSingle(m, whenInRangeMethod);
+        }
+        m.goTo(end);
+
+        m.visitLabel(whenOutOfRangeLabel);
+        if (whenOutOfRangeMethod.equals(inputMethod)) {
+            m.load(inputValue, Type.DOUBLE_TYPE);
+        } else {
+            context.callDelegateSingle(m, whenOutOfRangeMethod);
+        }
+
+        m.visitLabel(end);
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(RangeChoiceNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 inputSingle = context.newSingleMethodF64(node.input);
+        ValuesMethodDefF64 whenInRangeSingle = context.newSingleMethodF64(node.whenInRange);
+        ValuesMethodDefF64 whenOutOfRangeSingle = context.newSingleMethodF64(node.whenOutOfRange);
+        ValuesMethodDefF64 inputMulti = context.newMultiMethodF64(node.input);
+//        String whenInRangeMulti = context.newMultiMethod(this.whenInRange);
+//        String whenOutOfRangeMulti = context.newMultiMethod(this.whenOutOfRange);
+
+        context.callDelegateMulti(m, inputMulti);
+
+        context.doCountedLoop(m, localVarConsumer, idx -> {
+            Label whenOutOfRangeLabel = new Label();
+            Label end = new Label();
+
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+
+//            m.load(inputValue, Type.DOUBLE_TYPE);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+            m.aload(Type.DOUBLE_TYPE);
+            m.dconst(node.minInclusive);
+            m.cmpl(Type.DOUBLE_TYPE);
+            m.iflt(whenOutOfRangeLabel); // inputValue < minInclusive
+//            m.load(inputValue, Type.DOUBLE_TYPE);
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+            m.aload(Type.DOUBLE_TYPE);
+            m.dconst(node.maxExclusive);
+            m.cmpg(Type.DOUBLE_TYPE);
+            m.ifge(whenOutOfRangeLabel); // inputValue >= maxExclusive
+
+//            context.callDelegateSingle(m, whenInRangeSingle);
+            if (whenInRangeSingle.equals(inputSingle)) {
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+                m.aload(Type.DOUBLE_TYPE);
+            } else {
+                context.callDelegateSingleFromMulti(m, whenInRangeSingle, idx);
+            }
+            m.goTo(end);
+
+            m.visitLabel(whenOutOfRangeLabel);
+            if (whenOutOfRangeSingle.equals(inputSingle)) {
+                m.load(1, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+                m.aload(Type.DOUBLE_TYPE);
+            } else {
+                context.callDelegateSingleFromMulti(m, whenOutOfRangeSingle, idx);
+            }
+
+            m.visitLabel(end);
+            m.astore(Type.DOUBLE_TYPE);
+        });
+
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/RootNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/RootNodeBytecodeEmitter.java
@@ -1,0 +1,53 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.RootNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class RootNodeBytecodeEmitter implements BytecodeEmitter<RootNode> {
+    public static final RootNodeBytecodeEmitter INSTANCE = new RootNodeBytecodeEmitter();
+
+    private RootNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(RootNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 nextMethod = context.newSingleMethodF64(node.next);
+        context.callDelegateSingle(m, nextMethod);
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(RootNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        ValuesMethodDefF64 nextMethod = context.newMultiMethodF64(node.next);
+        context.callDelegateMulti(m, nextMethod);
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/SplineNormalNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/SplineNormalNodeBytecodeEmitter.java
@@ -1,0 +1,331 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+import com.ishland.c2me.opts.dfc.common.ast.spline.SplineAstNode;
+import com.ishland.c2me.opts.dfc.common.ast.spline.SplineNormalNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.InvocationShim;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.SplineSupport;
+import com.ishland.c2me.opts.dfc.common.gen.meta.ValuesMethodDefF64;
+import com.ishland.flowsched.util.Assertions;
+import org.objectweb.asm.Label;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class SplineNormalNodeBytecodeEmitter implements BytecodeEmitter<SplineNormalNode> {
+    public static final SplineNormalNodeBytecodeEmitter INSTANCE = new SplineNormalNodeBytecodeEmitter();
+
+    private SplineNormalNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(SplineNormalNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        String locations = context.newField(float[].class, node.locations);
+        String derivatives = context.newField(float[].class, node.derivatives);
+
+        int point = localVarConsumer.createLocalVariable("point", Type.FLOAT_TYPE.getDescriptor());
+        int rangeForLocation = localVarConsumer.createLocalVariable("rangeForLocation", Type.INT_TYPE.getDescriptor());
+
+        int lastConst = node.locations.length - 1;
+
+        ValuesMethodDefF64 locationFunction = context.newSingleMethodF64(node.locationFunction);
+        context.callDelegateSingle(m, locationFunction);
+        m.cast(Type.DOUBLE_TYPE, Type.FLOAT_TYPE);
+        m.store(point, Type.FLOAT_TYPE);
+
+        int valuesMethodsLength = node.values.length;
+        if (valuesMethodsLength == 1) {
+            m.load(point, Type.FLOAT_TYPE);
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    locations,
+                    Type.getDescriptor(float[].class)
+            );
+            context.callDelegateSingle(m, context.newSingleMethodF32(node.values[0]));
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    derivatives,
+                    Type.getDescriptor(float[].class)
+            );
+            m.iconst(0);
+            m.invokestatic(
+                    Type.getInternalName(SplineSupport.class),
+                    "sampleOutsideRange",
+                    Type.getMethodDescriptor(Type.FLOAT_TYPE, Type.FLOAT_TYPE, Type.getType(float[].class), Type.FLOAT_TYPE, Type.getType(float[].class), Type.INT_TYPE),
+                    false
+            );
+            m.areturn(Type.FLOAT_TYPE);
+        } else {
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    locations,
+                    Type.getDescriptor(float[].class)
+            );
+            m.load(point, Type.FLOAT_TYPE);
+            m.invokestatic(
+                    Type.getInternalName(SplineSupport.class),
+                    "findRangeForLocation",
+                    Type.getMethodDescriptor(Type.INT_TYPE, Type.getType(float[].class), Type.FLOAT_TYPE),
+                    false
+            );
+            m.store(rangeForLocation, Type.INT_TYPE);
+
+            Label label1 = new Label();
+            Label label2 = new Label();
+
+            m.load(rangeForLocation, Type.INT_TYPE);
+            m.ifge(label1);
+            // rangeForLocation < 0
+            m.load(point, Type.FLOAT_TYPE);
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    locations,
+                    Type.getDescriptor(float[].class)
+            );
+            context.callDelegateSingle(m, context.newSingleMethodF32(node.values[0]));
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    derivatives,
+                    Type.getDescriptor(float[].class)
+            );
+            m.iconst(0);
+            m.invokestatic(
+                    Type.getInternalName(SplineSupport.class),
+                    "sampleOutsideRange",
+                    Type.getMethodDescriptor(Type.FLOAT_TYPE, Type.FLOAT_TYPE, Type.getType(float[].class), Type.FLOAT_TYPE, Type.getType(float[].class), Type.INT_TYPE),
+                    false
+            );
+            m.areturn(Type.FLOAT_TYPE);
+
+            m.visitLabel(label1);
+            m.load(rangeForLocation, Type.INT_TYPE);
+            m.iconst(lastConst);
+            m.ificmpne(label2);
+            // rangeForLocation == last
+            m.load(point, Type.FLOAT_TYPE);
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    locations,
+                    Type.getDescriptor(float[].class)
+            );
+            context.callDelegateSingle(m, context.newSingleMethodF32(node.values[lastConst]));
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    derivatives,
+                    Type.getDescriptor(float[].class)
+            );
+            m.iconst(lastConst);
+            m.invokestatic(
+                    Type.getInternalName(SplineSupport.class),
+                    "sampleOutsideRange",
+                    Type.getMethodDescriptor(Type.FLOAT_TYPE, Type.FLOAT_TYPE, Type.getType(float[].class), Type.FLOAT_TYPE, Type.getType(float[].class), Type.INT_TYPE),
+                    false
+            );
+            m.areturn(Type.FLOAT_TYPE);
+
+            m.visitLabel(label2);
+
+            int loc0 = localVarConsumer.createLocalVariable("loc0", Type.FLOAT_TYPE.getDescriptor());
+            int loc1 = localVarConsumer.createLocalVariable("loc1", Type.FLOAT_TYPE.getDescriptor());
+            int locDist = localVarConsumer.createLocalVariable("locDist", Type.FLOAT_TYPE.getDescriptor());
+            int k = localVarConsumer.createLocalVariable("k", Type.FLOAT_TYPE.getDescriptor());
+            int n = localVarConsumer.createLocalVariable("n", Type.FLOAT_TYPE.getDescriptor());
+            int o = localVarConsumer.createLocalVariable("o", Type.FLOAT_TYPE.getDescriptor());
+            int onDist = localVarConsumer.createLocalVariable("onDist", Type.FLOAT_TYPE.getDescriptor());
+            int p = localVarConsumer.createLocalVariable("p", Type.FLOAT_TYPE.getDescriptor());
+            int q = localVarConsumer.createLocalVariable("q", Type.FLOAT_TYPE.getDescriptor());
+
+            int cache1Local = localVarConsumer.createLocalVariable("cache1Local", Type.FLOAT_TYPE.getDescriptor());
+
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    locations,
+                    Type.getDescriptor(float[].class)
+            );
+            m.load(rangeForLocation, Type.INT_TYPE);
+            m.aload(Type.FLOAT_TYPE);
+            m.store(loc0, Type.FLOAT_TYPE);
+
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    locations,
+                    Type.getDescriptor(float[].class)
+            );
+            m.load(rangeForLocation, Type.INT_TYPE);
+            m.iconst(1);
+            m.add(Type.INT_TYPE);
+            m.aload(Type.FLOAT_TYPE);
+            m.store(loc1, Type.FLOAT_TYPE);
+
+            m.load(loc1, Type.FLOAT_TYPE);
+            m.load(loc0, Type.FLOAT_TYPE);
+            m.sub(Type.FLOAT_TYPE);
+            m.store(locDist, Type.FLOAT_TYPE);
+
+            m.load(point, Type.FLOAT_TYPE);
+            m.load(loc0, Type.FLOAT_TYPE);
+            m.sub(Type.FLOAT_TYPE);
+            m.load(locDist, Type.FLOAT_TYPE);
+            m.div(Type.FLOAT_TYPE);
+            m.store(k, Type.FLOAT_TYPE);
+
+            Label[] jumpLabels = new Label[valuesMethodsLength - 1];
+            boolean[] jumpGenerated = new boolean[valuesMethodsLength - 1];
+            for (int i = 0; i < valuesMethodsLength - 1; i++) {
+                jumpLabels[i] = new Label();
+            }
+            Label defaultLabel = new Label();
+            Label label3 = new Label();
+
+            m.load(rangeForLocation, Type.INT_TYPE);
+            m.tableswitch(
+                    0,
+                    valuesMethodsLength - 2,
+                    defaultLabel,
+                    jumpLabels
+            );
+
+            for (int i = 0; i < valuesMethodsLength - 1; i++) {
+                if (jumpGenerated[i]) continue;
+                m.visitLabel(jumpLabels[i]);
+                jumpGenerated[i] = true;
+                for (int j = i + 1; j < valuesMethodsLength - 1; j++) { // deduplication
+                    if (node.values[i].equals(node.values[j]) && node.values[i + 1].equals(node.values[j + 1])) {
+                        m.visitLabel(jumpLabels[j]);
+                        jumpGenerated[j] = true;
+                    }
+                }
+
+                boolean optimizePure = node.values[i].equals(node.values[i + 1]);
+                context.callDelegateSingle(m, context.newSingleMethodF32(node.values[i]));
+                if (optimizePure) { // splines are pure
+                    m.dup();
+                    m.store(n, Type.FLOAT_TYPE);
+                    m.store(o, Type.FLOAT_TYPE);
+                } else {
+                    m.store(n, Type.FLOAT_TYPE);
+                    context.callDelegateSingle(m, context.newSingleMethodF32(node.values[i + 1]));
+                    m.store(o, Type.FLOAT_TYPE);
+                }
+                m.goTo(label3);
+            }
+
+            m.visitLabel(defaultLabel);
+            m.iconst(0);
+            m.aconst("boom");
+            m.invokestatic(
+                    Type.getInternalName(Assertions.class),
+                    "assertTrue",
+                    Type.getMethodDescriptor(Type.VOID_TYPE, Type.BOOLEAN_TYPE, Type.getType(String.class)),
+                    false
+            );
+            m.fconst(Float.NaN); // unreachable code
+            m.areturn(Type.FLOAT_TYPE);
+
+            m.visitLabel(label3);
+
+            m.load(o, Type.FLOAT_TYPE);
+            m.load(n, Type.FLOAT_TYPE);
+            m.sub(Type.FLOAT_TYPE);
+            m.store(onDist, Type.FLOAT_TYPE);
+
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    derivatives,
+                    Type.getDescriptor(float[].class)
+            );
+            m.load(rangeForLocation, Type.INT_TYPE);
+            m.aload(Type.FLOAT_TYPE);
+            m.load(locDist, Type.FLOAT_TYPE);
+            m.mul(Type.FLOAT_TYPE);
+            m.load(onDist, Type.FLOAT_TYPE);
+            m.sub(Type.FLOAT_TYPE);
+            m.store(p, Type.FLOAT_TYPE);
+
+            m.load(0, InstructionAdapter.OBJECT_TYPE);
+            m.getfield(
+                    context.className,
+                    derivatives,
+                    Type.getDescriptor(float[].class)
+            );
+            m.load(rangeForLocation, Type.INT_TYPE);
+            m.iconst(1);
+            m.add(Type.INT_TYPE);
+            m.aload(Type.FLOAT_TYPE);
+            m.neg(Type.FLOAT_TYPE);
+            m.load(locDist, Type.FLOAT_TYPE);
+            m.mul(Type.FLOAT_TYPE);
+            m.load(onDist, Type.FLOAT_TYPE);
+            m.add(Type.FLOAT_TYPE);
+            m.store(q, Type.FLOAT_TYPE);
+
+            m.load(k, Type.FLOAT_TYPE);
+            m.load(n, Type.FLOAT_TYPE);
+            m.load(o, Type.FLOAT_TYPE);
+            m.invokestatic(
+                    Type.getInternalName(InvocationShim.class),
+                    "invokeMathHelperLerp",
+                    "(FFF)F",
+                    false
+            );
+            m.load(k, Type.FLOAT_TYPE);
+            m.fconst(1.0F);
+            m.load(k, Type.FLOAT_TYPE);
+            m.sub(Type.FLOAT_TYPE);
+            m.mul(Type.FLOAT_TYPE);
+            m.load(k, Type.FLOAT_TYPE);
+            m.load(p, Type.FLOAT_TYPE);
+            m.load(q, Type.FLOAT_TYPE);
+            m.invokestatic(
+                    Type.getInternalName(InvocationShim.class),
+                    "invokeMathHelperLerp",
+                    "(FFF)F",
+                    false
+            );
+            m.mul(Type.FLOAT_TYPE);
+            m.add(Type.FLOAT_TYPE);
+            m.areturn(Type.FLOAT_TYPE);
+        }
+    }
+
+    @Override
+    public void doBytecodeGenMulti(SplineNormalNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        context.delegateAllToSingle(m, localVarConsumer, node);
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/YClampedGradientNodeBytecodeEmitter.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/misc/YClampedGradientNodeBytecodeEmitter.java
@@ -1,0 +1,85 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters.misc;
+
+import com.ishland.c2me.opts.dfc.common.ast.misc.YClampedGradientNode;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeEmitter;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.BytecodeGen;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.InvocationShim;
+import org.objectweb.asm.Type;
+import org.objectweb.asm.commons.InstructionAdapter;
+
+public class YClampedGradientNodeBytecodeEmitter implements BytecodeEmitter<YClampedGradientNode> {
+    public static final YClampedGradientNodeBytecodeEmitter INSTANCE = new YClampedGradientNodeBytecodeEmitter();
+
+    public YClampedGradientNodeBytecodeEmitter() {
+    }
+
+    @Override
+    public void doBytecodeGenSingle(YClampedGradientNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        m.load(2, Type.INT_TYPE);
+        m.cast(Type.INT_TYPE, Type.DOUBLE_TYPE);
+        m.dconst(node.fromY);
+        m.dconst(node.toY);
+        m.dconst(node.fromValue);
+        m.dconst(node.toValue);
+        m.invokestatic(
+                Type.getInternalName(InvocationShim.class),
+                "invokeMathHelperClampedMap",
+                "(DDDDD)D",
+                false
+        );
+        m.areturn(Type.DOUBLE_TYPE);
+    }
+
+    @Override
+    public void doBytecodeGenMulti(YClampedGradientNode node, BytecodeGen.Context context, InstructionAdapter m, BytecodeGen.Context.LocalVarConsumer localVarConsumer) {
+        context.doCountedLoop(m, localVarConsumer, idx -> {
+            m.load(1, InstructionAdapter.OBJECT_TYPE);
+            m.load(idx, Type.INT_TYPE);
+
+            {
+                m.load(3, InstructionAdapter.OBJECT_TYPE);
+                m.load(idx, Type.INT_TYPE);
+                m.aload(Type.INT_TYPE);
+                m.cast(Type.INT_TYPE, Type.DOUBLE_TYPE);
+                m.dconst(node.fromY);
+                m.dconst(node.toY);
+                m.dconst(node.fromValue);
+                m.dconst(node.toValue);
+                m.invokestatic(
+                        Type.getInternalName(InvocationShim.class),
+                        "invokeMathHelperClampedMap",
+                        "(DDDDD)D",
+                        false
+                );
+            }
+
+            m.astore(Type.DOUBLE_TYPE);
+        });
+
+        m.areturn(Type.VOID_TYPE);
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/package-info.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/emitters/package-info.java
@@ -1,0 +1,25 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.emitters;

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/internalapi/ArgumentVisitor.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/internalapi/ArgumentVisitor.java
@@ -1,0 +1,33 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi;
+
+public interface ArgumentVisitor {
+
+    public static final ArgumentVisitor IDENTITY = o -> o;
+
+    Object apply(Object operand);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/internalapi/IMultiMethod.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/internalapi/IMultiMethod.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+
+@FunctionalInterface
+public interface IMultiMethod {
+
+    void evalMulti(double[] res, int[] x, int[] y, int[] z, EvalType type, DfcObjectCache dfcObjectCache);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/internalapi/ISingleMethod.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/internalapi/ISingleMethod.java
@@ -1,0 +1,35 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.internalapi;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+
+@FunctionalInterface
+public interface ISingleMethod {
+
+    double evalSingle(int x, int y, int z, EvalType type, DfcObjectCache dfcObjectCache);
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/util/DfcObjectCache.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/util/DfcObjectCache.java
@@ -1,0 +1,184 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.util;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.vif.NoisePosVanillaInterface;
+import it.unimi.dsi.fastutil.ints.Int2ReferenceArrayMap;
+import it.unimi.dsi.fastutil.objects.ReferenceArrayList;
+import org.objectweb.asm.Type;
+
+import java.util.Arrays;
+
+public interface DfcObjectCache {
+
+    public static final String GET_NOISE_POS_VANILLA_INTERFACE_DESC = Type.getMethodDescriptor(
+            Type.getType(NoisePosVanillaInterface.class), Type.getType(int.class), Type.getType(int.class), Type.getType(int.class), Type.getType(EvalType.class), Type.getType(DfcObjectCache.class)
+    );
+
+    double[] getDoubleArray(int size, boolean zero);
+
+    float[] getFloatArray(int size, boolean zero);
+
+    int[] getIntArray(int size, boolean zero);
+
+    NoisePosVanillaInterface getNoisePosVanillaInterface(int x, int y, int z, EvalType type, DfcObjectCache cache);
+
+    void recycle(double[] array);
+
+    void recycle(float[] array);
+
+    void recycle(int[] array);
+
+    void recycle(NoisePosVanillaInterface noisePosVanillaInterface);
+
+    class Impl implements DfcObjectCache {
+
+        private final Int2ReferenceArrayMap<ReferenceArrayList<double[]>> doubleArrayCache = new Int2ReferenceArrayMap<>();
+        private final Int2ReferenceArrayMap<ReferenceArrayList<float[]>> floatArrayCache = new Int2ReferenceArrayMap<>();
+        private final Int2ReferenceArrayMap<ReferenceArrayList<int[]>> intArrayCache = new Int2ReferenceArrayMap<>();
+//        private final ReferenceArrayList<NoisePosVanillaInterface> noisePosVanillaInterfacesCache = new ReferenceArrayList<>();
+        private final NoisePosVanillaInterface noisePosVanillaInterfaceSingleton = new NoisePosVanillaInterface();
+
+        public double[] getDoubleArray(int size, boolean zero) {
+            ReferenceArrayList<double[]> list = this.doubleArrayCache.computeIfAbsent(size, k -> new ReferenceArrayList<>());
+            if (list.isEmpty()) {
+                return new double[size];
+            } else {
+                double[] popped = list.pop();
+                if (zero) {
+                    Arrays.fill(popped, 0.0);
+                }
+                return popped;
+            }
+        }
+
+        @Override
+        public float[] getFloatArray(int size, boolean zero) {
+            ReferenceArrayList<float[]> list = this.floatArrayCache.computeIfAbsent(size, k -> new ReferenceArrayList<>());
+            if (list.isEmpty()) {
+                return new float[size];
+            } else {
+                float[] popped = list.pop();
+                if (zero) {
+                    Arrays.fill(popped, 0.0F);
+                }
+                return popped;
+            }
+        }
+
+        public int[] getIntArray(int size, boolean zero) {
+            ReferenceArrayList<int[]> list = this.intArrayCache.computeIfAbsent(size, k -> new ReferenceArrayList<>());
+            if (list.isEmpty()) {
+                return new int[size];
+            } else {
+                int[] popped = list.pop();
+                if (zero) {
+                    Arrays.fill(popped, 0);
+                }
+                return popped;
+            }
+        }
+
+        @Override
+        public NoisePosVanillaInterface getNoisePosVanillaInterface(int x, int y, int z, EvalType type, DfcObjectCache cache) {
+//            ReferenceArrayList<NoisePosVanillaInterface> list = this.noisePosVanillaInterfacesCache;
+//            if (list.isEmpty()) {
+//                return new NoisePosVanillaInterface().at(x, y, z, type, cache);
+//            } else {
+//                return list.pop().at(x, y, z, type, cache);
+//            }
+            this.noisePosVanillaInterfaceSingleton.ensureUninitialized();
+            return this.noisePosVanillaInterfaceSingleton.at(x, y, z, type, cache);
+        }
+
+        public void recycle(double[] array) {
+            this.doubleArrayCache.computeIfAbsent(array.length, k -> new ReferenceArrayList<>()).add(array);
+        }
+
+        @Override
+        public void recycle(float[] array) {
+            this.floatArrayCache.computeIfAbsent(array.length, k -> new ReferenceArrayList<>()).add(array);
+        }
+
+        public void recycle(int[] array) {
+            this.intArrayCache.computeIfAbsent(array.length, k -> new ReferenceArrayList<>()).add(array);
+        }
+
+        @Override
+        public void recycle(NoisePosVanillaInterface noisePosVanillaInterface) {
+            noisePosVanillaInterface.deInit();
+//            this.noisePosVanillaInterfacesCache.add(noisePosVanillaInterface);
+        }
+
+    }
+
+    class Noop implements DfcObjectCache {
+
+        public static final Noop INSTANCE = new Noop();
+
+        private Noop() {
+        }
+
+        @Override
+        public double[] getDoubleArray(int size, boolean zero) {
+            return new double[size];
+        }
+
+        @Override
+        public float[] getFloatArray(int size, boolean zero) {
+            return new float[size];
+        }
+
+        @Override
+        public int[] getIntArray(int size, boolean zero) {
+            return new int[size];
+        }
+
+        @Override
+        public NoisePosVanillaInterface getNoisePosVanillaInterface(int x, int y, int z, EvalType type, DfcObjectCache cache) {
+            return new NoisePosVanillaInterface().at(x, y, z, type, cache);
+        }
+
+        @Override
+        public void recycle(double[] array) {
+        }
+
+        @Override
+        public void recycle(float[] array) {
+        }
+
+        @Override
+        public void recycle(int[] array) {
+        }
+
+        @Override
+        public void recycle(NoisePosVanillaInterface noisePosVanillaInterface) {
+            noisePosVanillaInterface.deInit();
+        }
+
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/util/ZeroUtils.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/util/ZeroUtils.java
@@ -1,0 +1,39 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.util;
+
+public class ZeroUtils {
+
+    public static boolean isPositiveZero(double x) {
+        if (x != 0.0) {
+            throw new IllegalArgumentException("x isn't zero");
+        }
+        return 1.0 / x > 0.0;
+    }
+
+    private ZeroUtils() {
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/vif/EachApplierVanillaInterface.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/vif/EachApplierVanillaInterface.java
@@ -1,0 +1,88 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.vif;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.ducks.IDfcObjectCacheCapable;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class EachApplierVanillaInterface implements DensityFunction.ContextProvider, IDfcObjectCacheCapable {
+
+    private final int[] x;
+    private final int[] y;
+    private final int[] z;
+    private final EvalType type;
+    private final DfcObjectCache cache;
+
+    private final NoisePosVanillaInterface noisePosVanillaInterface = new NoisePosVanillaInterface();
+
+    public EachApplierVanillaInterface(int[] x, int[] y, int[] z, EvalType type) {
+        this(x, y, z, type, DfcObjectCache.Noop.INSTANCE);
+    }
+
+    public EachApplierVanillaInterface(int[] x, int[] y, int[] z, EvalType type, DfcObjectCache cache) {
+        this.x = Objects.requireNonNull(x);
+        this.y = Objects.requireNonNull(y);
+        this.z = Objects.requireNonNull(z);
+        this.type = Objects.requireNonNull(type);
+        this.cache = Objects.requireNonNull(cache);
+    }
+
+    @Override
+    public DensityFunction.FunctionContext forIndex(int index) {
+        return this.noisePosVanillaInterface.at(x[index], y[index], z[index], type, cache);
+    }
+
+    @Override
+    public void fillAllDirectly(double[] densities, DensityFunction densityFunction) {
+        for (int i = 0; i < x.length; i++) {
+            densities[i] = densityFunction.compute(this.forIndex(i));
+        }
+        this.noisePosVanillaInterface.deInit();
+    }
+
+    public int[] getX() {
+        return x;
+    }
+
+    public int[] getY() {
+        return y;
+    }
+
+    public int[] getZ() {
+        return z;
+    }
+
+    public EvalType getType() {
+        return type;
+    }
+
+    @Override
+    public DfcObjectCache c2me$getDfcObjectCache() {
+        return this.cache;
+    }
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/vif/NoisePosVanillaInterface.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/jvm/vif/NoisePosVanillaInterface.java
@@ -1,0 +1,93 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.jvm.vif;
+
+import com.ishland.c2me.opts.dfc.common.ast.EvalType;
+import com.ishland.c2me.opts.dfc.common.gen.jvm.util.DfcObjectCache;
+import org.jspecify.annotations.NonNull;
+
+import java.util.Objects;
+import net.minecraft.world.level.levelgen.DensityFunction;
+
+public class NoisePosVanillaInterface implements DensityFunction.FunctionContext {
+
+    private int x;
+    private int y;
+    private int z;
+    private EvalType type;
+    private DfcObjectCache cache = DfcObjectCache.Noop.INSTANCE;
+
+    public NoisePosVanillaInterface() {
+    }
+
+    public void ensureUninitialized() {
+        if (type != null) throw new IllegalStateException("double use");
+    }
+
+    private void ensureInitialized() {
+        if (type == null) throw new IllegalStateException("uninitialized use");
+    }
+
+    public NoisePosVanillaInterface at(int x, int y, int z, EvalType type, DfcObjectCache cache) {
+        this.x = x;
+        this.y = y;
+        this.z = z;
+        this.type = Objects.requireNonNull(type);
+        this.cache = Objects.requireNonNull(cache);
+        return this;
+    }
+
+    @Override
+    public int blockX() {
+        ensureInitialized();
+        return x;
+    }
+
+    @Override
+    public int blockY() {
+        ensureInitialized();
+        return y;
+    }
+
+    @Override
+    public int blockZ() {
+        ensureInitialized();
+        return z;
+    }
+
+    public EvalType getType() {
+        ensureInitialized();
+        return type;
+    }
+
+    public void deInit() {
+        this.x = 0;
+        this.y = 0;
+        this.z = 0;
+        this.type = null;
+        this.cache = DfcObjectCache.Noop.INSTANCE;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/meta/ValuesMethodDef.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/meta/ValuesMethodDef.java
@@ -1,0 +1,37 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.meta;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public interface ValuesMethodDef {
+
+    String generatedMethod();
+
+    boolean isConst();
+
+    AstNode.ReturnType returnType();
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/meta/ValuesMethodDefF32.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/meta/ValuesMethodDefF32.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.meta;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public record ValuesMethodDefF32(boolean isConst, String generatedMethod, float constValue) implements ValuesMethodDef {
+
+    public ValuesMethodDefF32(String generatedMethod) {
+        this(false, generatedMethod, Float.NaN);
+    }
+
+    public ValuesMethodDefF32(float constValue) {
+        this(true, null, constValue);
+    }
+
+    @Override
+    public AstNode.ReturnType returnType() {
+        return AstNode.ReturnType.F32;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/meta/ValuesMethodDefF64.java
+++ b/canvas-server/src/main/java/com/ishland/c2me/opts/dfc/common/gen/meta/ValuesMethodDefF64.java
@@ -1,0 +1,44 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2021-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.c2me.opts.dfc.common.gen.meta;
+
+import com.ishland.c2me.opts.dfc.common.ast.AstNode;
+
+public record ValuesMethodDefF64(boolean isConst, String generatedMethod, double constValue) implements ValuesMethodDef {
+
+    public ValuesMethodDefF64(String generatedMethod) {
+        this(false, generatedMethod, Double.NaN);
+    }
+
+    public ValuesMethodDefF64(double constValue) {
+        this(true, null, constValue);
+    }
+
+    @Override
+    public AstNode.ReturnType returnType() {
+        return AstNode.ReturnType.F64;
+    }
+
+}

--- a/canvas-server/src/main/java/com/ishland/flowsched/util/Assertions.java
+++ b/canvas-server/src/main/java/com/ishland/flowsched/util/Assertions.java
@@ -1,0 +1,55 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2022-2026 ishland
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ */
+
+package com.ishland.flowsched.util;
+
+public final class Assertions {
+
+    private Assertions() {
+    }
+
+    public static void assertTrue(boolean value, String message) {
+        if (!value) {
+            final AssertionError error = new AssertionError(message);
+            error.printStackTrace();
+            throw error;
+        }
+    }
+
+    public static void assertTrue(boolean state, String format, Object... args) {
+        if (!state) {
+            final AssertionError error = new AssertionError(String.format(format, args));
+            error.printStackTrace();
+            throw error;
+        }
+    }
+
+    public static void assertTrue(boolean value) {
+        if (!value) {
+            final AssertionError error = new AssertionError();
+            error.printStackTrace();
+            throw error;
+        }
+    }
+}

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -442,6 +442,17 @@ public class GlobalConfiguration extends Part {
         }
 
         public boolean optimizeTreasureMapLocating = false;
+
+        {
+            option("optimizeEndSurfaceGeneration")
+                .docs(
+                    "Skip the End surface pass when the dimension's surface rule is a single block that already",
+                    "matches the default End stone. The noise terrain is unchanged; only the redundant surface",
+                    "walk is avoided. Ported from Leaf / FastNoise. On by default"
+                );
+        }
+
+        public boolean optimizeEndSurfaceGeneration = true;
     }
 
     // TODO - check these on minecraft updates

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -442,6 +442,17 @@ public class GlobalConfiguration extends Part {
         }
 
         public boolean optimizeTreasureMapLocating = false;
+
+        {
+            option("densityFunctionCompiler")
+                .docs(
+                    "JIT-compiles density function trees to bytecode during worldgen. Ported from Leaf's C2ME",
+                    "DensityFunction compiler. Off by default; enabling can reduce worldgen CPU at the cost of",
+                    "compile time when a dimension's noise router is first built"
+                );
+        }
+
+        public boolean densityFunctionCompiler = false;
     }
 
     // TODO - check these on minecraft updates


### PR DESCRIPTION
- Port Leaf’s C2ME DensityFunction compiler. It JIT-compiles noise-router trees to bytecode when a dimension first builds its router. Off by default: `chunk-system.density-function-compiler` in `config/canvas-server.yml`. Enabling after worlds are already loaded does not compile those dimensions; the flag must be true at world load.
- Port Leaf’s C2ME ore BitSet pool (`OreFeature`) so vein placement reuses per-thread BitSets instead of allocating a new one per blob.
- Port Leaf’s C2ME Beardifier / structure-weight math: array iteration, one switch per piece, and a cheaper bury falloff.
- Cache world-generator sea level and biome zoom seed so worldgen stops repeating those lookups.
- Finish the leftover C2ME noise / getBiome bits Canvas did not already have (PerlinNoise.wrap, noiseWithDerivative, quart-offset table).
- Skip the End surface pass when the rule is already a single default End-stone block. Config: chunk-system.optimize-end-surface-generation (on by default).
