### PR TITLE
Extended View Distance

### DIFF
--- a/canvas-api/paper-patches/features/0001-Extended-View-Distance.patch
+++ b/canvas-api/paper-patches/features/0001-Extended-View-Distance.patch
@@ -1,0 +1,37 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <duerismc@gmail.com>
+Date: Fri, 11 Sep 2026 15:52:13 -0700
+Subject: [PATCH] Extended View Distance
+
+
+diff --git a/src/main/java/org/bukkit/entity/Player.java b/src/main/java/org/bukkit/entity/Player.java
+index 65e83e171ab4c514662b9344e08f7065fa9efaa1..d604cb620b9086fc67f77b67785a4a2e2630a290 100644
+--- a/src/main/java/org/bukkit/entity/Player.java
++++ b/src/main/java/org/bukkit/entity/Player.java
+@@ -3505,6 +3505,26 @@ public interface Player extends HumanEntity, Conversable, OfflinePlayer, PluginM
+      */
+     public void setSendViewDistance(int viewDistance);
+     // Paper end
++    // Canvas start - extended view distance
++
++    /**
++     * Gets the visual view distance for this player.
++     * <p>
++     * Visual view distance is the view distance where chunks will load in for players as fake chunks
++     * </p>
++     * @return The visual view distance for this player.
++     */
++    public int getVisualViewDistance();
++
++    /**
++     * Sets the visual view distance for this player.
++     * <p>
++     * Visual view distance is the view distance where chunks will load in for players as fake chunks
++     * </p>
++     * @param vvDistance view distance in [2, 32] or -1
++     */
++    public void setVisualViewDistance(int vvDistance);
++    // Canvas end - extended view distance
+ 
+     /**
+      * Update the list of commands sent to the client.

--- a/canvas-server/minecraft-patches/base/0008-Leaf-Flush-location-while-knockback.patch
+++ b/canvas-server/minecraft-patches/base/0008-Leaf-Flush-location-while-knockback.patch
@@ -8,10 +8,10 @@ As part of Leaf: https://github.com/Winds-Studio/Leaf/blob/58a4a9cb7994474e63ba4
 Licensed under: https://github.com/Winds-Studio/Leaf/blob/9e1b4ca7bc2e9154bc5620b7a9fef0eab3c7aae5/LICENSE.md
 
 diff --git a/net/minecraft/world/entity/player/Player.java b/net/minecraft/world/entity/player/Player.java
-index a9058f3c401979fa8ba35124c83734d790508e46..16b42374e32aa2d54237f035757aedbc37c57fcc 100644
+index f6b95af8df0e7f5af1b8ca27dfeb65ee07a24576..f53afa176a3e2b449842ca79565b22d70cb3c9e3 100644
 --- a/net/minecraft/world/entity/player/Player.java
 +++ b/net/minecraft/world/entity/player/Player.java
-@@ -1081,6 +1081,12 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -1079,6 +1079,12 @@ public abstract class Player extends Avatar implements ContainerUser {
                          this.itemAttackInteraction(entity, attackingItemStack, damageSource, true);
                          this.damageStatsAndHearts(entity, oldLivingEntityHealth);
                          this.causeFoodExhaustion(this.level().spigotConfig.combatExhaustion, org.bukkit.event.entity.EntityExhaustionEvent.ExhaustionReason.ATTACK); // CraftBukkit - EntityExhaustionEvent // Spigot - Change to use configurable value
@@ -24,7 +24,7 @@ index a9058f3c401979fa8ba35124c83734d790508e46..16b42374e32aa2d54237f035757aedbc
                      } else {
                          this.playServerSideSound(SoundEvents.PLAYER_ATTACK_NODAMAGE);
                      }
-@@ -1246,7 +1252,17 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -1244,7 +1250,17 @@ public abstract class Player extends Avatar implements ContainerUser {
              }
  
              if (!cancelled) {
@@ -43,7 +43,7 @@ index a9058f3c401979fa8ba35124c83734d790508e46..16b42374e32aa2d54237f035757aedbc
              entity.hurtMarked = false;
              entity.setDeltaMovement(oldMovement);
              }
-@@ -1364,6 +1380,12 @@ public abstract class Player extends Avatar implements ContainerUser {
+@@ -1362,6 +1378,12 @@ public abstract class Player extends Avatar implements ContainerUser {
          this.itemAttackInteraction(target, weaponItem, damageSource, wasHurt);
          this.damageStatsAndHearts(target, oldLivingEntityHealth);
          this.causeFoodExhaustion(this.level().spigotConfig.combatExhaustion, org.bukkit.event.entity.EntityExhaustionEvent.ExhaustionReason.ATTACK); // CraftBukkit - EntityExhaustionEvent // Spigot - Change to use configurable value

--- a/canvas-server/minecraft-patches/features/0003-Extended-View-Distance.patch
+++ b/canvas-server/minecraft-patches/features/0003-Extended-View-Distance.patch
@@ -1,0 +1,1209 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <duerismc@gmail.com>
+Date: Fri, 11 Sep 2026 15:52:13 -0700
+Subject: [PATCH] Extended View Distance
+
+
+diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java b/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
+index fad788a6541a7e9edd42f699d2968897d446a353..ab35b21829601da927b6b882c674cf6659fb4254 100644
+--- a/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
++++ b/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
+@@ -63,7 +63,7 @@ public final class RegionizedPlayerChunkLoader {
+         private static final VarHandle VIEW_DISTANCES_HANDLE = ConcurrentUtil.getVarHandle(ViewDistanceHolder.class, "viewDistances", ViewDistances.class);
+ 
+         public ViewDistanceHolder() {
+-            VIEW_DISTANCES_HANDLE.setVolatile(this, new ViewDistances(-1, -1, -1));
++            VIEW_DISTANCES_HANDLE.setVolatile(this, new ViewDistances(-1, -1, -1, -1)); // Canvas - extended view distance
+         }
+ 
+         public ViewDistances getViewDistances() {
+@@ -105,6 +105,14 @@ public final class RegionizedPlayerChunkLoader {
+                 return param.setSendViewDistance(distance);
+             });
+         }
++        // Canvas start - extended view distance
++
++        public void setVisualViewDistance(final int distance) {
++            this.updateViewDistance((final ViewDistances param) -> {
++                return param.setVisualViewDistance(distance);
++            });
++        }
++        // Canvas end - extended view distance
+ 
+         public JsonObject toJson() {
+             return this.getViewDistances().toJson();
+@@ -114,13 +122,16 @@ public final class RegionizedPlayerChunkLoader {
+     public static final record ViewDistances(
+         int tickViewDistance,
+         int loadViewDistance,
+-        int sendViewDistance
++        // Canvas start - extended view distance
++        int sendViewDistance,
++        int vvDistance
++        // Canvas end - extended view distance
+     ) {
+         public ViewDistances setTickViewDistance(final int distance) {
+             if (distance != -1 && (distance < (0) || distance > (MoonriseConstants.MAX_VIEW_DISTANCE))) {
+                 throw new IllegalArgumentException(Integer.toString(distance));
+             }
+-            return new ViewDistances(distance, this.loadViewDistance, this.sendViewDistance);
++            return new ViewDistances(distance, this.loadViewDistance, this.sendViewDistance, this.vvDistance); // Canvas - extended view distance
+         }
+ 
+         public ViewDistances setLoadViewDistance(final int distance) {
+@@ -128,7 +139,7 @@ public final class RegionizedPlayerChunkLoader {
+             if (distance != -1 && (distance < (2 + 1) || distance > (MoonriseConstants.MAX_VIEW_DISTANCE + 1))) {
+                 throw new IllegalArgumentException(Integer.toString(distance));
+             }
+-            return new ViewDistances(this.tickViewDistance, distance, this.sendViewDistance);
++            return new ViewDistances(this.tickViewDistance, distance, this.sendViewDistance, this.vvDistance); // Canvas - extended view distance
+         }
+ 
+         public ViewDistances setSendViewDistance(final int distance) {
+@@ -136,8 +147,17 @@ public final class RegionizedPlayerChunkLoader {
+             if (distance != -1 && (distance < (0) || distance > (MoonriseConstants.MAX_VIEW_DISTANCE))) {
+                 throw new IllegalArgumentException(Integer.toString(distance));
+             }
+-            return new ViewDistances(this.tickViewDistance, this.loadViewDistance, distance);
++            return new ViewDistances(this.tickViewDistance, this.loadViewDistance, distance, this.vvDistance); // Canvas - extended view distance
++        }
++        // Canvas start - extended view distance
++
++        public ViewDistances setVisualViewDistance(final int distance) {
++            if (distance != -1 && (distance < (0) || distance > (MoonriseConstants.MAX_VIEW_DISTANCE))) {
++                throw new IllegalArgumentException(Integer.toString(distance));
++            }
++            return new ViewDistances(this.tickViewDistance, this.loadViewDistance, this.sendViewDistance, distance);
+         }
++        // Canvas end - extended view distance
+ 
+         public JsonObject toJson() {
+             final JsonObject ret = new JsonObject();
+@@ -145,6 +165,7 @@ public final class RegionizedPlayerChunkLoader {
+             ret.addProperty("tick-view-distance", this.tickViewDistance);
+             ret.addProperty("load-view-distance", this.loadViewDistance);
+             ret.addProperty("send-view-distance", this.sendViewDistance);
++            ret.addProperty("visual-view-distance", this.vvDistance); // Canvas - extended view distance
+ 
+             return ret;
+         }
+@@ -177,6 +198,17 @@ public final class RegionizedPlayerChunkLoader {
+         }
+         return data.lastSendDistance;
+     }
++    // Canvas start - extended view distance
++
++    public static int getAPIVisualViewDistance(final ServerPlayer player) {
++        final ServerLevel level = player.level();
++        final PlayerChunkLoaderData data = ((ChunkSystemServerPlayer)player).moonrise$getChunkLoader();
++        if (data == null) {
++            return ((ChunkSystemServerLevel)level).moonrise$getPlayerChunkLoader().getAPIVisualViewDistance();
++        }
++        return data.lastVVDistance;
++    }
++    // Canavs end - extended view distance
+ 
+     private final ServerLevel world;
+ 
+@@ -236,6 +268,12 @@ public final class RegionizedPlayerChunkLoader {
+     public void setTickDistance(final int distance) {
+         ((ChunkSystemServerLevel)this.world).moonrise$getViewDistanceHolder().setTickViewDistance(distance);
+     }
++    // Canvas start - extended view distance
++
++    public void setVisualViewDistance(final int distance) {
++        ((ChunkSystemServerLevel)this.world).moonrise$getViewDistanceHolder().setVisualViewDistance(distance);
++    }
++    // Canvas end - extended view distance
+ 
+     // Note: follow the player chunk loader so everything stays consistent...
+     public int getAPITickDistance() {
+@@ -272,6 +310,25 @@ public final class RegionizedPlayerChunkLoader {
+ 
+         return sendViewDistance;
+     }
++    // Canvas start - extended view distance
++
++    public int getAPIVisualViewDistance() {
++        final ViewDistances distances = ((ChunkSystemServerLevel)this.world).moonrise$getViewDistanceHolder().getViewDistances();
++        final int tickViewDistance = PlayerChunkLoaderData.getTickDistance(
++            -1, distances.tickViewDistance,
++            -1, distances.loadViewDistance
++        );
++        final int loadDistance = PlayerChunkLoaderData.getLoadViewDistance(tickViewDistance, -1, distances.loadViewDistance);
++        final int sendViewDistance = PlayerChunkLoaderData.getSendViewDistance(
++            loadDistance, -1, -1, distances.sendViewDistance
++        );
++
++        final int serverVVD = io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.visualViewDistance.vvDistance;
++        final int worldVVD = distances.vvDistance;
++
++        return PlayerChunkLoaderData.getVisualViewDistance(sendViewDistance, -1, worldVVD, serverVVD);
++    }
++    // Canvas end - extended view distance
+ 
+     public boolean isChunkSent(final ServerPlayer player, final int chunkX, final int chunkZ, final boolean borderOnly) {
+         return borderOnly ? this.isChunkSentBorderOnly(player, chunkX, chunkZ) : this.isChunkSent(player, chunkX, chunkZ);
+@@ -334,6 +391,7 @@ public final class RegionizedPlayerChunkLoader {
+         private int lastSendDistance = Integer.MIN_VALUE;
+         private int lastLoadDistance = Integer.MIN_VALUE;
+         private int lastTickDistance = Integer.MIN_VALUE;
++        private int lastVVDistance = Integer.MIN_VALUE; // Canvas - extended view distance
+ 
+         private int lastSentChunkCenterX = Integer.MIN_VALUE;
+         private int lastSentChunkCenterZ = Integer.MIN_VALUE;
+@@ -345,6 +403,10 @@ public final class RegionizedPlayerChunkLoader {
+ 
+         private final ArrayDeque<ChunkHolderManager.TicketOperation<?, ?>> delayedTicketOps = new ArrayDeque<>();
+         private final LongOpenHashSet sentChunks = new LongOpenHashSet();
++        // Canvas start - extended view distance
++        private final LongOpenHashSet fakeChunks = new LongOpenHashSet();
++        private final LongOpenHashSet pendingForget = new LongOpenHashSet();
++        // Canvas end - extended view distance
+ 
+         private static final byte CHUNK_TICKET_STAGE_NONE           = 0;
+         private static final byte CHUNK_TICKET_STAGE_LOADING        = 1;
+@@ -411,6 +473,10 @@ public final class RegionizedPlayerChunkLoader {
+         private final LongHeapPriorityQueue genQueue = new LongHeapPriorityQueue(this.queueComparator);
+         private final LongHeapPriorityQueue loadingQueue = new LongHeapPriorityQueue(this.queueComparator);
+         private final LongHeapPriorityQueue loadQueue = new LongHeapPriorityQueue(this.queueComparator);
++        // Canvas start - extended view distance
++        private final LongHeapPriorityQueue vvBuildQueue = new LongHeapPriorityQueue(this.queueComparator);
++        private final LongArrayList vvBuildingQueue = new LongArrayList();
++        // Canvas end - extended view distance
+ 
+         private volatile boolean removed;
+ 
+@@ -432,7 +498,18 @@ public final class RegionizedPlayerChunkLoader {
+         }
+ 
+         private void sendChunk(final int chunkX, final int chunkZ) {
+-            if (this.sentChunks.add(CoordinateUtils.getChunkKey(chunkX, chunkZ))) {
++            // Canvas start - extended view distance
++            final long chunkKey = CoordinateUtils.getChunkKey(chunkX, chunkZ);
++
++            this.pendingForget.remove(chunkKey);
++            if (this.fakeChunks.remove(chunkKey)) {
++                // there was a fake chunk, we can unwatch it, we are sending a real chunk now
++                this.sentChunks.remove(chunkKey);
++                this.world.extendedViewDistance().cache.unwatch(chunkKey);
++            }
++
++            if (this.sentChunks.add(chunkKey)) {
++            // Canvas end - extended view distance
+                 ((ChunkSystemChunkHolder)((ChunkSystemServerLevel)this.world).moonrise$getChunkTaskScheduler().chunkHolderManager
+                         .getChunkHolder(chunkX, chunkZ).vanillaChunkHolder).moonrise$addReceivedChunk(this.player);
+ 
+@@ -446,24 +523,43 @@ public final class RegionizedPlayerChunkLoader {
+         }
+ 
+         private void sendUnloadChunk(final int chunkX, final int chunkZ) {
+-            if (!this.sentChunks.remove(CoordinateUtils.getChunkKey(chunkX, chunkZ))) {
+-                return;
++            // Canvas start - extended view distance
++            final long chunkKey = CoordinateUtils.getChunkKey(chunkX, chunkZ);
++            final boolean wasSent = this.sentChunks.remove(chunkKey);
++            final boolean wasFake = wasSent && this.fakeChunks.remove(chunkKey);
++            final boolean owedForget = wasSent ? wasFake : this.pendingForget.remove(chunkKey);
++
++            if (wasFake) {
++                this.world.extendedViewDistance().cache.unwatch(chunkKey);
++            }
++
++            if (wasSent && !owedForget) {
++                this.sendUnloadChunkRaw(chunkX, chunkZ);
++            } else if (owedForget) {
++                this.player.connection.send(new ClientboundForgetLevelChunkPacket(new ChunkPos(chunkX, chunkZ)));
+             }
+-            this.sendUnloadChunkRaw(chunkX, chunkZ);
++            // Canvas end - extended view distance
+         }
+ 
+         private void sendUnloadChunkRaw(final int chunkX, final int chunkZ) {
++        // Canvas start - extended view distance
++            sendUnloadChunkRaw(chunkX, chunkZ, false);
++        }
++
++        private void sendUnloadChunkRaw(final int chunkX, final int chunkZ, final boolean addToPending) {
++        // Canvas end - extended view distance
+             PlatformHooks.get().onChunkUnWatch(this.world, new ChunkPos(chunkX, chunkZ), this.player);
+             // Note: Check PlayerChunkSender#dropChunk for other logic
+             // Note: drop isAlive() check so that chunks properly unload client-side when the player dies
+             ((ChunkSystemChunkHolder)((ChunkSystemServerLevel)this.world).moonrise$getChunkTaskScheduler().chunkHolderManager
+                 .getChunkHolder(chunkX, chunkZ).vanillaChunkHolder).moonrise$removeReceivedChunk(this.player);
+-            this.player.connection.send(new ClientboundForgetLevelChunkPacket(new ChunkPos(chunkX, chunkZ)));
++            if (!addToPending) this.player.connection.send(new ClientboundForgetLevelChunkPacket(new ChunkPos(chunkX, chunkZ))); // Canvas - extended view distance
+             // Paper start - PlayerChunkUnloadEvent
+             if (io.papermc.paper.event.packet.PlayerChunkUnloadEvent.getHandlerList().getRegisteredListeners().length > 0) {
+                 new io.papermc.paper.event.packet.PlayerChunkUnloadEvent(player.getBukkitEntity().getWorld().getChunkAt(new ChunkPos(chunkX, chunkZ).longKey()), player.getBukkitEntity()).callEvent();
+             }
+             // Paper end - PlayerChunkUnloadEvent
++            if (addToPending) this.pendingForget.add(CoordinateUtils.getChunkKey(chunkX, chunkZ)); // Canvas - extended view distance
+         }
+ 
+         private final SingleUserAreaMap<PlayerChunkLoaderData> broadcastMap = new SingleUserAreaMap<>(this) {
+@@ -560,6 +656,23 @@ public final class RegionizedPlayerChunkLoader {
+             );
+         }
+ 
++        // Canvas start - extended view distance
++        private static int getVisualViewDistance(
++            final int sendViewDistance, final int playerVVD, final int worldVVD, final int serverVVD
++        ) {
++            if (playerVVD <= 0 && worldVVD <= 0 && serverVVD <= 0) {
++                return sendViewDistance;
++            }
++
++            final int vvd = playerVVD <= 0 ? worldVVD <= 0 ? serverVVD : worldVVD : playerVVD;
++            return Math.max(sendViewDistance, Math.clamp(vvd, 0, MoonriseConstants.MAX_VIEW_DISTANCE));
++        }
++
++        private static int squaredDistance(final int dx, final int dz) {
++            return (dx * dx) + (dz * dz);
++        }
++
++        // Canvas end - extended view distance
+         private Packet<?> updateClientChunkRadius(final int radius) {
+             this.lastSentChunkRadius = radius;
+             return new ClientboundSetChunkCacheRadiusPacket(radius);
+@@ -634,6 +747,16 @@ public final class RegionizedPlayerChunkLoader {
+             );
+         }
+ 
++        // Canvas start - extended view distance
++        private boolean wantChunkInVVRange(final int chunkX, final int chunkZ) {
++            final int dx = this.lastChunkX - chunkX;
++            final int dz = this.lastChunkZ - chunkZ;
++            return (Math.max(Math.abs(dx), Math.abs(dz)) <= (this.lastVVDistance + 1)) && wantChunkLoaded(
++                this.lastChunkX, this.lastChunkZ, chunkX, chunkZ, this.lastVVDistance
++            );
++        }
++
++        // Canvas end - extended view distance
+         private boolean wantChunkTicked(final int chunkX, final int chunkZ) {
+             final int dx = this.lastChunkX - chunkX;
+             final int dz = this.lastChunkZ - chunkZ;
+@@ -842,6 +965,14 @@ public final class RegionizedPlayerChunkLoader {
+                 final long pendingSend = this.sendQueue.firstLong();
+                 final int pendingSendX = CoordinateUtils.getChunkX(pendingSend);
+                 final int pendingSendZ = CoordinateUtils.getChunkZ(pendingSend);
++                // Canvas start - extended view distance
++
++                // probably a fake chunk, break
++                if (!this.wantChunkSent(pendingSendX, pendingSendZ)) {
++                    break;
++                }
++
++                // Canvas end - extended view distance
+                 final LevelChunk chunk = ((ChunkSystemLevel)this.world).moonrise$getFullChunkIfLoaded(pendingSendX, pendingSendZ);
+                 if (!this.areNeighboursGenerated(pendingSendX, pendingSendZ, 1) || !TickThread.isTickThreadFor(this.world, pendingSendX, pendingSendZ)) {
+                     // nothing to do
+@@ -866,6 +997,111 @@ public final class RegionizedPlayerChunkLoader {
+                 }
+             }
+ 
++            // Canvas start - extended view distance
++            final io.canvasmc.canvas.extendedview.ExtendedViewDistance extendedViewDistance = this.world.extendedViewDistance();
++
++            // we need to resolve the nearest blocker to prevent weird shit from happening with the client
++            int nearestBlocker = this.vvBuildQueue.isEmpty()
++                ? Integer.MAX_VALUE
++                : squaredDistance(
++                    CoordinateUtils.getChunkX(this.vvBuildQueue.firstLong()) - this.lastChunkX,
++                    CoordinateUtils.getChunkZ(this.vvBuildQueue.firstLong()) - this.lastChunkZ
++                );
++            for (int index = 0, size = this.vvBuildingQueue.size(); index < size; ++index) {
++                final long pendingBuild = this.vvBuildingQueue.getLong(index);
++                final int pendingBuildX = CoordinateUtils.getChunkX(pendingBuild);
++                final int pendingBuildZ = CoordinateUtils.getChunkZ(pendingBuild);
++                final io.canvasmc.canvas.extendedview.Result result = extendedViewDistance.tryLoad(pendingBuildX, pendingBuildZ).getNow(null);
++
++                //noinspection ConstantValue - stfu IntelliJ
++                if (result == null || !result.isSuccess()) {
++                    nearestBlocker = Math.min(
++                        nearestBlocker,
++                        squaredDistance(pendingBuildX - this.lastChunkX, pendingBuildZ - this.lastChunkZ)
++                    );
++                }
++            }
++
++            for (final it.unimi.dsi.fastutil.longs.LongIterator it = this.vvBuildingQueue.iterator(); it.hasNext();) {
++                final long pendingBuild = it.nextLong();
++                final int pendingBuildX = CoordinateUtils.getChunkX(pendingBuild);
++                final int pendingBuildZ = CoordinateUtils.getChunkZ(pendingBuild);
++
++                // check future completion
++                final java.util.concurrent.CompletableFuture<io.canvasmc.canvas.extendedview.Result>
++                    future = extendedViewDistance.tryLoad(pendingBuildX, pendingBuildZ);
++                if (!future.isDone()) {
++                    continue;
++                }
++
++                final io.canvasmc.canvas.extendedview.Result result = future.getNow(null);
++                if (!result.isSuccess()) {
++                    if (this.pendingForget.remove(pendingBuild)) {
++                        this.player.connection.send(new ClientboundForgetLevelChunkPacket(new ChunkPos(pendingBuildX, pendingBuildZ)));
++                    }
++
++                    // remove, the fake load finished or failed, so not needed here anymore
++                    it.remove();
++                    continue;
++                }
++
++                final int distance = squaredDistance(pendingBuildX - this.lastChunkX, pendingBuildZ - this.lastChunkZ);
++                if (distance > nearestBlocker) {
++                    // there is a blocker, and it's farther away than the blocker, don't queue
++                    continue;
++                }
++
++                // this can be sent to the client, queue it
++                this.sendQueue.enqueue(pendingBuild);
++                it.remove();
++            }
++
++            // add all from the build queue -> buildING queue, start fake load
++            while (!this.vvBuildQueue.isEmpty()) {
++                final long pendingBuild = this.vvBuildQueue.dequeueLong();
++
++                // start load, add to building queue
++                extendedViewDistance.tryLoad(CoordinateUtils.getChunkX(pendingBuild), CoordinateUtils.getChunkZ(pendingBuild));
++                this.vvBuildingQueue.add(pendingBuild);
++            }
++
++            // try and send fake chunks in queue
++            for (int i = 0; i < maxSendsThisTick && !this.sendQueue.isEmpty(); ++i) {
++                final long pendingSend = this.sendQueue.firstLong();
++                final int pendingSendX = CoordinateUtils.getChunkX(pendingSend);
++                final int pendingSendZ = CoordinateUtils.getChunkZ(pendingSend);
++
++                // if the server wants this as a real chunk, break, not ready yet
++                if (this.wantChunkSent(pendingSendX, pendingSendZ)) {
++                    break;
++                }
++
++                this.sendQueue.dequeueLong();
++
++                final io.canvasmc.canvas.extendedview.Result result = extendedViewDistance.tryLoad(pendingSendX, pendingSendZ).getNow(null);
++                if (result == null || !result.isSuccess()) {
++                    this.vvBuildingQueue.add(pendingSend);
++                    continue;
++                }
++
++                if (this.wantChunkInVVRange(pendingSendX, pendingSendZ) && !this.sentChunks.contains(pendingSend)) {
++                    // send the fake chunk now
++                    final net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket packet = result.getPacketOrThrow();
++
++                    // add to sent and fake chunks, mark watch in cache
++                    this.sentChunks.add(pendingSend);
++                    this.fakeChunks.add(pendingSend);
++                    extendedViewDistance.cache.watch(pendingSend);
++
++                    // remove from pending forget and send chunk packet
++                    this.pendingForget.remove(pendingSend);
++                    this.player.connection.send(packet);
++                } else {
++                    extendedViewDistance.cache.evictIfUnwatched(pendingSend);
++                }
++            }
++
++            // Canvas end - extended view distance
+             this.flushDelayedTicketOps();
+         }
+ 
+@@ -888,13 +1124,14 @@ public final class RegionizedPlayerChunkLoader {
+             // send view cannot be greater-than load view
+             final int clientViewDistance = getClientViewDistance(this.player);
+             final int sendViewDistance = getSendViewDistance(loadViewDistance, clientViewDistance, playerDistances.sendViewDistance, worldDistances.sendViewDistance);
++            final int vvDistance = getVisualViewDistance(sendViewDistance, playerDistances.vvDistance, worldDistances.vvDistance, io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.visualViewDistance.vvDistance); // Canvas - extended view distance
+ 
+             // send view distances
+-            this.player.connection.send(this.updateClientChunkRadius(sendViewDistance));
++            this.player.connection.send(this.updateClientChunkRadius(vvDistance)); // Canvas - extended view distance
+             this.player.connection.send(this.updateClientSimulationDistance(tickViewDistance));
+ 
+             // add to distance maps
+-            this.broadcastMap.add(chunkX, chunkZ, sendViewDistance + 1);
++            this.broadcastMap.add(chunkX, chunkZ, vvDistance + 1); // Canvas - extended view distance
+             this.loadTicketCleanup.add(chunkX, chunkZ, loadViewDistance + 1);
+             this.tickMap.add(chunkX, chunkZ, tickViewDistance);
+ 
+@@ -935,6 +1172,7 @@ public final class RegionizedPlayerChunkLoader {
+             // send view cannot be greater-than load view
+             final int clientViewDistance = getClientViewDistance(this.player);
+             final int sendViewDistance = getSendViewDistance(loadViewDistance, clientViewDistance, playerDistances.sendViewDistance, worldDistances.sendViewDistance);
++            final int vvDistance = getVisualViewDistance(sendViewDistance, playerDistances.vvDistance, worldDistances.vvDistance, io.canvasmc.canvas.GlobalConfiguration.getInstance().chunkSystem.visualViewDistance.vvDistance); // Canvas - extended view distance
+ 
+             final ChunkPos playerPos = this.player.chunkPosition();
+             final boolean canGenerateChunks = this.canPlayerGenerateChunks();
+@@ -949,6 +1187,7 @@ public final class RegionizedPlayerChunkLoader {
+                 sendViewDistance == this.lastSendDistance
+                     && loadViewDistance == this.lastLoadDistance
+                     && tickViewDistance == this.lastTickDistance
++                    && vvDistance == this.lastVVDistance // Canvas - extended view distance
+ 
+                     // has our chunk stayed the same?
+                     && prevChunkX == currentChunkX
+@@ -962,7 +1201,7 @@ public final class RegionizedPlayerChunkLoader {
+             }
+ 
+             // update distance maps
+-            this.broadcastMap.update(currentChunkX, currentChunkZ, sendViewDistance + 1);
++            this.broadcastMap.update(currentChunkX, currentChunkZ, vvDistance + 1); // Canvas - extended view distance
+             this.loadTicketCleanup.update(currentChunkX, currentChunkZ, loadViewDistance + 1);
+             this.tickMap.update(currentChunkX, currentChunkZ, tickViewDistance);
+             if (sendViewDistance > loadViewDistance || tickViewDistance > loadViewDistance) {
+@@ -971,8 +1210,10 @@ public final class RegionizedPlayerChunkLoader {
+ 
+             // update VDs for client
+             // this should be after the distance map updates, as they will send unload packets
+-            if (this.lastSentChunkRadius != sendViewDistance) {
+-                this.player.connection.send(this.updateClientChunkRadius(sendViewDistance));
++            // Canvas start - extended view distance
++            if (this.lastSentChunkRadius != vvDistance) {
++                this.player.connection.send(this.updateClientChunkRadius(vvDistance));
++            // Canvas end - extended view distance
+             }
+             if (this.lastSentSimulationDistance != tickViewDistance) {
+                 this.player.connection.send(this.updateClientSimulationDistance(tickViewDistance));
+@@ -984,16 +1225,19 @@ public final class RegionizedPlayerChunkLoader {
+             this.genQueue.clear();
+             this.loadingQueue.clear();
+             this.loadQueue.clear();
++            this.vvBuildQueue.clear(); // Canvas - extended view distance
++            this.vvBuildingQueue.clear(); // Canvas - extended view distance
+ 
+             this.lastChunkX = currentChunkX;
+             this.lastChunkZ = currentChunkZ;
+             this.lastSendDistance = sendViewDistance;
+             this.lastLoadDistance = loadViewDistance;
+             this.lastTickDistance = tickViewDistance;
++            this.lastVVDistance = vvDistance; // Canvas - extended view distance
+             this.canGenerateChunks = canGenerateChunks;
+ 
+             // +1 since we need to load chunks +1 around the load view distance...
+-            final long[] toIterate = ParallelSearchRadiusIteration.getEuclideanIteration(loadViewDistance + 1);
++            final long[] toIterate = ParallelSearchRadiusIteration.getEuclideanIteration(vvDistance + 1); // Canvas - extended view distance
+             // the iteration order is by increasing manhattan distance - so, we do NOT need to
+             // sort anything in the queue!
+             for (final long deltaChunk : toIterate) {
+@@ -1004,6 +1248,7 @@ public final class RegionizedPlayerChunkLoader {
+                 final long chunk = CoordinateUtils.getChunkKey(chunkX, chunkZ);
+                 final int squareDistance = Math.max(Math.abs(dx), Math.abs(dz));
+                 final int manhattanDistance = Math.abs(dx) + Math.abs(dz);
++                final boolean withinLoadRange = squareDistance <= (loadViewDistance + 1); // Canvas - extended view distance
+ 
+                 // since chunk sending is not by radius alone, we need an extra check here to account for
+                 // everything <= sendDistance
+@@ -1011,12 +1256,31 @@ public final class RegionizedPlayerChunkLoader {
+                 // the dist <= view check
+                 final boolean sendChunk = (squareDistance <= (sendViewDistance + 1))
+                     && wantChunkLoaded(currentChunkX, currentChunkZ, chunkX, chunkZ, sendViewDistance);
+-                final boolean sentChunk = sendChunk ? this.sentChunks.contains(chunk) : this.sentChunks.remove(chunk);
++                // Canvas start - extended view distance
++                final boolean vvChunk = !sendChunk && (squareDistance <= (vvDistance + 1))
++                    && wantChunkLoaded(currentChunkX, currentChunkZ, chunkX, chunkZ, vvDistance);
++                final boolean isFake = this.fakeChunks.contains(chunk);
++                final boolean keepSent = !sendChunk && this.sentChunks.contains(chunk) && (isFake ? vvChunk : withinLoadRange);
++
++                boolean sentChunk = keepSent || (sendChunk ? this.sentChunks.contains(chunk) && !isFake : this.sentChunks.remove(chunk));
++                if (!sendChunk && !keepSent && sentChunk) {
++                    this.fakeChunks.remove(chunk);
++                    if (isFake) {
++                        this.world.extendedViewDistance().cache.unwatch(chunk);
++                        this.player.connection.send(new ClientboundForgetLevelChunkPacket(new ChunkPos(chunkX, chunkZ)));
++                    } else {
++                        this.sendUnloadChunkRaw(chunkX, chunkZ, vvChunk);
++                    }
++                    sentChunk = false;
++                }
++
++                if (vvChunk && !sentChunk) {
++                    this.vvBuildQueue.enqueue(chunk);
++                }
+ 
+-                if (!sendChunk && sentChunk) {
+-                    // have sent the chunk, but don't want it anymore
+-                    // unload it now
+-                    this.sendUnloadChunkRaw(chunkX, chunkZ);
++                if (!withinLoadRange) {
++                    continue;
++                // Canvas end - extended view distance
+                 }
+ 
+                 final byte stage = this.chunkTicketStage.get(chunk);
+@@ -1090,6 +1354,8 @@ public final class RegionizedPlayerChunkLoader {
+             this.genQueue.clear();
+             this.loadingQueue.clear();
+             this.loadQueue.clear();
++            this.vvBuildQueue.clear(); // Canvas - extended view distance
++            this.vvBuildingQueue.clear(); // Canvas - extended view distance
+ 
+             // flush ticket changes
+             this.flushDelayedTicketOps();
+diff --git a/io/canvasmc/canvas/extendedview/ExtendedViewDistance.java b/io/canvasmc/canvas/extendedview/ExtendedViewDistance.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..712dec5a195a1fb5ffb8c720a451c27a0a2b3be2
+--- /dev/null
++++ b/io/canvasmc/canvas/extendedview/ExtendedViewDistance.java
+@@ -0,0 +1,195 @@
++package io.canvasmc.canvas.extendedview;
++
++import ca.spottedleaf.concurrentutil.executor.PrioritisedExecutor;
++import ca.spottedleaf.concurrentutil.util.Priority;
++import ca.spottedleaf.moonrise.common.util.CoordinateUtils;
++import ca.spottedleaf.moonrise.common.util.MoonriseCommon;
++import ca.spottedleaf.moonrise.patches.chunk_system.io.MoonriseRegionFileIO;
++import com.mojang.logging.LogUtils;
++import io.canvasmc.canvas.GlobalConfiguration;
++import io.canvasmc.canvas.util.Util;
++import java.util.concurrent.CompletableFuture;
++import net.minecraft.nbt.CompoundTag;
++import net.minecraft.network.protocol.game.ClientboundLevelChunkPacketData;
++import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
++import net.minecraft.network.protocol.game.ClientboundLightUpdatePacketData;
++import net.minecraft.server.level.ServerLevel;
++import net.minecraft.world.level.ChunkPos;
++import net.minecraft.world.level.chunk.LevelChunk;
++import net.minecraft.world.level.chunk.LevelChunkSection;
++import net.minecraft.world.level.chunk.PalettedContainerFactory;
++import net.minecraft.world.level.chunk.UpgradeData;
++import net.minecraft.world.level.chunk.status.ChunkStatus;
++import net.minecraft.world.level.chunk.storage.SerializableChunkData;
++import net.minecraft.world.ticks.LevelChunkTicks;
++import org.jspecify.annotations.Nullable;
++import org.slf4j.Logger;
++
++public final class ExtendedViewDistance {
++
++    public static final Logger LOGGER = LogUtils.getLogger();
++
++    // we use our own executor in the worker pool for building data after the io read
++    private static final PrioritisedExecutor PACKET_BUILD_EXECUTOR = MoonriseCommon.SERVER_GROUP.createExecutor();
++
++    public final VVChunkCache cache = new VVChunkCache();
++
++    private final ServerLevel world;
++    private final LevelChunkSection airSection;
++
++    public ExtendedViewDistance(final ServerLevel world) {
++        this.world = world;
++
++        final PalettedContainerFactory factory = PalettedContainerFactory.create(this.world.registryAccess());
++        this.airSection = new LevelChunkSection(factory.createForBlockStates(), factory.createForBiomes());
++    }
++
++    public CompletableFuture<Result> tryLoad(final int chunkX, final int chunkZ) {
++        return this.cache.computeIfAbsent(
++            CoordinateUtils.getChunkKey(chunkX, chunkZ),
++            (_) -> this.startBuild(chunkX, chunkZ)
++        );
++    }
++
++    private CompletableFuture<Result> startBuild(final int chunkX, final int chunkZ) {
++        final long chunkKey = CoordinateUtils.getChunkKey(chunkX, chunkZ);
++        final CompletableFuture<Result> future = new CompletableFuture<>();
++
++        try {
++            // load the chunk data ONLY
++            MoonriseRegionFileIO.loadDataAsync(
++                this.world,
++                chunkX,
++                chunkZ,
++                MoonriseRegionFileIO.RegionFileType.CHUNK_DATA,
++                (tag, throwable) -> PACKET_BUILD_EXECUTOR.queueTask(
++                    () -> this.completeBuild(chunkKey, chunkX, chunkZ, future, tag, throwable), Priority.IDLE
++                ),
++                false,
++                Priority.IDLE // use idle, i dont give a fuck about this
++            );
++        } catch (final Throwable thrown) {
++            this.cache.remove(chunkKey, future);
++
++            // ruh roh :(
++            future.complete(new Result.Failure(thrown));
++        }
++
++        return future;
++    }
++
++    private void completeBuild(
++        final long chunkKey,
++        final int chunkX,
++        final int chunkZ,
++        final CompletableFuture<Result> future,
++        @Nullable
++        final CompoundTag tag,
++        @Nullable
++        final Throwable ioThrowable
++    ) {
++        if (ioThrowable != null) {
++            // failed, remove from cache and return
++            this.cache.remove(chunkKey, future);
++            future.complete(new Result.Failure(ioThrowable));
++            return;
++        }
++
++        try {
++            if (tag != null) {
++                // parse the tag and then try and create the packet
++                final SerializableChunkData data = SerializableChunkData.parse(
++                    this.world,
++                    this.world.palettedContainerFactory(),
++                    tag
++                );
++
++                //noinspection ConstantValue - the data is nullable, stfu IntelliJ
++                if (
++                    data != null &&
++                    data.chunkStatus().isOrAfter(ChunkStatus.FULL) &&
++                    data.chunkPos().equals(new ChunkPos(chunkX, chunkZ))
++                ) {
++                    final Result.Success result = this.buildRealChunkPacket(chunkX, chunkZ, data);
++
++                    // set "ready" bc of antixray
++                    result.packet().setReady(true);
++                    future.complete(result);
++                    return;
++                }
++            }
++
++            // not generated or something
++            this.cache.remove(chunkKey, future);
++            future.complete(Result.NotGenerated.INSTANCE);
++        } catch (final Throwable thrown) {
++            LOGGER.warn(
++                "Failed to build VV chunk at ({}, {}) in '{}', treating it as ungenerated",
++                chunkX,
++                chunkZ,
++                Util.getLevelName(this.world),
++                thrown
++            );
++
++            // remove from cache and report failure
++            this.cache.remove(chunkKey, future);
++            future.complete(new Result.Failure(thrown));
++        }
++    }
++
++    private Result.Success buildRealChunkPacket(
++        final int chunkX,
++        final int chunkZ,
++        final SerializableChunkData data
++    ) {
++        final int sectionCount = this.world.getSectionsCount();
++        final int minSectionY = this.world.getMinSectionY();
++
++        @Nullable
++        final LevelChunkSection[] sections = new LevelChunkSection[sectionCount];
++
++        // truncate and read sections
++        for (final SerializableChunkData.SectionData sectionData : data.sectionData()) {
++            final int index = sectionData.y() - minSectionY;
++            if (index >= 0 && index < sectionCount && sectionData.chunkSection() != null) {
++                sections[index] = sectionData.chunkSection();
++            }
++        }
++
++        // replace "null" sections with air
++        for (int index = 0; index < sectionCount; ++index) {
++            // this makes "sections" nonnull - required
++            if (sections[index] == null) {
++                sections[index] = this.airSection;
++            }
++        }
++
++        // try hollow chunks before we create the actual chunk object
++        if (GlobalConfiguration.getInstance().chunkSystem.visualViewDistance.hollowChunks) {
++            //noinspection NullableProblems - we made "sections" nonnull above
++            PacketConstructorUtils.carveChunk(sections, this.world, this.airSection);
++        }
++
++        // remove the ores if asked of us
++        if (GlobalConfiguration.getInstance().chunkSystem.visualViewDistance.hideOres) {
++            //noinspection NullableProblems - we made "sections" nonnull above
++            PacketConstructorUtils.clearOres(sections);
++        }
++
++        //noinspection NullableProblems - we made "sections" nonnull above
++        final LevelChunk chunk = new LevelChunk(
++            this.world, new ChunkPos(chunkX, chunkZ), UpgradeData.EMPTY,
++            new LevelChunkTicks<>(), new LevelChunkTicks<>(), 0L, sections, null, null
++        );
++
++        // construct and return the finished packet
++        //noinspection DataFlowIssue - chunkPacketInfo can be null, Paper didnt add that annotation
++        final ClientboundLevelChunkPacketData chunkData = new ClientboundLevelChunkPacketData(chunk, null);
++        final ClientboundLightUpdatePacketData lightData = PacketConstructorUtils.createLightData(
++            data,
++            this.world
++        );
++
++        return new Result.Success(new ClientboundLevelChunkWithLightPacket(chunkX, chunkZ, chunkData, lightData));
++    }
++}
+diff --git a/io/canvasmc/canvas/extendedview/PacketConstructorUtils.java b/io/canvasmc/canvas/extendedview/PacketConstructorUtils.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..568faeca6f97e23a30b661bb26749f50e519e156
+--- /dev/null
++++ b/io/canvasmc/canvas/extendedview/PacketConstructorUtils.java
+@@ -0,0 +1,210 @@
++package io.canvasmc.canvas.extendedview;
++
++import it.unimi.dsi.fastutil.objects.ObjectArrayList;
++import java.util.BitSet;
++import java.util.function.Predicate;
++import net.minecraft.network.protocol.game.ClientboundLightUpdatePacketData;
++import net.minecraft.server.level.ServerLevel;
++import net.minecraft.tags.BlockTags;
++import net.minecraft.world.level.block.Blocks;
++import net.minecraft.world.level.block.state.BlockState;
++import net.minecraft.world.level.chunk.DataLayer;
++import net.minecraft.world.level.chunk.LevelChunkSection;
++import net.minecraft.world.level.chunk.storage.SerializableChunkData;
++import net.minecraft.world.level.lighting.LevelLightEngine;
++import org.jspecify.annotations.Nullable;
++
++public class PacketConstructorUtils {
++
++    public static final int MASK_SIZE = 4096; // 16^3
++
++    private static final Predicate<BlockState> IS_ORE = (state) ->
++        state.is(BlockTags.COPPER_ORES)
++        || state.is(BlockTags.IRON_ORES)
++        || state.is(BlockTags.GOLD_ORES)
++        || state.is(Blocks.COAL_ORE)
++        || state.is(Blocks.DEEPSLATE_COAL_ORE)
++        || state.is(Blocks.LAPIS_ORE)
++        || state.is(Blocks.DEEPSLATE_LAPIS_ORE)
++        || state.is(Blocks.REDSTONE_ORE)
++        || state.is(Blocks.DEEPSLATE_REDSTONE_ORE)
++        || state.is(Blocks.DIAMOND_ORE)
++        || state.is(Blocks.DEEPSLATE_DIAMOND_ORE);
++
++    public static void clearOres(final LevelChunkSection[] sections) {
++        for (final LevelChunkSection section : sections) {
++            if (section.hasOnlyAir()) {
++                continue;
++            }
++
++            for (int y = 0; y < 16; ++y) {
++                for (int x = 0; x < 16; ++x) {
++                    for (int z = 0; z < 16; ++z) {
++                        final BlockState state = section.getBlockState(x, y, z);
++                        if (state.isAir()) {
++                            // don't care
++                            continue;
++                        }
++
++                        if (IS_ORE.test(state)) {
++                            // is an ore, replace with stone
++                            // we already truncate the bottom half of the world, so we can
++                            // do stone without worrying about blending with deepslate
++                            section.setBlockState(x, y, z, Blocks.STONE.defaultBlockState(), false);
++                            continue;
++                        }
++
++                        // netherite needs a special case because that's for the nether only
++                        if (state.is(Blocks.ANCIENT_DEBRIS)) {
++                            section.setBlockState(x, y, z, Blocks.NETHERRACK.defaultBlockState(), false);
++                        }
++                    }
++                }
++            }
++        }
++    }
++
++    public static void carveChunk(
++        final LevelChunkSection[] sections,
++        final ServerLevel world,
++        final LevelChunkSection airSection
++    ) {
++        final int sectionCount = sections.length;
++        final int minSectionY = world.getMinSectionY();
++        final BlockState air = Blocks.AIR.defaultBlockState();
++
++        @Nullable final BitSet[] translucentInSection = new BitSet[sectionCount];
++
++        // collect the translucent blocks in the section first, since if we
++        // modify in the same pass then we get weird inaccurate carving
++
++        for (int index = 0; index < sectionCount; ++index) {
++            final int sectionBaseY = (index + minSectionY) << 4;
++            final LevelChunkSection section = sectionBaseY + 15 <= 0 ? (sections[index] = airSection) : sections[index];
++            if (section.hasOnlyAir()) {
++                continue;
++            }
++
++            final BitSet mask = new BitSet(MASK_SIZE);
++            for (int y = 0; y < 16; ++y) {
++                for (int x = 0; x < 16; ++x) {
++                    for (int z = 0; z < 16; ++z) {
++                        if (section.getBlockState(x, y, z).isSeeThrough()) {
++                            mask.set(localPos(x, y, z));
++                        }
++                    }
++                }
++            }
++
++            translucentInSection[index] = mask;
++        }
++
++        // iterate over the translucent blocks in the section
++        for (int index = 0; index < sectionCount; ++index) {
++            final BitSet translucentBlocks = translucentInSection[index];
++            if (translucentBlocks == null) {
++                continue;
++            }
++
++            final int sectionBaseY = (index + minSectionY) << 4;
++            final BitSet below = index > 0 ? translucentInSection[index - 1] : null;
++            final BitSet above = index < sectionCount - 1 ? translucentInSection[index + 1] : null;
++            final LevelChunkSection section = sections[index];
++
++            for (int y = Math.max(0, 1 - sectionBaseY); y < 16; ++y) {
++                for (int x = 1; x < 15; ++x) {
++                    for (int z = 1; z < 15; ++z) {
++                        final int pos = localPos(x, y, z);
++                        final boolean isExposed =
++                            translucentBlocks.get(pos)
++                            || translucentBlocks.get(pos - 16) || translucentBlocks.get(pos + 16)
++                            || translucentBlocks.get(pos - 1) || translucentBlocks.get(pos + 1)
++                            || (y > 0 ? translucentBlocks.get(pos - 256) : inSection(below, x, 15, z))
++                            || (y < 15 ? translucentBlocks.get(pos + 256) : inSection(above, x, 0, z));
++
++                        if (!isExposed) {
++                            section.setBlockState(x, y, z, air, false);
++                        }
++                    }
++                }
++            }
++        }
++    }
++
++    public static ClientboundLightUpdatePacketData createLightData(
++        final SerializableChunkData data, final ServerLevel world
++    ) {
++        final LevelLightEngine lightEngine = world.getLightEngine();
++        final int minLightSection = lightEngine.getMinLightSection();
++        final int sectionCount = lightEngine.getLightSectionCount();
++        final boolean hasSkyLight = world.dimensionType().hasSkyLight();
++
++        final SerializableChunkData.@Nullable SectionData[] byY = new SerializableChunkData.SectionData[sectionCount];
++
++        if (data.lightCorrect()) {
++            for (final SerializableChunkData.SectionData section : data.sectionData()) {
++                final int idx = section.y() - minLightSection;
++                if (idx >= 0 && idx < sectionCount) byY[idx] = section;
++            }
++        }
++
++        final BitSet skyMask = new BitSet();
++        final BitSet blockMask = new BitSet();
++        final BitSet emptySkyMask = new BitSet();
++        final BitSet emptyBlockMask = new BitSet();
++
++        final ObjectArrayList<byte[]> skyUpdates = new ObjectArrayList<>();
++        final ObjectArrayList<byte[]> blockUpdates = new ObjectArrayList<>();
++
++        for (int lIdx = 0; lIdx < sectionCount; ++lIdx) {
++            final SerializableChunkData.SectionData stored = byY[lIdx];
++
++            recordLayer(stored == null ? null : stored.blockLight(), lIdx, blockMask, emptyBlockMask, blockUpdates);
++
++            // only record skylight if the dimension HAS skylight
++            if (hasSkyLight) {
++                recordLayer(stored == null ? null : stored.skyLight(), lIdx, skyMask, emptySkyMask, skyUpdates);
++            }
++        }
++
++        return new ClientboundLightUpdatePacketData(
++            skyMask,
++            blockMask,
++            emptySkyMask,
++            emptyBlockMask,
++            skyUpdates,
++            blockUpdates
++        );
++    }
++
++    private static void recordLayer(
++        @Nullable
++        final DataLayer layer,
++        final int idx,
++        final BitSet mask,
++        final BitSet emptyMask,
++        final ObjectArrayList<byte[]> updates
++    ) {
++        if (layer != null) {
++            mask.set(idx);
++            updates.add(layer.copy().getData());
++        }
++        else {
++            emptyMask.set(idx);
++        }
++    }
++
++    private static boolean inSection(
++        @Nullable
++        final BitSet section,
++        final int x,
++        final int y,
++        final int z
++    ) {
++        return section == null || section.get(localPos(x, y, z));
++    }
++
++    private static int localPos(final int x, final int y, final int z) {
++        return (y << 8) | (x << 4) | z;
++    }
++}
+diff --git a/io/canvasmc/canvas/extendedview/Result.java b/io/canvasmc/canvas/extendedview/Result.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..4467b34664a68a37c4f5904ced7532d9b4e117a5
+--- /dev/null
++++ b/io/canvasmc/canvas/extendedview/Result.java
+@@ -0,0 +1,81 @@
++package io.canvasmc.canvas.extendedview;
++
++import net.minecraft.network.protocol.game.ClientboundLevelChunkWithLightPacket;
++
++public sealed interface Result {
++    boolean isFailure();
++
++    boolean isNotGenerated();
++
++    boolean isSuccess();
++
++    ClientboundLevelChunkWithLightPacket getPacketOrThrow();
++
++    record Success(ClientboundLevelChunkWithLightPacket packet) implements Result {
++        @Override
++        public boolean isFailure() {
++            return false;
++        }
++
++        @Override
++        public boolean isNotGenerated() {
++            return false;
++        }
++
++        @Override
++        public boolean isSuccess() {
++            return true;
++        }
++
++        @Override
++        public ClientboundLevelChunkWithLightPacket getPacketOrThrow() {
++            return this.packet;
++        }
++    }
++
++    record NotGenerated() implements Result {
++        public static final NotGenerated INSTANCE = new NotGenerated();
++
++        @Override
++        public boolean isFailure() {
++            return false;
++        }
++
++        @Override
++        public boolean isNotGenerated() {
++            return true;
++        }
++
++        @Override
++        public boolean isSuccess() {
++            return false;
++        }
++
++        @Override
++        public ClientboundLevelChunkWithLightPacket getPacketOrThrow() {
++            throw new IllegalStateException("Chunk is not generated");
++        }
++    }
++
++    record Failure(Throwable cause) implements Result {
++        @Override
++        public boolean isFailure() {
++            return true;
++        }
++
++        @Override
++        public boolean isNotGenerated() {
++            return false;
++        }
++
++        @Override
++        public boolean isSuccess() {
++            return false;
++        }
++
++        @Override
++        public ClientboundLevelChunkWithLightPacket getPacketOrThrow() {
++            throw new IllegalStateException("Chunk failed to load", this.cause);
++        }
++    }
++}
+diff --git a/io/canvasmc/canvas/extendedview/VVChunkCache.java b/io/canvasmc/canvas/extendedview/VVChunkCache.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..26a32e7e311953add36c67fa935ada7d8be45731
+--- /dev/null
++++ b/io/canvasmc/canvas/extendedview/VVChunkCache.java
+@@ -0,0 +1,37 @@
++package io.canvasmc.canvas.extendedview;
++
++import ca.spottedleaf.concurrentutil.map.concurrent.longs.ConcurrentChainedLong2IntHashTable;
++import ca.spottedleaf.concurrentutil.map.concurrent.longs.ConcurrentChainedLong2ReferenceHashTable;
++import java.util.concurrent.CompletableFuture;
++
++public final class VVChunkCache {
++    private final ConcurrentChainedLong2ReferenceHashTable<CompletableFuture<Result>> cache = new ConcurrentChainedLong2ReferenceHashTable<>();
++    private final ConcurrentChainedLong2IntHashTable watchers = new ConcurrentChainedLong2IntHashTable();
++
++    public CompletableFuture<Result> computeIfAbsent(
++        final long chunkKey,
++        final ConcurrentChainedLong2ReferenceHashTable.BiLongObjectFunction<? extends CompletableFuture<Result>> builder
++    ) {
++        return this.cache.computeIfAbsent(chunkKey, builder);
++    }
++
++    public void remove(final long chunkKey, final CompletableFuture<Result> expect) {
++        this.cache.remove(chunkKey, expect);
++    }
++
++    public void watch(final long chunkKey) {
++        this.watchers.addTo(chunkKey, 1, 1);
++    }
++
++    public void unwatch(final long chunkKey) {
++        if (this.watchers.decFrom(chunkKey, 1, 0) <= 0) {
++            this.cache.remove(chunkKey);
++        }
++    }
++
++    public void evictIfUnwatched(final long chunkKey) {
++        if (!this.watchers.containsKey(chunkKey)) {
++            this.cache.remove(chunkKey);
++        }
++    }
++}
+diff --git a/io/canvasmc/canvas/extendedview/package-info.java b/io/canvasmc/canvas/extendedview/package-info.java
+new file mode 100644
+index 0000000000000000000000000000000000000000..0f544dd39307dd7cf8f441365b1161bf6a6739ad
+--- /dev/null
++++ b/io/canvasmc/canvas/extendedview/package-info.java
+@@ -0,0 +1,4 @@
++@NullMarked
++package io.canvasmc.canvas.extendedview;
++
++import org.jspecify.annotations.NullMarked;
+diff --git a/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java b/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java
+index a1018e9ca9dfb978d6e6633577abd7d5d0960fa6..d9e446c6330204e8d0abaeb554387bacf35957b9 100644
+--- a/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java
++++ b/net/minecraft/network/protocol/game/ClientboundLevelChunkWithLightPacket.java
+@@ -57,6 +57,20 @@ public class ClientboundLevelChunkWithLightPacket implements Packet<ClientGamePa
+         levelChunk.getLevel().chunkPacketBlockController.modifyBlocks(this, chunkPacketInfo); // Paper - Anti-Xray - Modify blocks
+     }
+ 
++    // Canvas start - extended view distance
++    public ClientboundLevelChunkWithLightPacket(
++        final int x,
++        final int z,
++        final ClientboundLevelChunkPacketData chunkData,
++        final ClientboundLightUpdatePacketData lightData
++    ) {
++        this.x = x;
++        this.z = z;
++        this.chunkData = chunkData;
++        this.lightData = lightData;
++    }
++
++    // Canvas end - extended view distance
+     private ClientboundLevelChunkWithLightPacket(final RegistryFriendlyByteBuf input) {
+         this.x = input.readInt();
+         this.z = input.readInt();
+diff --git a/net/minecraft/network/protocol/game/ClientboundLightUpdatePacketData.java b/net/minecraft/network/protocol/game/ClientboundLightUpdatePacketData.java
+index a6971411d035f1fd759c8348320c6b43d65ce957..d19d853c001dff2649732b056da266a69899f310 100644
+--- a/net/minecraft/network/protocol/game/ClientboundLightUpdatePacketData.java
++++ b/net/minecraft/network/protocol/game/ClientboundLightUpdatePacketData.java
+@@ -47,6 +47,24 @@ public class ClientboundLightUpdatePacketData {
+         }
+     }
+ 
++    // Canvas start - extended view distance
++    public ClientboundLightUpdatePacketData(
++        final BitSet skyYMask,
++        final BitSet blockYMask,
++        final BitSet emptySkyYMask,
++        final BitSet emptyBlockYMask,
++        final List<byte[]> skyUpdates,
++        final List<byte[]> blockUpdates
++    ) {
++        this.skyYMask = skyYMask;
++        this.blockYMask = blockYMask;
++        this.emptySkyYMask = emptySkyYMask;
++        this.emptyBlockYMask = emptyBlockYMask;
++        this.skyUpdates = skyUpdates;
++        this.blockUpdates = blockUpdates;
++    }
++
++    // Canvas end - extended view distance
+     public ClientboundLightUpdatePacketData(final FriendlyByteBuf input, final int x, final int z) {
+         this.skyYMask = input.readBitSet();
+         this.blockYMask = input.readBitSet();
+diff --git a/net/minecraft/server/level/ServerLevel.java b/net/minecraft/server/level/ServerLevel.java
+index e9dfc516cbbc991412d4b6463572099ad3865954..fec2eb256418f46392bc8f2582f1bc1790e62159 100644
+--- a/net/minecraft/server/level/ServerLevel.java
++++ b/net/minecraft/server/level/ServerLevel.java
+@@ -372,6 +372,14 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+         return this.chunkTaskScheduler;
+     }
+ 
++    // Canvas start - extended view distance
++    private final io.canvasmc.canvas.extendedview.ExtendedViewDistance extendedViewDistance;
++
++    public io.canvasmc.canvas.extendedview.ExtendedViewDistance extendedViewDistance() {
++        return this.extendedViewDistance;
++    }
++
++    // Canvas end - extended view distance
+     @Override
+     public final ca.spottedleaf.moonrise.patches.chunk_system.io.MoonriseRegionFileIO.RegionDataController  moonrise$getChunkDataController() {
+         return this.chunkDataController;
+@@ -708,12 +716,16 @@ public class ServerLevel extends Level implements WorldGenLevel, ServerEntityGet
+         this.getCraftServer().addWorld(this.getWorld()); // CraftBukkit
+         this.updateTickData(); // Folia - region threading - make sure it is initialised before ticked
+         // Canvas start - per world distance
+-        int viewDistance = this.serverLevelData.canvas$distanceConfig.viewDistanceOrDefault();
++        final int viewDistance = this.serverLevelData.canvas$distanceConfig.viewDistanceOrDefault();
+         this.chunkSource.setViewDistance(viewDistance);
+ 
+-        int simulationDistance = this.serverLevelData.canvas$distanceConfig.simulationDistanceOrDefault();
++        final int simulationDistance = this.serverLevelData.canvas$distanceConfig.simulationDistanceOrDefault();
+         this.chunkSource.setSimulationDistance(simulationDistance);
++
++        final int visualViewDistance = this.serverLevelData.canvas$distanceConfig.visualViewDistanceOrDefault();
++        this.moonrise$getPlayerChunkLoader().setVisualViewDistance(visualViewDistance);
+         // Canvas end - per world distance
++        this.extendedViewDistance = new io.canvasmc.canvas.extendedview.ExtendedViewDistance(this); // Canvas - extended view distance
+     }
+ 
+     // Folia start - region threading
+diff --git a/net/minecraft/world/level/block/state/BlockBehaviour.java b/net/minecraft/world/level/block/state/BlockBehaviour.java
+index 6f21dac9da5e7ae529d74a578c9d74f219957719..1615cb58c8abe13f8d51814d82b0093206a3366c 100644
+--- a/net/minecraft/world/level/block/state/BlockBehaviour.java
++++ b/net/minecraft/world/level/block/state/BlockBehaviour.java
+@@ -739,6 +739,13 @@ public abstract class BlockBehaviour implements FeatureElement {
+         public final boolean isAir() { // Paper - Perf: Final for inlining
+             return this.isAir;
+         }
++        // Canvas start - extended view distance
++
++        // air is see through, non-occluding blocks are see through, and SOME fluids too
++        public final boolean isSeeThrough() {
++            return this.isAir || !this.canOcclude || !this.getFluidState().isEmpty();
++        }
++        // Canvas end - extended view distance
+ 
+         public boolean ignitedByLava() {
+             return this.ignitedByLava;

--- a/canvas-server/minecraft-patches/features/0003-Extended-View-Distance.patch
+++ b/canvas-server/minecraft-patches/features/0003-Extended-View-Distance.patch
@@ -5,7 +5,7 @@ Subject: [PATCH] Extended View Distance
 
 
 diff --git a/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java b/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
-index fad788a6541a7e9edd42f699d2968897d446a353..ab35b21829601da927b6b882c674cf6659fb4254 100644
+index fad788a6541a7e9edd42f699d2968897d446a353..fede09ee32da72d414dacc553af91199e954ad99 100644
 --- a/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
 +++ b/ca/spottedleaf/moonrise/patches/chunk_system/player/RegionizedPlayerChunkLoader.java
 @@ -63,7 +63,7 @@ public final class RegionizedPlayerChunkLoader {
@@ -101,7 +101,7 @@ index fad788a6541a7e9edd42f699d2968897d446a353..ab35b21829601da927b6b882c674cf66
 +        }
 +        return data.lastVVDistance;
 +    }
-+    // Canavs end - extended view distance
++    // Canvas end - extended view distance
  
      private final ServerLevel world;
  

--- a/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
+++ b/canvas-server/minecraft-patches/sources/net/minecraft/world/entity/player/Player.java.patch
@@ -38,7 +38,7 @@
                              this.doSweepAttack(entity, baseDamage, damageSource, attackStrengthScale);
                          }
  
-@@ -1162,7 +_,7 @@
+@@ -1168,7 +_,7 @@
          if (entity instanceof LivingEntity livingEntity) {
              float actualDamage = oldLivingEntityHealth - livingEntity.getHealth();
              this.awardStat(Stats.DAMAGE_DEALT, Math.round(actualDamage * 10.0F));
@@ -47,7 +47,7 @@
                  int count = (int)(actualDamage * 0.5);
                  ((ServerLevel)this.level())
                      .sendParticles(ParticleTypes.DAMAGE_INDICATOR, entity.getX(), entity.getY(0.5), entity.getZ(), count, 0.1, 0.0, 0.1, 0.2);
-@@ -1961,6 +_,7 @@
+@@ -1983,6 +_,7 @@
      }
  
      public float getCurrentItemAttackStrengthDelay() {
@@ -55,7 +55,7 @@
          return (float)(1.0 / this.getAttributeValue(Attributes.ATTACK_SPEED) * 20.0);
      }
  
-@@ -1971,6 +_,7 @@
+@@ -1993,6 +_,7 @@
      }
  
      public float getAttackStrengthScale(final float a) {

--- a/canvas-server/paper-patches/features/0001-Extended-View-Distance.patch
+++ b/canvas-server/paper-patches/features/0001-Extended-View-Distance.patch
@@ -1,0 +1,29 @@
+From 0000000000000000000000000000000000000000 Mon Sep 17 00:00:00 2001
+From: Dueris <duerismc@gmail.com>
+Date: Fri, 11 Sep 2026 15:52:13 -0700
+Subject: [PATCH] Extended View Distance
+
+
+diff --git a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+index 7dc0e2a221b55bd4ec0223cce13beed164db8371..6412b5666204537f2be6732182d8cfdb73689593 100644
+--- a/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
++++ b/src/main/java/org/bukkit/craftbukkit/entity/CraftPlayer.java
+@@ -3300,6 +3300,18 @@ public class CraftPlayer extends CraftHumanEntity implements Player, PluginMessa
+     public void setSendViewDistance(final int viewDistance) {
+         FeatureHooks.setSendViewDistance(this.getHandle(), viewDistance); // Paper - chunk system
+     }
++    // Canvas start - extended view distance
++
++    @Override
++    public int getVisualViewDistance() {
++        return ca.spottedleaf.moonrise.patches.chunk_system.player.RegionizedPlayerChunkLoader.getAPIVisualViewDistance(getHandle());
++    }
++
++    @Override
++    public void setVisualViewDistance(final int viewDistance) {
++        getHandle().moonrise$getViewDistanceHolder().setVisualViewDistance(viewDistance);
++    }
++    // Canvas end - extended view distance
+ 
+     // Paper start - entity effect API
+     @Override

--- a/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/GlobalConfiguration.java
@@ -442,6 +442,29 @@ public class GlobalConfiguration extends Part {
         }
 
         public boolean optimizeTreasureMapLocating = false;
+
+        public VisualViewDistance visualViewDistance = new VisualViewDistance();
+        public static class VisualViewDistance extends Part {
+
+            {
+                option("vvDistance")
+                    .docs(
+                        "Extends the client view distance with already loaded chunks that don't get fully loaded into",
+                        "the server, AKA \"fake chunks\". Best used on pre-generated worlds, since this system never",
+                        "generates chunks itself, it only reads what's already on disk. Using on non-pregen worlds could",
+                        "cause visual glitches on the client due to \"lazy loading\""
+                    ).greaterThanOrEqualTo(0.0F);
+                option("hollowChunks")
+                    .docs("Hollows out the \"fake chunks\" loaded by the server to reduce bandwidth");
+            }
+
+            // TODO - hide grass - foliage-like blocks are hard to see from far away, not needed
+            // TODO - andesite -> stone config? basically the same from far away
+            // TODO - neighbor-aware chunk hollowing - this will help bandwidth even more
+            public int vvDistance = 0;
+            public boolean hollowChunks = true;
+            public boolean hideOres = true;
+        }
     }
 
     // TODO - check these on minecraft updates

--- a/canvas-server/src/main/java/io/canvasmc/canvas/subcommands/WorldDistanceSubCommand.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/subcommands/WorldDistanceSubCommand.java
@@ -28,7 +28,7 @@ import static net.minecraft.commands.Commands.literal;
 public class WorldDistanceSubCommand implements SubCommand {
 
     private static final SimpleCommandExceptionType ILLEGAL_TYPE_ARG = new SimpleCommandExceptionType(
-        Component.literal("Illegal type argument. Must be [\"view\", \"simulation\", \"v\", \"s\", or \"sim\"]")
+        Component.literal("Illegal type argument. Must be [\"view\", \"simulation\", \"visual\", \"visual_view\", \"v\", \"vv\", \"s\", or \"sim\"]")
     );
     private static final SimpleCommandExceptionType INVALID_DISTANCE = new SimpleCommandExceptionType(
         Component.literal("New value must be above 0")
@@ -46,6 +46,7 @@ public class WorldDistanceSubCommand implements SubCommand {
                 .suggests((_, builder) -> {
                     builder.suggest("view");
                     builder.suggest("simulation");
+                    builder.suggest("visual");
                     return builder.buildFuture();
                 })
                 .then(argument("dimension", DimensionArgument.dimension())
@@ -74,7 +75,7 @@ public class WorldDistanceSubCommand implements SubCommand {
     private static int setDistance(final CommandContext<CommandSourceStack> context) throws CommandSyntaxException {
         final Type type = Type.from(StringArgumentType.getString(context, "type").toUpperCase(Locale.ROOT));
         final ServerLevel level = DimensionArgument.getDimension(context, "dimension");
-        final int distance = Math.min(context.getArgument("distance", int.class), MoonriseConstants.MAX_VIEW_DISTANCE - 3);
+        final int distance = Math.min(context.getArgument("distance", int.class), MoonriseConstants.MAX_VIEW_DISTANCE);
 
         if (distance <= 0) {
             throw INVALID_DISTANCE.create();
@@ -87,22 +88,25 @@ public class WorldDistanceSubCommand implements SubCommand {
     }
 
     private static void applyOperation(final Type type, final ServerLevel level, final int distance) {
+        final int clampTo = type != Type.VISUAL_VIEW ? MoonriseConstants.MAX_VIEW_DISTANCE - 3 : MoonriseConstants.MAX_VIEW_DISTANCE;
+        final int clamped = Math.clamp(distance, -1, clampTo);
+
         // update the distance override that we can use later on
-        type.set(level, distance);
+        type.set(level, clamped);
 
         final PerWorldDistanceConfig state = level.serverLevelData.canvas$distanceConfig;
-        final int updated = Math.min(
-            (type.equals(Type.VIEW)
-                ? state.viewDistanceOrDefault()
-                : state.simulationDistanceOrDefault()),
-            MoonriseConstants.MAX_VIEW_DISTANCE - 3
-        );
+        final int updated = switch (type) {
+            case VIEW -> state.viewDistanceOrDefault();
+            case SIMULATION -> state.simulationDistanceOrDefault();
+            case VISUAL_VIEW -> state.visualViewDistanceOrDefault();
+        };
 
         switch (type) {
             // we go straight through here because FeatureHooks hard-clamps at 32, which is technically wrong
             // since it should abide by the MAX_VIEW_DISTANCE arg
             case VIEW -> level.getChunkSource().chunkMap.setServerViewDistance(updated);
             case SIMULATION -> level.getChunkSource().chunkMap.getDistanceManager().updateSimulationDistance(updated);
+            case VISUAL_VIEW -> level.moonrise$getPlayerChunkLoader().setVisualViewDistance(updated);
         }
     }
 
@@ -129,6 +133,11 @@ public class WorldDistanceSubCommand implements SubCommand {
             (world) -> world.serverLevelData.canvas$distanceConfig.simulationDistanceOrDefault(),
             (world, dist) -> world.serverLevelData.canvas$distanceConfig.setSimulationDistance(dist),
             "Simulation"
+        ),
+        VISUAL_VIEW(
+            (world) -> world.serverLevelData.canvas$distanceConfig.visualViewDistanceOrDefault(),
+            (world, dist) -> world.serverLevelData.canvas$distanceConfig.setVisualViewDistance(dist),
+            "VVDistance"
         );
 
         private final Function<ServerLevel, Integer> getter;
@@ -146,6 +155,7 @@ public class WorldDistanceSubCommand implements SubCommand {
             return switch (lower) {
                 case "view", "v" -> VIEW;
                 case "simulation", "sim", "s" -> SIMULATION;
+                case "visual", "visual_view", "vv" -> VISUAL_VIEW;
                 default -> throw ILLEGAL_TYPE_ARG.create();
             };
         }

--- a/canvas-server/src/main/java/io/canvasmc/canvas/world/PerWorldDistanceConfig.java
+++ b/canvas-server/src/main/java/io/canvasmc/canvas/world/PerWorldDistanceConfig.java
@@ -2,6 +2,7 @@ package io.canvasmc.canvas.world;
 
 import com.mojang.serialization.Codec;
 import com.mojang.serialization.codecs.RecordCodecBuilder;
+import io.canvasmc.canvas.GlobalConfiguration;
 import io.canvasmc.canvas.util.LockedReference;
 import java.util.Optional;
 import net.minecraft.server.MinecraftServer;
@@ -17,26 +18,33 @@ import net.minecraft.server.dedicated.DedicatedServer;
  *     the simulation distance override
  */
 public record PerWorldDistanceConfig(
-    LockedReference<Integer> viewDistance, LockedReference<Integer> simulationDistance
+    LockedReference<Integer> viewDistance,
+    LockedReference<Integer> simulationDistance,
+    LockedReference<Integer> visualViewDistance
 ) {
-    public static PerWorldDistanceConfig DEFAULT = new PerWorldDistanceConfig(Optional.empty(), Optional.empty());
+    public static PerWorldDistanceConfig DEFAULT = new PerWorldDistanceConfig(Optional.empty(), Optional.empty(), Optional.empty());
     public static final Codec<PerWorldDistanceConfig> CODEC = RecordCodecBuilder.create(i -> i.group(
         Codec.INT.optionalFieldOf("ViewDistance").orElse(Optional.empty()).forGetter(PerWorldDistanceConfig::viewDistanceAsOptional),
-        Codec.INT.optionalFieldOf("SimulationDistance").orElse(Optional.empty()).forGetter(PerWorldDistanceConfig::simulationDistanceAsOptional)
+        Codec.INT.optionalFieldOf("SimulationDistance").orElse(Optional.empty()).forGetter(PerWorldDistanceConfig::simulationDistanceAsOptional),
+        Codec.INT.optionalFieldOf("VisualViewDistance").orElse(Optional.empty()).forGetter(PerWorldDistanceConfig::visualViewDistanceAsOptional)
     ).apply(i, PerWorldDistanceConfig::new));
 
     // this is for the codec, nothing much else
     @SuppressWarnings("OptionalUsedAsFieldOrParameterType")
-    public PerWorldDistanceConfig(final Optional<Integer> view, final Optional<Integer> simulation) {
+    public PerWorldDistanceConfig(
+        final Optional<Integer> view, final Optional<Integer> simulation, final Optional<Integer> visualView
+    ) {
         this(
             view.map(LockedReference::new).orElse(new LockedReference<>(null)),
-            simulation.map(LockedReference::new).orElse(new LockedReference<>(null))
+            simulation.map(LockedReference::new).orElse(new LockedReference<>(null)),
+            visualView.map(LockedReference::new).orElse(new LockedReference<>(null))
         );
     }
 
     public PerWorldDistanceConfig(
         final LockedReference<Integer> viewDistance,
-        final LockedReference<Integer> simulationDistance
+        final LockedReference<Integer> simulationDistance,
+        final LockedReference<Integer> visualViewDistance
     ) {
 
         // for backwards compat with old system. we used to store
@@ -44,6 +52,7 @@ public record PerWorldDistanceConfig(
 
         final Integer view = viewDistance.getValue();
         final Integer simulation = simulationDistance.getValue();
+        final Integer visualView = visualViewDistance.getValue();
 
         this.viewDistance = Integer.valueOf(-1).equals(view)
             ? new LockedReference<>(null)
@@ -52,6 +61,10 @@ public record PerWorldDistanceConfig(
         this.simulationDistance = Integer.valueOf(-1).equals(simulation)
             ? new LockedReference<>(null)
             : simulationDistance;
+
+        this.visualViewDistance = Integer.valueOf(-1).equals(visualView)
+            ? new LockedReference<>(null)
+            : visualViewDistance;
     }
 
     public int snapshotViewDistance() {
@@ -70,12 +83,24 @@ public record PerWorldDistanceConfig(
         return raw;
     }
 
+    public int snapshotVisualViewDistance() {
+        final Integer raw = visualViewDistance().getValue();
+        if (raw == null) {
+            return -1;
+        }
+        return raw;
+    }
+
     public Optional<Integer> viewDistanceAsOptional() {
         return viewDistance.asOptional();
     }
 
     public Optional<Integer> simulationDistanceAsOptional() {
         return simulationDistance.asOptional();
+    }
+
+    public Optional<Integer> visualViewDistanceAsOptional() {
+        return visualViewDistance.asOptional();
     }
 
     public int viewDistanceOrDefault() {
@@ -88,6 +113,11 @@ public record PerWorldDistanceConfig(
         return snapshot <= 0 ? ((DedicatedServer) MinecraftServer.getServer()).settings.getProperties().simulationDistance.get() : snapshot;
     }
 
+    public int visualViewDistanceOrDefault() {
+        final int snapshot = snapshotVisualViewDistance();
+        return snapshot <= 0 ? GlobalConfiguration.getInstance().chunkSystem.visualViewDistance.vvDistance : snapshot;
+    }
+
     public boolean isViewDistanceOverridden() {
         return this.viewDistance().isSet();
     }
@@ -96,8 +126,12 @@ public record PerWorldDistanceConfig(
         return this.simulationDistance().isSet();
     }
 
+    public boolean isVisualViewDistanceOverridden() {
+        return this.visualViewDistance().isSet();
+    }
+
     public void setViewDistance(final int distance) {
-        if (distance == -1) {
+        if (distance <= 0) {
             viewDistance().unset();
         }
         else {
@@ -106,11 +140,20 @@ public record PerWorldDistanceConfig(
     }
 
     public void setSimulationDistance(final int distance) {
-        if (distance == -1) {
+        if (distance <= 0) {
             simulationDistance().unset();
         }
         else {
             simulationDistance().swapValue(distance);
+        }
+    }
+
+    public void setVisualViewDistance(final int distance) {
+        if (distance <= 0) {
+            visualViewDistance().unset();
+        }
+        else {
+            visualViewDistance().swapValue(distance);
         }
     }
 }


### PR DESCRIPTION
This will be made into a base patch soon, but I need to extract the per-world-distance system too, since this is based somewhat on that system.

This adds a new "fake chunk" system to Canvas, sending out fake chunks to extend the view distance of the client without actually loading any chunks on the server. One caveat is that this *only* reads already generated chunks from disk, and does *not* generate new chunks, meaning this will only really be beneficial for servers that are pre-generated.

This needs some production testing, and a few more things need to be done, but the base implementation is done. This also has builtin "hollowing" of chunks to try and set as much of the chunk to air as possible to try and reduce bandwidth as much as possible. At the time of creating this PR bandwidth for these chunks seems to be cut anywhere between 35-65%, and hopefully it will be a bit better later.